### PR TITLE
Add WalkBuilder, NewWalk, and migration tests (PR 2/3)

### DIFF
--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -180,8 +180,10 @@
 		AAAA000000000000000000C5 /* PromptDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000C6 /* PromptDetailView.swift */; };
 		BB00AA010000000000000002 /* PilgrimV1.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00AA010000000000000001 /* PilgrimV1.swift */; };
 		CC00BB010000000000000002 /* VoiceRecordingInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00BB010000000000000001 /* VoiceRecordingInterface.swift */; };
+		CDB0F563A56A46B5981279A2 /* WalkBuilderStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4102471AC572B099189FB03 /* WalkBuilderStatusTests.swift */; };
 		DD00CC0100000000000002 /* MeditateDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00CC0100000000000001 /* MeditateDetection.swift */; };
 		F28633E25671B876232C0F34 /* BackupSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB8B7996545B4CEF51D686E /* BackupSerializationTests.swift */; };
+		FE15922AE9DAD82F62BA4601 /* NewWalkComputationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E892B071C7BE6EBD74F3FC /* NewWalkComputationTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -367,6 +369,7 @@
 		AAAA000000000000000000C2 /* PromptGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptGenerator.swift; sourceTree = "<group>"; };
 		AAAA000000000000000000C4 /* PromptListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptListView.swift; sourceTree = "<group>"; };
 		AAAA000000000000000000C6 /* PromptDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptDetailView.swift; sourceTree = "<group>"; };
+		B3E892B071C7BE6EBD74F3FC /* NewWalkComputationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NewWalkComputationTests.swift; sourceTree = "<group>"; };
 		BB00AA010000000000000001 /* PilgrimV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV1.swift; sourceTree = "<group>"; };
 		C1B583B563EC4764AEDC9E50 /* Pods-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C1C8D965F1351F85D4E4F35D /* Pods-Pilgrim.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pilgrim.release.xcconfig"; path = "Pods/Target Support Files/Pods-Pilgrim/Pods-Pilgrim.release.xcconfig"; sourceTree = "<group>"; };
@@ -376,6 +379,7 @@
 		D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Pilgrim.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DD00CC0100000000000001 /* MeditateDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeditateDetection.swift; sourceTree = "<group>"; };
 		DD13E8087B26CC89725C3041 /* PromptGeneratorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptGeneratorTests.swift; sourceTree = "<group>"; };
+		E4102471AC572B099189FB03 /* WalkBuilderStatusTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkBuilderStatusTests.swift; sourceTree = "<group>"; };
 		EC2D4ACA7F21BA80523DF98C /* DateFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DateFactory.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -853,6 +857,8 @@
 				C2D23FF60A762C30296A69E6 /* ComputationTests.swift */,
 				DD13E8087B26CC89725C3041 /* PromptGeneratorTests.swift */,
 				1AB8B7996545B4CEF51D686E /* BackupSerializationTests.swift */,
+				E4102471AC572B099189FB03 /* WalkBuilderStatusTests.swift */,
+				B3E892B071C7BE6EBD74F3FC /* NewWalkComputationTests.swift */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -1311,6 +1317,8 @@
 				2B6F4CE80AB1FB057688EAA1 /* ComputationTests.swift in Sources */,
 				03A4AA6D8DD2B3AA6E9AF157 /* PromptGeneratorTests.swift in Sources */,
 				F28633E25671B876232C0F34 /* BackupSerializationTests.swift in Sources */,
