### PR TITLE
Add test infrastructure and core logic tests (PR 1/3)

### DIFF
--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -7,7 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		AAAA000000000000000000A1 /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = AAAA000000000000000000A3 /* WhisperKit */; };
+		03A4AA6D8DD2B3AA6E9AF157 /* PromptGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD13E8087B26CC89725C3041 /* PromptGeneratorTests.swift */; };
+		0900F4294F091546C199FA0A /* WalkDataFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4181215714A52E71449BC390 /* WalkDataFactory.swift */; };
+		0E29E944B6EEAD64EB33151E /* XCTestCase+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721BF267E7540B2B259806D1 /* XCTestCase+Combine.swift */; };
 		2201BCA929423DF100F54277 /* View+Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2201BCA829423DF100F54277 /* View+Navigation.swift */; };
 		2201BCAB29423E1600F54277 /* NavigationLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2201BCAA29423E1600F54277 /* NavigationLink.swift */; };
 		2201BCAD29423FDE00F54277 /* SetupViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2201BCAC29423FDE00F54277 /* SetupViewModel.swift */; };
@@ -17,7 +19,6 @@
 		2207B75623128F8A00BA71B5 /* CLLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2207B75523128F8A00BA71B5 /* CLLocation.swift */; };
 		2209E53924DD4A8F00BBFC2F /* AltitudeManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2209E53824DD4A8F00BBFC2F /* AltitudeManagement.swift */; };
 		2213137D23B4110700881806 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2213137C23B4110700881806 /* PermissionManager.swift */; };
-		AAAA000000000000000000B1 /* TranscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000B2 /* TranscriptionService.swift */; };
 		221436B924432B390010D82B /* DataManager+Query.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221436B824432B390010D82B /* DataManager+Query.swift */; };
 		221436BB244356A90010D82B /* Array.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221436BA244356A90010D82B /* Array.swift */; };
 		221436BF2443746B0010D82B /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 221436BE2443746B0010D82B /* Event.swift */; };
@@ -109,7 +110,6 @@
 		22BC993C2941D9A800D9B1A5 /* RoundedButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC992B2941D9A800D9B1A5 /* RoundedButton.swift */; };
 		22BC993D2941D9A800D9B1A5 /* PillView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC992C2941D9A800D9B1A5 /* PillView.swift */; };
 		22BC993E2941D9A800D9B1A5 /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC992D2941D9A800D9B1A5 /* CardView.swift */; };
-		AA000002PILGRIMLOGO00000 /* PilgrimLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000001PILGRIMLOGO00000 /* PilgrimLogoView.swift */; };
 		22BC993F2941D9A800D9B1A5 /* ProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC992E2941D9A800D9B1A5 /* ProgressView.swift */; };
 		22BC99402941D9A800D9B1A5 /* FeatureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC992F2941D9A800D9B1A5 /* FeatureView.swift */; };
 		22BC99412941D9A800D9B1A5 /* BaseMapMenuView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC99302941D9A800D9B1A5 /* BaseMapMenuView.swift */; };
@@ -158,24 +158,30 @@
 		22FEA0AD24CDD4CA0007CA9C /* FileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FEA0AC24CDD4CA0007CA9C /* FileManager.swift */; };
 		22FEA0AF24CDD7B50007CA9C /* DiskStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FEA0AE24CDD7B50007CA9C /* DiskStorage.swift */; };
 		22FEA0B124CDDFF80007CA9C /* CustomByteFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FEA0B024CDDFF80007CA9C /* CustomByteFormatting.swift */; };
+		2B6F4CE80AB1FB057688EAA1 /* ComputationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D23FF60A762C30296A69E6 /* ComputationTests.swift */; };
 		487022E2F9AD1AE6D374FF39 /* Pods_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C56A574B3F5BFCBF50DB5368 /* Pods_UnitTests.framework */; };
 		50A16B63C6F23E2D1E6210BA /* Pods_Pilgrim.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */; };
+		76B622EBDD59AD9489586120 /* DateFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2D4ACA7F21BA80523DF98C /* DateFactory.swift */; };
+		AA000002PILGRIMLOGO00000 /* PilgrimLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000001PILGRIMLOGO00000 /* PilgrimLogoView.swift */; };
 		AA0001010000000000000011 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001010000000000000001 /* HomeView.swift */; };
 		AA0001010000000000000012 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001010000000000000002 /* HomeViewModel.swift */; };
 		AA0001010000000000000013 /* WalkRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001010000000000000003 /* WalkRowView.swift */; };
 		AA0001010000000000000014 /* ActiveWalkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001010000000000000004 /* ActiveWalkView.swift */; };
 		AA0001010000000000000015 /* ActiveWalkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001010000000000000005 /* ActiveWalkViewModel.swift */; };
-		AA00030100000000000002 /* MeditationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00030100000000000001 /* MeditationView.swift */; };
 		AA0001010000000000000016 /* WalkSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001010000000000000006 /* WalkSummaryView.swift */; };
 		AA0001010000000000000017 /* MainCoordinatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001010000000000000007 /* MainCoordinatorView.swift */; };
 		AA00020100000000000002 /* VoiceRecording.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00020100000000000001 /* VoiceRecording.swift */; };
 		AA00020100000000000004 /* VoiceRecordingManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00020100000000000003 /* VoiceRecordingManagement.swift */; };
