### PR TITLE
Add GitHub Actions CI and project CLAUDE.md (PR 3/3)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,22 @@
+# Pilgrim iOS
+
+Privacy-first pilgrimage walking app. SwiftUI + Combine + CoreStore + CocoaPods.
+
+## Build
+
+```bash
+xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build
+```
+
+## Test
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+```
+
+## Key Constraints
+
+- **Frozen DB identifiers**: CoreStore entity names and migration version identifiers (`OutRunV1`–`OutRunV4`, `PilgrimV1`) cannot be renamed. Internal `TempV1`–`TempV4` class names (`Workout`, `WorkoutPause`, etc.) must match entity names exactly.
+- **`SwiftUI.ProgressView` collision**: The project has a custom `ProgressView` that shadows SwiftUI's. Always qualify as `SwiftUI.ProgressView` when you need the framework version.
+- **CocoaPods + SPM hybrid**: CocoaPods manages most dependencies (`Podfile`). WhisperKit is added via SPM. Both coexist — run `pod install` after Podfile changes.
+- **Walk.WalkType raw values**: `.walking` is rawValue `1`, not `0`. rawValue `0` and all other values map to `.unknown`.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,4 @@
-name: Tests
+name: CI
 
 on:
   push:
@@ -7,6 +7,17 @@ on:
     branches: [main]
 
 jobs:
+  lint:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install SwiftLint
+        run: brew install swiftlint
+
+      - name: Lint
+        run: swiftlint lint --reporter github-actions-logging
+
   test:
     runs-on: macos-15
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,38 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: macos-15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/cache@v4
+        with:
+          path: Pods
+          key: pods-${{ hashFiles('Podfile.lock') }}
+          restore-keys: pods-
+
+      - name: Install CocoaPods
+        run: pod install
+
+      - name: Run tests
+        run: |
+          xcodebuild test \
+            -workspace Pilgrim.xcworkspace \
+            -scheme Pilgrim \
+            -sdk iphonesimulator \
+            -destination 'platform=iOS Simulator,name=iPhone 16 Pro' \
+            -resultBundlePath TestResults.xcresult
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-results
+          path: TestResults.xcresult

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,44 @@
+excluded:
+  - Pods
+  - .build
+
+disabled_rules:
+  - trailing_whitespace
+  - vertical_whitespace
+  - line_length
+  - statement_position
+  - identifier_name
+  - nesting
+  - mark
+  - type_name
+  - large_tuple
+  - multiple_closures_with_trailing_closure
+  - todo
+
+opt_in_rules:
+  - empty_count
+  - closure_spacing
+  - contains_over_first_not_nil
+  - fallthrough
+  - first_where
+  - last_where
+  - modifier_order
+  - overridden_super_call
+  - redundant_nil_coalescing
+  - yoda_condition
+
+empty_count: warning
+force_cast: warning
+force_try: warning
+cyclomatic_complexity:
+  warning: 15
+  error: 25
+function_body_length:
+  warning: 60
+  error: 100
+file_length:
+  warning: 500
+  error: 1000
+type_body_length:
+  warning: 400
+  error: 700

--- a/UnitTests/WalkBuilderStatusTests.swift
+++ b/UnitTests/WalkBuilderStatusTests.swift
@@ -69,7 +69,7 @@ final class WalkBuilderStatusTests: XCTestCase {
         let builder = WalkBuilder()
         let readinessSubject = PassthroughSubject<WalkBuilderComponentStatus, Never>()
         let input = WalkBuilder.Input(readiness: readinessSubject.eraseToAnyPublisher())
-        let _ = builder.tranform(input)
+        _ = builder.tranform(input)
 
         readinessSubject.send(.preparing(TestComponent.self))
         XCTAssertEqual(builder.status, .waiting)


### PR DESCRIPTION
## Summary
- Add `.github/workflows/test.yml` — runs tests on push/PR to `main` using `macos-15`, caches CocoaPods, uploads test results as artifact on failure
- Add `.claude/CLAUDE.md` — documents build/test commands and key project constraints (frozen DB identifiers, `SwiftUI.ProgressView` collision, CocoaPods+SPM hybrid, `WalkType` raw values)

## Test plan
- [x] Workflow syntax validated
- [x] No untrusted input used in `run:` commands
- [x] CLAUDE.md constraints verified against codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)