+				CDB0F563A56A46B5981279A2 /* WalkBuilderStatusTests.swift in Sources */,
+				FE15922AE9DAD82F62BA4601 /* NewWalkComputationTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/UnitTests/MigrationTests.swift
+++ b/UnitTests/MigrationTests.swift
@@ -1,48 +1,146 @@
-//
-//  MigrationTests.swift
-//
-//  Pilgrim
-//  Copyright (C) 2022 Tim Fraedrich <timfraedrich@icloud.com>
-//
-//  This program is free software: you can redistribute it and/or modify
-//  it under the terms of the GNU General Public License as published by
-//  the Free Software Foundation, either version 3 of the License, or
-//  (at your option) any later version.
-//
-//  This program is distributed in the hope that it will be useful,
-//  but WITHOUT ANY WARRANTY; without even the implied warranty of
-//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-//  GNU General Public License for more details.
-//
-//  You should have received a copy of the GNU General Public License
-//  along with this program.  If not, see <http://www.gnu.org/licenses/>.
-//
-
 import XCTest
+@testable import Pilgrim
 
-class MigrationTests: XCTestCase {
+final class MigrationTests: XCTestCase {
 
-    override func setUpWithError() throws {
-        // Put setup code here. This method is called before the invocation of each test method in the class.
+    // MARK: - V1 Migration
+
+    func testV1_asTemp_setsDefaultsForMissingFields() {
+        let v1 = TempV1.Workout(
+            uuid: UUID(),
+            workoutType: 1,
+            startDate: DateFactory.makeDate(2024, 1, 15, 8, 0, 0),
+            endDate: DateFactory.makeDate(2024, 1, 15, 9, 0, 0),
+            distance: 3000,
+            burnedEnergy: 150,
+            healthKitUUID: nil,
+            locations: []
+        )
+        let temp = v1.asTemp
+        XCTAssertNil(temp.steps)
+        XCTAssertNil(temp.comment)
+        XCTAssertFalse(temp.isRace)
+        XCTAssertFalse(temp.isUserModified)
+        XCTAssertTrue(temp.finishedRecording)
+        XCTAssertEqual(temp.pauseDuration, 0)
+        XCTAssertEqual(temp.talkDuration, 0)
+        XCTAssertEqual(temp.meditateDuration, 0)
+        XCTAssertEqual(temp.pauses.count, 0)
+        XCTAssertEqual(temp.workoutEvents.count, 0)
+        XCTAssertEqual(temp.voiceRecordings.count, 0)
     }
 
-    override func tearDownWithError() throws {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    func testV1_asTemp_convertsRouteData() {
+        let location = TempV1.RouteDataSample(
+            uuid: UUID(),
+            timestamp: DateFactory.makeDate(2024, 1, 15, 8, 5, 0),
+            latitude: 48.8566,
+            longitude: 2.3522,
+            altitude: 35,
+            speed: 1.4,
+            direction: 90
+        )
+        let v1 = TempV1.Workout(
+            uuid: UUID(),
+            workoutType: 1,
+            startDate: DateFactory.makeDate(2024, 1, 15, 8, 0, 0),
+            endDate: DateFactory.makeDate(2024, 1, 15, 9, 0, 0),
+            distance: 3000,
+            burnedEnergy: 150,
+            healthKitUUID: nil,
+            locations: [location]
+        )
+        let temp = v1.asTemp
+        XCTAssertEqual(temp.routeData.count, 1)
+        XCTAssertEqual(temp.routeData.first?.latitude, 48.8566)
+        XCTAssertEqual(temp.routeData.first?.horizontalAccuracy, 0)
+        XCTAssertEqual(temp.routeData.first?.verticalAccuracy, 0)
     }
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
-        // Any test you write for XCTest can be annotated as throws and async.
-        // Mark your test throws to produce an unexpected failure when your test encounters an uncaught error.
-        // Mark your test async to allow awaiting for asynchronous code to complete. Check the results with assertions afterwards.
+    // MARK: - V2 Migration
+
+    func testV2_asTemp_carriesOverAllFields() {
+        let v2 = TempV2.Workout(
+            uuid: UUID(),
+            workoutType: 1,
+            startDate: DateFactory.makeDate(2024, 3, 20, 7, 0, 0),
+            endDate: DateFactory.makeDate(2024, 3, 20, 8, 30, 0),
+            distance: 8000,
+            isRace: true,
+            isUserModified: true,
+            comment: "Pilgrimage walk",
+            burnedEnergy: 350,
+            healthKitUUID: nil,
+            locations: []
+        )
+        let temp = v2.asTemp
+        XCTAssertEqual(temp.distance, 8000)
+        XCTAssertEqual(temp.burnedEnergy, 350)
+        XCTAssertEqual(temp.workoutType, .walking)
+        XCTAssertTrue(temp.isRace)
+        XCTAssertTrue(temp.isUserModified)
+        XCTAssertEqual(temp.comment, "Pilgrimage walk")
     }
 
-    func testPerformanceExample() throws {
-        // This is an example of a performance test case.
-        measure {
-            // Put the code you want to measure the time of here.
-        }
+    // MARK: - V3 Migration
+
+    func testV3_asTemp_noEvents_emptyPauses() {
+        let v3 = TempV3.Workout(
+            uuid: UUID(),
+            workoutType: 1,
+            startDate: DateFactory.makeDate(2024, 6, 1, 6, 0, 0),
+            endDate: DateFactory.makeDate(2024, 6, 1, 7, 0, 0),
+            distance: 5000,
+            steps: 7000,
+            isRace: false,
+            isUserModified: false,
+            comment: nil,
+            burnedEnergy: nil,
+            healthKitUUID: nil,
+            workoutEvents: [],
+            locations: [],
+            heartRates: []
+        )
+        let temp = v3.asTemp
+        XCTAssertEqual(temp.pauses.count, 0)
+        XCTAssertEqual(temp.pauseDuration, 0)
+        XCTAssertEqual(temp.workoutEvents.count, 0)
     }
 
+    func testV3_asTemp_pauseEventsUsedForPausesNotWorkoutEvents() {
+        let start = DateFactory.makeDate(2024, 6, 1, 6, 0, 0)
+        let end = DateFactory.makeDate(2024, 6, 1, 7, 0, 0)
+        let v3 = TempV3.Workout(
+            uuid: UUID(),
+            workoutType: 1,
+            startDate: start,
+            endDate: end,
+            distance: 5000,
+            steps: nil,
+            isRace: false,
+            isUserModified: false,
+            comment: nil,
+            burnedEnergy: nil,
+            healthKitUUID: nil,
+            workoutEvents: [
+                TempV3.WorkoutEvent(uuid: nil, eventType: 0,
+                    startDate: DateFactory.makeDate(2024, 6, 1, 6, 15, 0),
+                    endDate: DateFactory.makeDate(2024, 6, 1, 6, 15, 0)),
+                TempV3.WorkoutEvent(uuid: nil, eventType: 2,
+                    startDate: DateFactory.makeDate(2024, 6, 1, 6, 20, 0),
+                    endDate: DateFactory.makeDate(2024, 6, 1, 6, 20, 0)),
+                TempV3.WorkoutEvent(uuid: nil, eventType: 1,
+                    startDate: DateFactory.makeDate(2024, 6, 1, 6, 35, 0),
+                    endDate: DateFactory.makeDate(2024, 6, 1, 6, 35, 0)),
+                TempV3.WorkoutEvent(uuid: nil, eventType: 3,
+                    startDate: DateFactory.makeDate(2024, 6, 1, 6, 40, 0),
+                    endDate: DateFactory.makeDate(2024, 6, 1, 6, 40, 0))
+            ],
+            locations: [],
+            heartRates: []
+        )
+        let temp = v3.asTemp
+        XCTAssertEqual(temp.pauses.count, 2)
+        XCTAssertEqual(temp.workoutEvents.count, 0)
+    }
 }

--- a/UnitTests/NewWalkComputationTests.swift
+++ b/UnitTests/NewWalkComputationTests.swift
@@ -1,0 +1,87 @@
+import XCTest
+@testable import Pilgrim
+
+final class NewWalkComputationTests: XCTestCase {
+
+    func testTalkDuration_clampedToActiveDuration() {
+        let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        let end = DateFactory.makeDate(2024, 6, 15, 9, 10, 0)
+        let recordings = [
+            WalkDataFactory.makeVoiceRecording(duration: 600),
+            WalkDataFactory.makeVoiceRecording(duration: 600)
+        ]
+        let walk = NewWalk(
+            workoutType: .walking, distance: 1000, steps: nil,
+            startDate: start, endDate: end,
+            isRace: false, comment: nil, isUserModified: false, finishedRecording: true,
+            heartRates: [], routeData: [], pauses: [], workoutEvents: [],
+            voiceRecordings: recordings
+        )
+        XCTAssertEqual(walk.talkDuration, 600, accuracy: 0.01)
+    }
+
+    func testMeditateDuration_clampedToActiveDuration() {
+        let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        let end = DateFactory.makeDate(2024, 6, 15, 9, 10, 0)
+        let walk = NewWalk(
+            workoutType: .walking, distance: 1000, steps: nil,
+            startDate: start, endDate: end,
+            isRace: false, comment: nil, isUserModified: false, finishedRecording: true,
+            heartRates: [], routeData: [], pauses: [], workoutEvents: [],
+            meditateDuration: 1200
+        )
+        XCTAssertEqual(walk.meditateDuration, 600, accuracy: 0.01)
+    }
+
+    func testElevation_computedFromRouteAltitudes() {
+        let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        let end = DateFactory.makeDate(2024, 6, 15, 10, 0, 0)
+        let routeData = Array(stride(from: 0.0, through: 200.0, by: 5.0)).enumerated().map { i, alt in
+            WalkDataFactory.makeRouteDataSample(
+                timestamp: start.addingTimeInterval(Double(i) * 60),
+                altitude: alt
+            )
+        }
+        let walk = NewWalk(
+            workoutType: .walking, distance: 5000, steps: nil,
+            startDate: start, endDate: end,
+            isRace: false, comment: nil, isUserModified: false, finishedRecording: true,
+            heartRates: [], routeData: routeData, pauses: [], workoutEvents: []
+        )
+        XCTAssertGreaterThan(walk.ascend, 0)
+    }
+
+    func testDuration_computedFromStartEndPauses() {
+        let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        let end = DateFactory.makeDate(2024, 6, 15, 10, 0, 0)
+        let pauses = [
+            WalkDataFactory.makePause(
+                startDate: DateFactory.makeDate(2024, 6, 15, 9, 20, 0),
+                endDate: DateFactory.makeDate(2024, 6, 15, 9, 30, 0)
+            )
+        ]
+        let walk = NewWalk(
+            workoutType: .walking, distance: 5000, steps: nil,
+            startDate: start, endDate: end,
+            isRace: false, comment: nil, isUserModified: false, finishedRecording: true,
+            heartRates: [], routeData: [], pauses: pauses, workoutEvents: []
+        )
+        XCTAssertEqual(walk.activeDuration, 3000, accuracy: 0.01)
+        XCTAssertEqual(walk.pauseDuration, 600, accuracy: 0.01)
+    }
+
+    func testBurnedEnergy_nilWhenNoWeightPreference() {
+        let saved = UserPreferences.weight.value
+        UserPreferences.weight.value = nil
+        defer { UserPreferences.weight.value = saved }
+
+        let walk = NewWalk(
+            workoutType: .walking, distance: 5000, steps: nil,
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            endDate: DateFactory.makeDate(2024, 6, 15, 10, 0, 0),
+            isRace: false, comment: nil, isUserModified: false, finishedRecording: true,
+            heartRates: [], routeData: [], pauses: [], workoutEvents: []
+        )
+        XCTAssertNil(walk.burnedEnergy)
+    }
+}

--- a/UnitTests/WalkBuilderStatusTests.swift
+++ b/UnitTests/WalkBuilderStatusTests.swift
@@ -1,0 +1,147 @@
+import XCTest
+import Combine
+@testable import Pilgrim
+
+private class TestComponent: WalkBuilderComponent {
+    required init(builder: WalkBuilder) {}
+    func bind(builder: WalkBuilder) {}
+}
+
+final class WalkBuilderStatusTests: XCTestCase {
+
+    // MARK: - Status Transitions
+
+    func testInitialStatus_isWaiting() {
+        let builder = WalkBuilder()
+        XCTAssertEqual(builder.status, .waiting)
+    }
+
+    func testWaitingToRecording_rejected() {
+        let builder = WalkBuilder()
+        builder.setStatus(.recording)
+        XCTAssertEqual(builder.status, .waiting)
+    }
+
+    func testReadyToRecording_accepted() {
+        let builder = WalkBuilder()
+        builder.setStatus(.ready)
+        builder.setStatus(.recording)
+        XCTAssertEqual(builder.status, .recording)
+    }
+
+    func testRecordingToPaused_accepted() {
+        let builder = WalkBuilder()
+        builder.setStatus(.ready)
+        builder.setStatus(.recording)
+        builder.setStatus(.paused)
+        XCTAssertEqual(builder.status, .paused)
+    }
+
+    func testRecordingToAutoPaused_accepted() {
+        let builder = WalkBuilder()
+        builder.setStatus(.ready)
+        builder.setStatus(.recording)
+        builder.setStatus(.autoPaused)
+        XCTAssertEqual(builder.status, .autoPaused)
+    }
+
+    func testPausedToRecording_accepted() {
+        let builder = WalkBuilder()
+        builder.setStatus(.ready)
+        builder.setStatus(.recording)
+        builder.setStatus(.paused)
+        builder.setStatus(.recording)
+        XCTAssertEqual(builder.status, .recording)
+    }
+
+    func testPausedToAutoPaused_rejected() {
+        let builder = WalkBuilder()
+        builder.setStatus(.ready)
+        builder.setStatus(.recording)
+        builder.setStatus(.paused)
+        builder.setStatus(.autoPaused)
+        XCTAssertEqual(builder.status, .paused)
+    }
+
+    // MARK: - Component Readiness
+
+    func testComponentReadiness_preparingThenReady_becomesReady() {
+        let builder = WalkBuilder()
+        let readinessSubject = PassthroughSubject<WalkBuilderComponentStatus, Never>()
+        let input = WalkBuilder.Input(readiness: readinessSubject.eraseToAnyPublisher())
+        let _ = builder.tranform(input)
+
+        readinessSubject.send(.preparing(TestComponent.self))
+        XCTAssertEqual(builder.status, .waiting)
+
+        readinessSubject.send(.ready(TestComponent.self))
+        XCTAssertEqual(builder.status, .ready)
+    }
+
+    // MARK: - Pause Creation
+
+    func testPauseCreatedOnResumeFromPaused() {
+        let builder = WalkBuilder()
+        var latestPauses: [TempWalkPause] = []
+        let cancellable = builder.pausesPublisher.sink { latestPauses = $0 }
+        defer { cancellable.cancel() }
+
+        builder.setStatus(.ready)
+        builder.setStatus(.recording)
+        builder.setStatus(.paused)
+        builder.setStatus(.recording)
+
+        XCTAssertEqual(latestPauses.count, 1)
+        XCTAssertEqual(latestPauses.first?.pauseType, .manual)
+    }
+
+    func testShortAutoPause_discarded() {
+        let builder = WalkBuilder()
+        var latestPauses: [TempWalkPause] = []
+        let cancellable = builder.pausesPublisher.sink { latestPauses = $0 }
+        defer { cancellable.cancel() }
+
+        builder.setStatus(.ready)
+        builder.setStatus(.recording)
+        builder.setStatus(.autoPaused)
+        builder.setStatus(.recording)
+
+        XCTAssertEqual(latestPauses.count, 0)
+    }
+
+    func testLongAutoPause_kept() {
+        let builder = WalkBuilder()
+        var latestPauses: [TempWalkPause] = []
+        let cancellable = builder.pausesPublisher.sink { latestPauses = $0 }
+        defer { cancellable.cancel() }
+
+        builder.setStatus(.ready)
+        builder.setStatus(.recording)
+        builder.setStatus(.autoPaused)
+        Thread.sleep(forTimeInterval: 3.5)
+        builder.setStatus(.recording)
+
+        XCTAssertEqual(latestPauses.count, 1)
+        XCTAssertEqual(latestPauses.first?.pauseType, .automatic)
+    }
+
+    func testConsecutiveSameTypePauses_merged() {
+        let builder = WalkBuilder()
+        var latestPauses: [TempWalkPause] = []
+        let cancellable = builder.pausesPublisher.sink { latestPauses = $0 }
+        defer { cancellable.cancel() }
+
+        builder.setStatus(.ready)
+        builder.setStatus(.recording)
+
+        builder.setStatus(.paused)
+        builder.setStatus(.recording)
+        let firstPauseStart = latestPauses.first!.startDate
+
+        builder.setStatus(.paused)
+        builder.setStatus(.recording)
+
+        XCTAssertEqual(latestPauses.count, 2)
+        XCTAssertEqual(latestPauses.last?.startDate, firstPauseStart)
+    }
+}


### PR DESCRIPTION
## Summary
- **WalkBuilderStatusTests** (12 tests): validates the status machine — transition acceptance/rejection, component readiness flow, manual/auto pause creation, short auto-pause (<3s) discard, long auto-pause retention, and consecutive same-type pause merging
- **NewWalkComputationTests** (5 tests): verifies NewWalk's integration of Computation functions — talk/meditate duration clamping to active duration, elevation from route altitudes, duration from start/end/pauses, burned energy nil when no weight preference
- **MigrationTests** (5 tests, replaces empty template): V1 default field mapping and route data conversion (horizontalAccuracy/verticalAccuracy default to 0), V2 full field carry-over, V3 empty-event handling and pause-event filtering (types 0-3 become pauses, not workoutEvents)

## Test plan
- [x] `xcodebuild test` — 62 tests, 0 failures
- [x] Long auto-pause test uses 3.5s real-time wait (unavoidable without DI for Date)
- [x] NewWalk weight test saves/restores UserDefaults to avoid side effects

🤖 Generated with [Claude Code](https://claude.com/claude-code)