-		BB00AA010000000000000002 /* PilgrimV1.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00AA010000000000000001 /* PilgrimV1.swift */; };
-		CC00BB010000000000000002 /* VoiceRecordingInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00BB010000000000000001 /* VoiceRecordingInterface.swift */; };
-		DD00CC0100000000000002 /* MeditateDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00CC0100000000000001 /* MeditateDetection.swift */; };
+		AA00030100000000000002 /* MeditationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00030100000000000001 /* MeditationView.swift */; };
+		AAAA000000000000000000A1 /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = AAAA000000000000000000A3 /* WhisperKit */; };
+		AAAA000000000000000000B1 /* TranscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000B2 /* TranscriptionService.swift */; };
 		AAAA000000000000000000C1 /* PromptGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000C2 /* PromptGenerator.swift */; };
 		AAAA000000000000000000C3 /* PromptListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000C4 /* PromptListView.swift */; };
 		AAAA000000000000000000C5 /* PromptDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000C6 /* PromptDetailView.swift */; };
+		BB00AA010000000000000002 /* PilgrimV1.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00AA010000000000000001 /* PilgrimV1.swift */; };
+		CC00BB010000000000000002 /* VoiceRecordingInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00BB010000000000000001 /* VoiceRecordingInterface.swift */; };
+		DD00CC0100000000000002 /* MeditateDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00CC0100000000000001 /* MeditateDetection.swift */; };
+		F28633E25671B876232C0F34 /* BackupSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB8B7996545B4CEF51D686E /* BackupSerializationTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -189,6 +195,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1AB8B7996545B4CEF51D686E /* BackupSerializationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackupSerializationTests.swift; sourceTree = "<group>"; };
 		2201BCA829423DF100F54277 /* View+Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Navigation.swift"; sourceTree = "<group>"; };
 		2201BCAA29423E1600F54277 /* NavigationLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLink.swift; sourceTree = "<group>"; };
 		2201BCAC29423FDE00F54277 /* SetupViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupViewModel.swift; sourceTree = "<group>"; };
@@ -198,7 +205,6 @@
 		2207B75523128F8A00BA71B5 /* CLLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLLocation.swift; sourceTree = "<group>"; };
 		2209E53824DD4A8F00BBFC2F /* AltitudeManagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AltitudeManagement.swift; sourceTree = "<group>"; };
 		2213137C23B4110700881806 /* PermissionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionManager.swift; sourceTree = "<group>"; };
-		AAAA000000000000000000B2 /* TranscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionService.swift; sourceTree = "<group>"; };
 		221436B824432B390010D82B /* DataManager+Query.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataManager+Query.swift"; sourceTree = "<group>"; };
 		221436BA244356A90010D82B /* Array.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Array.swift; sourceTree = "<group>"; };
 		221436BE2443746B0010D82B /* Event.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Event.swift; sourceTree = "<group>"; };
@@ -292,7 +298,6 @@
 		22BC992B2941D9A800D9B1A5 /* RoundedButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RoundedButton.swift; sourceTree = "<group>"; };
 		22BC992C2941D9A800D9B1A5 /* PillView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PillView.swift; sourceTree = "<group>"; };
 		22BC992D2941D9A800D9B1A5 /* CardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
-		AA000001PILGRIMLOGO00000 /* PilgrimLogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimLogoView.swift; sourceTree = "<group>"; };
 		22BC992E2941D9A800D9B1A5 /* ProgressView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgressView.swift; sourceTree = "<group>"; };
 		22BC992F2941D9A800D9B1A5 /* FeatureView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeatureView.swift; sourceTree = "<group>"; };
 		22BC99302941D9A800D9B1A5 /* BaseMapMenuView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BaseMapMenuView.swift; sourceTree = "<group>"; };
@@ -343,28 +348,35 @@
 		22FEA0AC24CDD4CA0007CA9C /* FileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManager.swift; sourceTree = "<group>"; };
 		22FEA0AE24CDD7B50007CA9C /* DiskStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskStorage.swift; sourceTree = "<group>"; };
 		22FEA0B024CDDFF80007CA9C /* CustomByteFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomByteFormatting.swift; sourceTree = "<group>"; };
+		4181215714A52E71449BC390 /* WalkDataFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkDataFactory.swift; sourceTree = "<group>"; };
+		721BF267E7540B2B259806D1 /* XCTestCase+Combine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Combine.swift"; sourceTree = "<group>"; };
 		8C0699EE439FF3DC5E16B8E0 /* Pods-Pilgrim.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pilgrim.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Pilgrim/Pods-Pilgrim.debug.xcconfig"; sourceTree = "<group>"; };
 		980407DB8189D982A61A73F9 /* Pods-UnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.release.xcconfig"; sourceTree = "<group>"; };
-		C1B583B563EC4764AEDC9E50 /* Pods-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
-		C1C8D965F1351F85D4E4F35D /* Pods-Pilgrim.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pilgrim.release.xcconfig"; path = "Pods/Target Support Files/Pods-Pilgrim/Pods-Pilgrim.release.xcconfig"; sourceTree = "<group>"; };
-		C56A574B3F5BFCBF50DB5368 /* Pods_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Pilgrim.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		AA000001PILGRIMLOGO00000 /* PilgrimLogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimLogoView.swift; sourceTree = "<group>"; };
 		AA0001010000000000000001 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		AA0001010000000000000002 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		AA0001010000000000000003 /* WalkRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkRowView.swift; sourceTree = "<group>"; };
 		AA0001010000000000000004 /* ActiveWalkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveWalkView.swift; sourceTree = "<group>"; };
 		AA0001010000000000000005 /* ActiveWalkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveWalkViewModel.swift; sourceTree = "<group>"; };
-		AA00030100000000000001 /* MeditationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeditationView.swift; sourceTree = "<group>"; };
 		AA0001010000000000000006 /* WalkSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkSummaryView.swift; sourceTree = "<group>"; };
 		AA0001010000000000000007 /* MainCoordinatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCoordinatorView.swift; sourceTree = "<group>"; };
 		AA00020100000000000001 /* VoiceRecording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecording.swift; sourceTree = "<group>"; };
 		AA00020100000000000003 /* VoiceRecordingManagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecordingManagement.swift; sourceTree = "<group>"; };
-		BB00AA010000000000000001 /* PilgrimV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV1.swift; sourceTree = "<group>"; };
-		CC00BB010000000000000001 /* VoiceRecordingInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecordingInterface.swift; sourceTree = "<group>"; };
-		DD00CC0100000000000001 /* MeditateDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeditateDetection.swift; sourceTree = "<group>"; };
+		AA00030100000000000001 /* MeditationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeditationView.swift; sourceTree = "<group>"; };
+		AAAA000000000000000000B2 /* TranscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionService.swift; sourceTree = "<group>"; };
 		AAAA000000000000000000C2 /* PromptGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptGenerator.swift; sourceTree = "<group>"; };
 		AAAA000000000000000000C4 /* PromptListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptListView.swift; sourceTree = "<group>"; };
 		AAAA000000000000000000C6 /* PromptDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptDetailView.swift; sourceTree = "<group>"; };
+		BB00AA010000000000000001 /* PilgrimV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV1.swift; sourceTree = "<group>"; };
+		C1B583B563EC4764AEDC9E50 /* Pods-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
+		C1C8D965F1351F85D4E4F35D /* Pods-Pilgrim.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pilgrim.release.xcconfig"; path = "Pods/Target Support Files/Pods-Pilgrim/Pods-Pilgrim.release.xcconfig"; sourceTree = "<group>"; };
+		C2D23FF60A762C30296A69E6 /* ComputationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ComputationTests.swift; sourceTree = "<group>"; };
+		C56A574B3F5BFCBF50DB5368 /* Pods_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		CC00BB010000000000000001 /* VoiceRecordingInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecordingInterface.swift; sourceTree = "<group>"; };
+		D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Pilgrim.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		DD00CC0100000000000001 /* MeditateDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeditateDetection.swift; sourceTree = "<group>"; };
+		DD13E8087B26CC89725C3041 /* PromptGeneratorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptGeneratorTests.swift; sourceTree = "<group>"; };
+		EC2D4ACA7F21BA80523DF98C /* DateFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DateFactory.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -837,6 +849,10 @@
 			isa = PBXGroup;
 			children = (
 				22DD158B280C5BB4002CDB45 /* MigrationTests.swift */,
+				4C304343458BA5DB0C7E2372 /* Helpers */,
+				C2D23FF60A762C30296A69E6 /* ComputationTests.swift */,
+				DD13E8087B26CC89725C3041 /* PromptGeneratorTests.swift */,
+				1AB8B7996545B4CEF51D686E /* BackupSerializationTests.swift */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -882,15 +898,15 @@
 			path = WalkBuilder;
 			sourceTree = "<group>";
 		};
-		BA69BA2459A15E9F0E7493C3 /* Pods */ = {
+		4C304343458BA5DB0C7E2372 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
-				8C0699EE439FF3DC5E16B8E0 /* Pods-Pilgrim.debug.xcconfig */,
-				C1C8D965F1351F85D4E4F35D /* Pods-Pilgrim.release.xcconfig */,
-				C1B583B563EC4764AEDC9E50 /* Pods-UnitTests.debug.xcconfig */,
-				980407DB8189D982A61A73F9 /* Pods-UnitTests.release.xcconfig */,
+				EC2D4ACA7F21BA80523DF98C /* DateFactory.swift */,
+				4181215714A52E71449BC390 /* WalkDataFactory.swift */,
+				721BF267E7540B2B259806D1 /* XCTestCase+Combine.swift */,
 			);
-			name = Pods;
+			name = Helpers;
+			path = Helpers;
 			sourceTree = "<group>";
 		};
 		AA0001010000000000000021 /* Home */ = {
@@ -928,6 +944,17 @@
 				AAAA000000000000000000C6 /* PromptDetailView.swift */,
 			);
 			path = Prompts;
+			sourceTree = "<group>";
+		};
+		BA69BA2459A15E9F0E7493C3 /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				8C0699EE439FF3DC5E16B8E0 /* Pods-Pilgrim.debug.xcconfig */,
+				C1C8D965F1351F85D4E4F35D /* Pods-Pilgrim.release.xcconfig */,
+				C1B583B563EC4764AEDC9E50 /* Pods-UnitTests.debug.xcconfig */,
+				980407DB8189D982A61A73F9 /* Pods-UnitTests.release.xcconfig */,
+			);
+			name = Pods;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1278,6 +1305,12 @@
 			buildActionMask = 2147483647;
 			files = (
 				22DD158C280C5BB4002CDB45 /* MigrationTests.swift in Sources */,
+				76B622EBDD59AD9489586120 /* DateFactory.swift in Sources */,
+				0900F4294F091546C199FA0A /* WalkDataFactory.swift in Sources */,
+				0E29E944B6EEAD64EB33151E /* XCTestCase+Combine.swift in Sources */,
+				2B6F4CE80AB1FB057688EAA1 /* ComputationTests.swift in Sources */,
+				03A4AA6D8DD2B3AA6E9AF157 /* PromptGeneratorTests.swift in Sources */,
+				F28633E25671B876232C0F34 /* BackupSerializationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/UnitTests/BackupSerializationTests.swift
+++ b/UnitTests/BackupSerializationTests.swift
@@ -1,0 +1,143 @@
+import XCTest
+@testable import Pilgrim
+
+final class BackupSerializationTests: XCTestCase {
+
+    // MARK: - Version Codes
+
+    func testBackupV4_versionCode_isV4() {
+        XCTAssertEqual(BackupV4.versionCode, "V4")
+    }
+
+    func testAllVersionCodes_areUnique() {
+        let codes = [
+            BackupV1.versionCode,
+            BackupV2.versionCode,
+            BackupV3.versionCode,
+            BackupV4.versionCode
+        ]
+        XCTAssertEqual(Set(codes).count, codes.count)
+    }
+
+    // MARK: - BackupV4 Serialization
+
+    func testBackupV4_encodeDecodeRoundTrip_preservesFields() throws {
+        let walk = WalkDataFactory.makeWalk(
+            distance: 5000,
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            endDate: DateFactory.makeDate(2024, 6, 15, 10, 0, 0),
+            ascend: 50,
+            descend: 30,
+            activeDuration: 3600
+        )
+        let event = TempV4.Event(
+            uuid: UUID(),
+            title: "Morning Walk",
+            comment: "Nice walk",
+            startDate: walk.startDate,
+            endDate: walk.endDate,
+            workouts: [walk.uuid ?? UUID()]
+        )
+
+        let backup = BackupV4(workouts: [walk], events: [event])
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(backup)
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let decoded = try decoder.decode(BackupV4.self, from: data)
+
+        XCTAssertEqual(decoded.version, "V4")
+        XCTAssertEqual(decoded.workoutData.count, 1)
+        XCTAssertEqual(decoded.eventData.count, 1)
+        XCTAssertEqual(decoded.workoutData.first?.distance, 5000)
+        XCTAssertEqual(decoded.eventData.first?.title, "Morning Walk")
+    }
+
+    func testBackupV4_encodedJSON_containsCorrectVersionKey() throws {
+        let backup = BackupV4(workouts: [], events: [])
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        let data = try encoder.encode(backup)
+
+        let json = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(json["version"] as? String, "V4")
+    }
+
+    // MARK: - Legacy asTemp Conversions
+
+    func testV1_asTemp_mapsFieldsCorrectly() {
+        let v1 = TempV1.Workout(
+            uuid: UUID(),
+            workoutType: 1,
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            endDate: DateFactory.makeDate(2024, 6, 15, 10, 0, 0),
+            distance: 5000,
+            burnedEnergy: 200,
+            healthKitUUID: nil,
+            locations: []
+        )
+        let temp = v1.asTemp
+        XCTAssertEqual(temp.distance, 5000)
+        XCTAssertEqual(temp.workoutType, .walking)
+        XCTAssertEqual(temp.burnedEnergy, 200)
+        XCTAssertFalse(temp.isRace)
+        XCTAssertTrue(temp.finishedRecording)
+        XCTAssertEqual(temp.pauses.count, 0)
+    }
+
+    func testV2_asTemp_preservesIsRaceAndComment() {
+        let v2 = TempV2.Workout(
+            uuid: UUID(),
+            workoutType: 1,
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            endDate: DateFactory.makeDate(2024, 6, 15, 10, 0, 0),
+            distance: 10000,
+            isRace: true,
+            isUserModified: true,
+            comment: "Morning pilgrimage",
+            burnedEnergy: 400,
+            healthKitUUID: nil,
+            locations: []
+        )
+        let temp = v2.asTemp
+        XCTAssertTrue(temp.isRace)
+        XCTAssertTrue(temp.isUserModified)
+        XCTAssertEqual(temp.comment, "Morning pilgrimage")
+    }
+
+    func testV3_asTemp_derivesPausesFromEvents() {
+        let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        let end = DateFactory.makeDate(2024, 6, 15, 10, 0, 0)
+        let pauseStart = DateFactory.makeDate(2024, 6, 15, 9, 20, 0)
+        let pauseEnd = DateFactory.makeDate(2024, 6, 15, 9, 25, 0)
+
+        let v3 = TempV3.Workout(
+            uuid: UUID(),
+            workoutType: 1,
+            startDate: start,
+            endDate: end,
+            distance: 5000,
+            steps: 6000,
+            isRace: false,
+            isUserModified: false,
+            comment: nil,
+            burnedEnergy: 200,
+            healthKitUUID: nil,
+            workoutEvents: [
+                TempV3.WorkoutEvent(uuid: nil, eventType: 0, startDate: pauseStart, endDate: pauseStart),
+                TempV3.WorkoutEvent(uuid: nil, eventType: 2, startDate: pauseEnd, endDate: pauseEnd)
+            ],
+            locations: [],
+            heartRates: []
+        )
+        let temp = v3.asTemp
+        XCTAssertEqual(temp.pauses.count, 1)
+        XCTAssertEqual(temp.pauses.first?.startDate, pauseStart)
+        XCTAssertEqual(temp.pauses.first?.endDate, pauseEnd)
+        XCTAssertEqual(temp.steps, 6000)
+    }
+}

--- a/UnitTests/ComputationTests.swift
+++ b/UnitTests/ComputationTests.swift
@@ -1,0 +1,240 @@
+import XCTest
+@testable import Pilgrim
+
+final class ComputationTests: XCTestCase {
+
+    // MARK: - calculateElevationData
+
+    func testElevation_emptyAltitudes_returnsZero() {
+        let result = Computation.calculateElevationData(from: [])
+        XCTAssertEqual(result.ascending, 0)
+        XCTAssertEqual(result.descending, 0)
+    }
+
+    func testElevation_singleAltitude_returnsZero() {
+        let result = Computation.calculateElevationData(from: [100.0])
+        XCTAssertEqual(result.ascending, 0)
+        XCTAssertEqual(result.descending, 0)
+    }
+
+    func testElevation_flatTerrain_returnsZero() {
+        let altitudes = Array(repeating: 100.0, count: 20)
+        let result = Computation.calculateElevationData(from: altitudes)
+        XCTAssertEqual(result.ascending, 0, accuracy: 0.01)
+        XCTAssertEqual(result.descending, 0, accuracy: 0.01)
+    }
+
+    func testElevation_steadyClimb_ascendingOnly() {
+        let altitudes = Array(stride(from: 0.0, through: 200.0, by: 5.0))
+        let result = Computation.calculateElevationData(from: altitudes)
+        XCTAssertGreaterThan(result.ascending, 0)
+        XCTAssertEqual(result.descending, 0, accuracy: 0.01)
+    }
+
+    func testElevation_steadyDescent_descendingOnly() {
+        let altitudes = Array(stride(from: 200.0, through: 0.0, by: -5.0))
+        let result = Computation.calculateElevationData(from: altitudes)
+        XCTAssertEqual(result.ascending, 0, accuracy: 0.01)
+        XCTAssertGreaterThan(result.descending, 0)
+    }
+
+    func testElevation_smallFluctuationsBelowThreshold_ignored() {
+        var altitudes: [Double] = []
+        for i in 0..<30 {
+            altitudes.append(100.0 + (i.isMultiple(of: 2) ? 0.0 : 0.5))
+        }
+        let result = Computation.calculateElevationData(from: altitudes)
+        XCTAssertEqual(result.ascending, 0, accuracy: 0.01)
+        XCTAssertEqual(result.descending, 0, accuracy: 0.01)
+    }
+
+    func testElevation_largeFluctuations_counted() {
+        let altitudes = Array(repeating: 0.0, count: 20) + Array(repeating: 50.0, count: 20)
+        let result = Computation.calculateElevationData(from: altitudes)
+        XCTAssertGreaterThan(result.ascending, 0)
+    }
+
+    func testElevation_mixedTerrain_bothNonzero() {
+        let up = Array(stride(from: 0.0, through: 100.0, by: 5.0))
+        let flat = Array(repeating: 100.0, count: 15)
+        let down = Array(stride(from: 100.0, through: 0.0, by: -5.0))
+        let altitudes = up + flat + down
+        let result = Computation.calculateElevationData(from: altitudes)
+        XCTAssertGreaterThan(result.ascending, 0)
+        XCTAssertGreaterThan(result.descending, 0)
+    }
+
+    // MARK: - calculateDurationData
+
+    func testDuration_noPauses_fullActiveDuration() {
+        let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        let end = DateFactory.makeDate(2024, 6, 15, 10, 0, 0)
+        let result = Computation.calculateDurationData(from: start, end: end)
+        XCTAssertEqual(result.activeDuration, 3600, accuracy: 0.01)
+        XCTAssertEqual(result.pauseDuration, 0, accuracy: 0.01)
+    }
+
+    func testDuration_singlePause_correctlySubtracted() {
+        let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        let end = DateFactory.makeDate(2024, 6, 15, 10, 0, 0)
+        let pauses: [Computation.RawPauseTouple] = [
+            (start: DateFactory.makeDate(2024, 6, 15, 9, 20, 0),
+             end: DateFactory.makeDate(2024, 6, 15, 9, 30, 0))
+        ]
+        let result = Computation.calculateDurationData(from: start, end: end, pauses: pauses)
+        XCTAssertEqual(result.activeDuration, 3000, accuracy: 0.01)
+        XCTAssertEqual(result.pauseDuration, 600, accuracy: 0.01)
+    }
+
+    func testDuration_multiplePauses_allSubtracted() {
+        let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        let end = DateFactory.makeDate(2024, 6, 15, 10, 0, 0)
+        let pauses: [Computation.RawPauseTouple] = [
+            (start: DateFactory.makeDate(2024, 6, 15, 9, 10, 0),
+             end: DateFactory.makeDate(2024, 6, 15, 9, 15, 0)),
+            (start: DateFactory.makeDate(2024, 6, 15, 9, 30, 0),
+             end: DateFactory.makeDate(2024, 6, 15, 9, 40, 0))
+        ]
+        let result = Computation.calculateDurationData(from: start, end: end, pauses: pauses)
+        XCTAssertEqual(result.activeDuration, 2700, accuracy: 0.01)
+        XCTAssertEqual(result.pauseDuration, 900, accuracy: 0.01)
+    }
+
+    func testDuration_zeroLengthPause_noEffect() {
+        let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        let end = DateFactory.makeDate(2024, 6, 15, 10, 0, 0)
+        let pauseTime = DateFactory.makeDate(2024, 6, 15, 9, 30, 0)
+        let pauses: [Computation.RawPauseTouple] = [(start: pauseTime, end: pauseTime)]
+        let result = Computation.calculateDurationData(from: start, end: end, pauses: pauses)
+        XCTAssertEqual(result.activeDuration, 3600, accuracy: 0.01)
+        XCTAssertEqual(result.pauseDuration, 0, accuracy: 0.01)
+    }
+
+    // MARK: - calculateAndValidatePauses
+
+    func testPauses_emptyEvents_returnsEmptyArray() {
+        let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        let end = DateFactory.makeDate(2024, 6, 15, 10, 0, 0)
+        let result = Computation.calculateAndValidatePauses(from: [], walkStart: start, walkEnd: end)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.count, 0)
+    }
+
+    func testPauses_validManualPauseResume_returnsPause() {
+        let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        let end = DateFactory.makeDate(2024, 6, 15, 10, 0, 0)
+        let events: [Computation.EventTouple] = [
+            (type: 0, date: DateFactory.makeDate(2024, 6, 15, 9, 20, 0)),
+            (type: 2, date: DateFactory.makeDate(2024, 6, 15, 9, 25, 0))
+        ]
+        let result = Computation.calculateAndValidatePauses(from: events, walkStart: start, walkEnd: end)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.count, 1)
+        XCTAssertEqual(result?.first?.type, 0)
+    }
+
+    func testPauses_validAutoPauseResume_returnsPause() {
+        let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        let end = DateFactory.makeDate(2024, 6, 15, 10, 0, 0)
+        let events: [Computation.EventTouple] = [
+            (type: 1, date: DateFactory.makeDate(2024, 6, 15, 9, 20, 0)),
+            (type: 3, date: DateFactory.makeDate(2024, 6, 15, 9, 25, 0))
+        ]
+        let result = Computation.calculateAndValidatePauses(from: events, walkStart: start, walkEnd: end)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.count, 1)
+        XCTAssertEqual(result?.first?.type, 1)
+    }
+
+    func testPauses_eventOutsideWalkRange_returnsNil() {
+        let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        let end = DateFactory.makeDate(2024, 6, 15, 10, 0, 0)
+        let events: [Computation.EventTouple] = [
+            (type: 0, date: DateFactory.makeDate(2024, 6, 15, 8, 50, 0)),
+            (type: 2, date: DateFactory.makeDate(2024, 6, 15, 9, 5, 0))
+        ]
+        let result = Computation.calculateAndValidatePauses(from: events, walkStart: start, walkEnd: end)
+        XCTAssertNil(result)
+    }
+
+    func testPauses_resumeBeforePause_returnsNil() {
+        let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        let end = DateFactory.makeDate(2024, 6, 15, 10, 0, 0)
+        let events: [Computation.EventTouple] = [
+            (type: 2, date: DateFactory.makeDate(2024, 6, 15, 9, 20, 0)),
+            (type: 0, date: DateFactory.makeDate(2024, 6, 15, 9, 25, 0))
+        ]
+        let result = Computation.calculateAndValidatePauses(from: events, walkStart: start, walkEnd: end)
+        XCTAssertNil(result)
+    }
+
+    func testPauses_moreResumesThanPauses_returnsNil() {
+        let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        let end = DateFactory.makeDate(2024, 6, 15, 10, 0, 0)
+        let events: [Computation.EventTouple] = [
+            (type: 0, date: DateFactory.makeDate(2024, 6, 15, 9, 10, 0)),
+            (type: 2, date: DateFactory.makeDate(2024, 6, 15, 9, 15, 0)),
+            (type: 2, date: DateFactory.makeDate(2024, 6, 15, 9, 20, 0))
+        ]
+        let result = Computation.calculateAndValidatePauses(from: events, walkStart: start, walkEnd: end)
+        XCTAssertNil(result)
+    }
+
+    func testPauses_unmatchedPauseAtEnd_usesWalkEnd() {
+        let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        let end = DateFactory.makeDate(2024, 6, 15, 10, 0, 0)
+        let events: [Computation.EventTouple] = [
+            (type: 0, date: DateFactory.makeDate(2024, 6, 15, 9, 50, 0))
+        ]
+        let result = Computation.calculateAndValidatePauses(from: events, walkStart: start, walkEnd: end)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.count, 1)
+        XCTAssertEqual(result?.first?.end, end)
+    }
+
+    func testPauses_sameRangeManualAndAuto_mergedAsAuto() {
+        let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        let end = DateFactory.makeDate(2024, 6, 15, 10, 0, 0)
+        let pauseStart = DateFactory.makeDate(2024, 6, 15, 9, 20, 0)
+        let pauseEnd = DateFactory.makeDate(2024, 6, 15, 9, 25, 0)
+        let events: [Computation.EventTouple] = [
+            (type: 0, date: pauseStart),
+            (type: 1, date: pauseStart),
+            (type: 2, date: pauseEnd),
+            (type: 3, date: pauseEnd)
+        ]
+        let result = Computation.calculateAndValidatePauses(from: events, walkStart: start, walkEnd: end)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.count, 1)
+        XCTAssertEqual(result?.first?.type, 1)
+    }
+
+    func testPauses_highEventTypesFiltered() {
+        let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        let end = DateFactory.makeDate(2024, 6, 15, 10, 0, 0)
+        let events: [Computation.EventTouple] = [
+            (type: 5, date: DateFactory.makeDate(2024, 6, 15, 9, 20, 0)),
+            (type: 10, date: DateFactory.makeDate(2024, 6, 15, 9, 30, 0))
+        ]
+        let result = Computation.calculateAndValidatePauses(from: events, walkStart: start, walkEnd: end)
+        XCTAssertNotNil(result)
+        XCTAssertEqual(result?.count, 0)
+    }
+
+    // MARK: - calculateBurnedEnergy
+
+    func testBurnedEnergy_walking_expectedResult() {
+        let result = Computation.calculateBurnedEnergy(for: .walking, distance: 5000, weight: 70)
+        XCTAssertEqual(result, 229.25, accuracy: 0.01)
+    }
+
+    func testBurnedEnergy_unknownType_returnsZero() {
+        let result = Computation.calculateBurnedEnergy(for: .unknown, distance: 5000, weight: 70)
+        XCTAssertEqual(result, 0)
+    }
+
+    func testBurnedEnergy_zeroDistance_returnsZero() {
+        let result = Computation.calculateBurnedEnergy(for: .walking, distance: 0, weight: 70)
+        XCTAssertEqual(result, 0)
+    }
+}

--- a/UnitTests/Helpers/DateFactory.swift
+++ b/UnitTests/Helpers/DateFactory.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+enum DateFactory {
+
+    private static let utcCalendar: Calendar = {
+        var cal = Calendar(identifier: .gregorian)
+        cal.timeZone = TimeZone(identifier: "UTC")!
+        return cal
+    }()
+
+    static func makeDate(_ year: Int, _ month: Int, _ day: Int, _ hour: Int = 0, _ minute: Int = 0, _ second: Int = 0) -> Date {
+        let components = DateComponents(year: year, month: month, day: day, hour: hour, minute: minute, second: second)
+        return utcCalendar.date(from: components)!
+    }
+
+    static func makeLocalDate(_ year: Int, _ month: Int, _ day: Int, _ hour: Int = 0, _ minute: Int = 0, _ second: Int = 0) -> Date {
+        let components = DateComponents(year: year, month: month, day: day, hour: hour, minute: minute, second: second)
+        return Calendar.current.date(from: components)!
+    }
+}

--- a/UnitTests/Helpers/WalkDataFactory.swift
+++ b/UnitTests/Helpers/WalkDataFactory.swift
@@ -1,0 +1,94 @@
+import Foundation
+@testable import Pilgrim
+
+enum WalkDataFactory {
+
+    static func makeWalk(
+        uuid: UUID? = nil,
+        workoutType: Walk.WalkType = .walking,
+        distance: Double = 1000,
+        steps: Int? = nil,
+        startDate: Date = DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+        endDate: Date = DateFactory.makeDate(2024, 6, 15, 9, 30, 0),
+        burnedEnergy: Double? = nil,
+        isRace: Bool = false,
+        comment: String? = nil,
+        isUserModified: Bool = false,
+        healthKitUUID: UUID? = nil,
+        finishedRecording: Bool = true,
+        ascend: Double = 0,
+        descend: Double = 0,
+        activeDuration: Double = 1800,
+        pauseDuration: Double = 0,
+        dayIdentifier: String = "20240615",
+        talkDuration: Double = 0,
+        meditateDuration: Double = 0,
+        heartRates: [TempV4.WorkoutHeartRateDataSample] = [],
+        routeData: [TempV4.WorkoutRouteDataSample] = [],
+        pauses: [TempV4.WorkoutPause] = [],
+        workoutEvents: [TempV4.WorkoutEvent] = [],
+        voiceRecordings: [TempV4.VoiceRecording] = []
+    ) -> TempWalk {
+        TempWalk(
+            uuid: uuid, workoutType: workoutType, distance: distance, steps: steps,
+            startDate: startDate, endDate: endDate, burnedEnergy: burnedEnergy,
+            isRace: isRace, comment: comment, isUserModified: isUserModified,
+            healthKitUUID: healthKitUUID, finishedRecording: finishedRecording,
+            ascend: ascend, descend: descend, activeDuration: activeDuration,
+            pauseDuration: pauseDuration, dayIdentifier: dayIdentifier,
+            talkDuration: talkDuration, meditateDuration: meditateDuration,
+            heartRates: heartRates, routeData: routeData, pauses: pauses,
+            workoutEvents: workoutEvents, voiceRecordings: voiceRecordings
+        )
+    }
+
+    static func makePause(
+        uuid: UUID? = nil,
+        startDate: Date = DateFactory.makeDate(2024, 6, 15, 9, 10, 0),
+        endDate: Date = DateFactory.makeDate(2024, 6, 15, 9, 15, 0),
+        pauseType: WalkPause.PauseType = .manual
+    ) -> TempWalkPause {
+        TempWalkPause(uuid: uuid, startDate: startDate, endDate: endDate, pauseType: pauseType)
+    }
+
+    static func makeRouteDataSample(
+        uuid: UUID? = nil,
+        timestamp: Date = DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+        latitude: Double = 48.8566,
+        longitude: Double = 2.3522,
+        altitude: Double = 35,
+        horizontalAccuracy: Double = 5,
+        verticalAccuracy: Double = 3,
+        speed: Double = 1.4,
+        direction: Double = 0
+    ) -> TempRouteDataSample {
+        TempRouteDataSample(
+            uuid: uuid, timestamp: timestamp, latitude: latitude, longitude: longitude,
+            altitude: altitude, horizontalAccuracy: horizontalAccuracy,
+            verticalAccuracy: verticalAccuracy, speed: speed, direction: direction
+        )
+    }
+
+    static func makeVoiceRecording(
+        uuid: UUID? = nil,
+        startDate: Date = DateFactory.makeDate(2024, 6, 15, 9, 5, 0),
+        endDate: Date = DateFactory.makeDate(2024, 6, 15, 9, 6, 0),
+        duration: Double = 60,
+        fileRelativePath: String = "recordings/test.m4a",
+        transcription: String? = "Test transcription"
+    ) -> TempVoiceRecording {
+        TempVoiceRecording(
+            uuid: uuid, startDate: startDate, endDate: endDate,
+            duration: duration, fileRelativePath: fileRelativePath,
+            transcription: transcription
+        )
+    }
+
+    static func makeWorkoutEvent(
+        uuid: UUID? = nil,
+        eventType: WalkEvent.EventType = .marker,
+        timestamp: Date = DateFactory.makeDate(2024, 6, 15, 9, 10, 0)
+    ) -> TempWalkEvent {
+        TempWalkEvent(uuid: uuid, eventType: eventType, timestamp: timestamp)
+    }
+}

--- a/UnitTests/Helpers/XCTestCase+Combine.swift
+++ b/UnitTests/Helpers/XCTestCase+Combine.swift
@@ -1,0 +1,59 @@
+import XCTest
+import Combine
+
+extension XCTestCase {
+
+    func awaitPublisher<P: Publisher>(
+        _ publisher: P,
+        timeout: TimeInterval = 1.0,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws -> P.Output {
+        var result: Result<P.Output, Error>?
+        let exp = expectation(description: "Awaiting publisher")
+
+        let cancellable = publisher
+            .first()
+            .sink(
+                receiveCompletion: { completion in
+                    if case .failure(let error) = completion {
+                        result = .failure(error)
+                    }
+                    exp.fulfill()
+                },
+                receiveValue: { value in
+                    result = .success(value)
+                }
+            )
+
+        waitForExpectations(timeout: timeout)
+        cancellable.cancel()
+
+        let unwrapped = try XCTUnwrap(result, "Publisher did not produce output", file: file, line: line)
+        return try unwrapped.get()
+    }
+
+    func collectValues<P: Publisher>(
+        from publisher: P,
+        count: Int,
+        timeout: TimeInterval = 1.0,
+        file: StaticString = #file,
+        line: UInt = #line
+    ) throws -> [P.Output] {
+        var values: [P.Output] = []
+        let exp = expectation(description: "Collecting \(count) values")
+
+        let cancellable = publisher
+            .prefix(count)
+            .sink(
+                receiveCompletion: { _ in exp.fulfill() },
+                receiveValue: { values.append($0) }
+            )
+
+        waitForExpectations(timeout: timeout)
+        cancellable.cancel()
+
+        XCTAssertEqual(values.count, count, file: file, line: line)
+        return values
+    }
+}

--- a/UnitTests/PromptGeneratorTests.swift
+++ b/UnitTests/PromptGeneratorTests.swift
@@ -1,0 +1,125 @@
+import XCTest
+@testable import Pilgrim
+
+final class PromptGeneratorTests: XCTestCase {
+
+    func testGenerateAll_returnsOnePerStyle() {
+        let prompts = PromptGenerator.generateAll(
+            recordings: [],
+            duration: 1800,
+            distance: 2000,
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        )
+        XCTAssertEqual(prompts.count, 6)
+        let styles = Set(prompts.map { $0.style })
+        XCTAssertEqual(styles.count, PromptStyle.allCases.count)
+    }
+
+    func testGenerate_containsTranscriptionText() {
+        let recording = PromptGenerator.RecordingContext(
+            text: "The birds are singing beautifully today",
+            timestamp: DateFactory.makeDate(2024, 6, 15, 9, 5, 0),
+            startCoordinate: nil,
+            endCoordinate: nil
+        )
+        let prompt = PromptGenerator.generate(
+            style: .reflective,
+            recordings: [recording],
+            duration: 1800,
+            distance: 2000,
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        )
+        XCTAssertTrue(prompt.text.contains("The birds are singing beautifully today"))
+    }
+
+    func testGenerate_containsFormattedDuration() {
+        let prompt = PromptGenerator.generate(
+            style: .contemplative,
+            recordings: [],
+            duration: 1800,
+            distance: 2000,
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        )
+        XCTAssertTrue(prompt.text.contains("30 minutes"))
+    }
+
+    func testTimeOfDay_earlyMorning() {
+        let prompt = PromptGenerator.generate(
+            style: .contemplative,
+            recordings: [],
+            duration: 1800,
+            distance: 2000,
+            startDate: DateFactory.makeLocalDate(2024, 6, 15, 5, 0, 0)
+        )
+        XCTAssertTrue(prompt.text.contains("early morning"))
+    }
+
+    func testTimeOfDay_midday() {
+        let prompt = PromptGenerator.generate(
+            style: .contemplative,
+            recordings: [],
+            duration: 1800,
+            distance: 2000,
+            startDate: DateFactory.makeLocalDate(2024, 6, 15, 12, 0, 0)
+        )
+        XCTAssertTrue(prompt.text.contains("midday"))
+    }
+
+    func testTimeOfDay_night() {
+        let prompt = PromptGenerator.generate(
+            style: .contemplative,
+            recordings: [],
+            duration: 1800,
+            distance: 2000,
+            startDate: DateFactory.makeLocalDate(2024, 6, 15, 22, 0, 0)
+        )
+        XCTAssertTrue(prompt.text.contains("night"))
+    }
+
+    func testGenerate_recordingWithGPS_containsCoordinates() {
+        let recording = PromptGenerator.RecordingContext(
+            text: "Walking in the park",
+            timestamp: DateFactory.makeDate(2024, 6, 15, 9, 5, 0),
+            startCoordinate: (lat: 48.85660, lon: 2.35220),
+            endCoordinate: nil
+        )
+        let prompt = PromptGenerator.generate(
+            style: .reflective,
+            recordings: [recording],
+            duration: 1800,
+            distance: 2000,
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        )
+        XCTAssertTrue(prompt.text.contains("GPS"))
+        XCTAssertTrue(prompt.text.contains("48.85660"))
+    }
+
+    func testGenerate_recordingWithoutGPS_omitsCoordinates() {
+        let recording = PromptGenerator.RecordingContext(
+            text: "Walking in the park",
+            timestamp: DateFactory.makeDate(2024, 6, 15, 9, 5, 0),
+            startCoordinate: nil,
+            endCoordinate: nil
+        )
+        let prompt = PromptGenerator.generate(
+            style: .reflective,
+            recordings: [recording],
+            duration: 1800,
+            distance: 2000,
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        )
+        XCTAssertFalse(prompt.text.contains("GPS"))
+    }
+
+    func testGenerate_emptyRecordings_producesValidPrompt() {
+        let prompt = PromptGenerator.generate(
+            style: .journaling,
+            recordings: [],
+            duration: 1800,
+            distance: 2000,
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        )
+        XCTAssertFalse(prompt.text.isEmpty)
+        XCTAssertTrue(prompt.text.contains("Walking Transcription"))
+    }
+}


### PR DESCRIPTION
## Summary
- Add shared test helpers: `DateFactory` (deterministic UTC/local dates), `WalkDataFactory` (TempWalk/Pause/Route/VoiceRecording factories), `XCTestCase+Combine` (publisher collection helpers)
- Add 40 new tests across 3 test suites covering the most bug-prone pure logic in the codebase
- **ComputationTests** (24 tests): elevation smoothing/thresholds, duration with pauses, pause state machine validation, burned energy MET calculation
- **PromptGeneratorTests** (9 tests): style generation, transcription embedding, time-of-day boundaries, GPS coordinate inclusion/omission
- **BackupSerializationTests** (7 tests): version codes, V4 encode/decode round-trip, V1/V2/V3 `asTemp` migration correctness

## Test plan
- [x] `xcodebuild test` — 42 tests, 0 failures
- [x] All new tests target pure functions with zero external dependencies
- [x] Time-of-day tests use local calendar to avoid timezone-dependent failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)