### PR TITLE
Enhance AI prompt generation with context and custom styles

### DIFF
--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -178,6 +178,7 @@
 		AAAA000000000000000000C1 /* PromptGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000C2 /* PromptGenerator.swift */; };
 		AAAA000000000000000000C3 /* PromptListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000C4 /* PromptListView.swift */; };
 		AAAA000000000000000000C5 /* PromptDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000C6 /* PromptDetailView.swift */; };
+		AAAA000000000000000000D1 /* CustomPromptStyleStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000D2 /* CustomPromptStyleStore.swift */; };
 		BB00AA010000000000000002 /* PilgrimV1.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00AA010000000000000001 /* PilgrimV1.swift */; };
 		CC00BB010000000000000002 /* VoiceRecordingInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00BB010000000000000001 /* VoiceRecordingInterface.swift */; };
 		CDB0F563A56A46B5981279A2 /* WalkBuilderStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4102471AC572B099189FB03 /* WalkBuilderStatusTests.swift */; };
@@ -378,6 +379,7 @@
 		AAAA000000000000000000C2 /* PromptGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptGenerator.swift; sourceTree = "<group>"; };
 		AAAA000000000000000000C4 /* PromptListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptListView.swift; sourceTree = "<group>"; };
 		AAAA000000000000000000C6 /* PromptDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptDetailView.swift; sourceTree = "<group>"; };
+		AAAA000000000000000000D2 /* CustomPromptStyleStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPromptStyleStore.swift; sourceTree = "<group>"; };
 		B3E892B071C7BE6EBD74F3FC /* NewWalkComputationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NewWalkComputationTests.swift; sourceTree = "<group>"; };
 		BB00AA010000000000000001 /* PilgrimV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV1.swift; sourceTree = "<group>"; };
 		C1B583B563EC4764AEDC9E50 /* Pods-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
@@ -696,6 +698,7 @@
 				AAAA000000000000000000B2 /* TranscriptionService.swift */,
 				22834F792542239800057FEB /* HelperMethods.swift */,
 				AAAA000000000000000000C2 /* PromptGenerator.swift */,
+				AAAA000000000000000000D2 /* CustomPromptStyleStore.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1336,6 +1339,7 @@
 				EF1533CDBBC5498EA3BFDFC6 /* ActivityIntervalInterface.swift in Sources */,
 				DD00CC0100000000000002 /* MeditateDetection.swift in Sources */,
 				AAAA000000000000000000C1 /* PromptGenerator.swift in Sources */,
+				AAAA000000000000000000D1 /* CustomPromptStyleStore.swift in Sources */,
 				AAAA000000000000000000C3 /* PromptListView.swift in Sources */,
 				AAAA000000000000000000C5 /* PromptDetailView.swift in Sources */,
 			);

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -185,6 +185,7 @@
 		F28633E25671B876232C0F34 /* BackupSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB8B7996545B4CEF51D686E /* BackupSerializationTests.swift */; };
 		FE15922AE9DAD82F62BA4601 /* NewWalkComputationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E892B071C7BE6EBD74F3FC /* NewWalkComputationTests.swift */; };
 		3F8E37CD28D541C1838F01BD /* PilgrimV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2722224F049B455DB473E7C9 /* PilgrimV2.swift */; };
+		A1B2C3D4E5F601020304050B /* PilgrimV3.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F601020304050A /* PilgrimV3.swift */; };
 		9726AFAB9F744FDA86EEC2CF /* ActivityInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA57CE96EE3401595264807 /* ActivityInterval.swift */; };
 		EF1533CDBBC5498EA3BFDFC6 /* ActivityIntervalInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964D4C7663494F3ABBEEF84F /* ActivityIntervalInterface.swift */; };
 		08508B6253B3427ABA939DED /* ActivityTimelineBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CBD6B08E4C437DA90FDDB0 /* ActivityTimelineBar.swift */; };
@@ -390,6 +391,7 @@
 		E4102471AC572B099189FB03 /* WalkBuilderStatusTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkBuilderStatusTests.swift; sourceTree = "<group>"; };
 		EC2D4ACA7F21BA80523DF98C /* DateFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DateFactory.swift; sourceTree = "<group>"; };
 		2722224F049B455DB473E7C9 /* PilgrimV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV2.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F601020304050A /* PilgrimV3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV3.swift; sourceTree = "<group>"; };
 		1BA57CE96EE3401595264807 /* ActivityInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityInterval.swift; sourceTree = "<group>"; };
 		964D4C7663494F3ABBEEF84F /* ActivityIntervalInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIntervalInterface.swift; sourceTree = "<group>"; };
 		C9CBD6B08E4C437DA90FDDB0 /* ActivityTimelineBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityTimelineBar.swift; sourceTree = "<group>"; };
@@ -461,6 +463,7 @@
 				22B1DD91253F91380093822B /* OutRunV4.swift */,
 				BB00AA010000000000000001 /* PilgrimV1.swift */,
 				2722224F049B455DB473E7C9 /* PilgrimV2.swift */,
+				A1B2C3D4E5F601020304050A /* PilgrimV3.swift */,
 			);
 			path = Versions;
 			sourceTree = "<group>";
@@ -1328,6 +1331,7 @@
 				AA00020100000000000004 /* VoiceRecordingManagement.swift in Sources */,
 				BB00AA010000000000000002 /* PilgrimV1.swift in Sources */,
 				3F8E37CD28D541C1838F01BD /* PilgrimV2.swift in Sources */,
+				A1B2C3D4E5F601020304050B /* PilgrimV3.swift in Sources */,
 				CC00BB010000000000000002 /* VoiceRecordingInterface.swift in Sources */,
 				EF1533CDBBC5498EA3BFDFC6 /* ActivityIntervalInterface.swift in Sources */,
 				DD00CC0100000000000002 /* MeditateDetection.swift in Sources */,

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -194,6 +194,8 @@
 		6F242558E79A4653BAAAE3FB /* ActivityListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FDF0BD38D9467B99B2C4D7 /* ActivityListView.swift */; };
 		B9C538ECD15D4CE3B5B4186E /* ActivityInsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D6AFD9DABC41629606A762 /* ActivityInsightsView.swift */; };
 		4E9F3E9C7E3A4840ACD9DA73 /* ActivityIntervalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B789284BE2A474BA89993F2 /* ActivityIntervalTests.swift */; };
+		AAAA000000000000000000D3 /* CustomPromptStyleStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000D4 /* CustomPromptStyleStoreTests.swift */; };
+		AAAA000000000000000000E1 /* CustomPromptEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000E2 /* CustomPromptEditorView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -401,6 +403,8 @@
 		D2FDF0BD38D9467B99B2C4D7 /* ActivityListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityListView.swift; sourceTree = "<group>"; };
 		04D6AFD9DABC41629606A762 /* ActivityInsightsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityInsightsView.swift; sourceTree = "<group>"; };
 		3B789284BE2A474BA89993F2 /* ActivityIntervalTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActivityIntervalTests.swift; sourceTree = "<group>"; };
+		AAAA000000000000000000D4 /* CustomPromptStyleStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomPromptStyleStoreTests.swift; sourceTree = "<group>"; };
+		AAAA000000000000000000E2 /* CustomPromptEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPromptEditorView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -885,6 +889,7 @@
 				E4102471AC572B099189FB03 /* WalkBuilderStatusTests.swift */,
 				B3E892B071C7BE6EBD74F3FC /* NewWalkComputationTests.swift */,
 				3B789284BE2A474BA89993F2 /* ActivityIntervalTests.swift */,
+				AAAA000000000000000000D4 /* CustomPromptStyleStoreTests.swift */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -978,6 +983,7 @@
 			children = (
 				AAAA000000000000000000C4 /* PromptListView.swift */,
 				AAAA000000000000000000C6 /* PromptDetailView.swift */,
+				AAAA000000000000000000E2 /* CustomPromptEditorView.swift */,
 			);
 			path = Prompts;
 			sourceTree = "<group>";
@@ -1342,6 +1348,7 @@
 				AAAA000000000000000000D1 /* CustomPromptStyleStore.swift in Sources */,
 				AAAA000000000000000000C3 /* PromptListView.swift in Sources */,
 				AAAA000000000000000000C5 /* PromptDetailView.swift in Sources */,
+				AAAA000000000000000000E1 /* CustomPromptEditorView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1359,6 +1366,7 @@
 				CDB0F563A56A46B5981279A2 /* WalkBuilderStatusTests.swift in Sources */,
 				FE15922AE9DAD82F62BA4601 /* NewWalkComputationTests.swift in Sources */,
 				4E9F3E9C7E3A4840ACD9DA73 /* ActivityIntervalTests.swift in Sources */,
+				AAAA000000000000000000D3 /* CustomPromptStyleStoreTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pilgrim/Models/CustomPromptStyleStore.swift
+++ b/Pilgrim/Models/CustomPromptStyleStore.swift
@@ -6,3 +6,44 @@ struct CustomPromptStyle: Codable, Identifiable {
     var icon: String
     var instruction: String
 }
+
+final class CustomPromptStyleStore: ObservableObject {
+    static let maxStyles = 3
+
+    @Published private(set) var styles: [CustomPromptStyle]
+
+    private let userDefaultsKey: String
+
+    init(userDefaultsKey: String = "CustomPromptStyles") {
+        self.userDefaultsKey = userDefaultsKey
+        if let data = UserDefaults.standard.data(forKey: userDefaultsKey),
+           let decoded = try? JSONDecoder().decode([CustomPromptStyle].self, from: data) {
+            styles = decoded
+        } else {
+            styles = []
+        }
+    }
+
+    var canAddMore: Bool { styles.count < Self.maxStyles }
+
+    func save(_ style: CustomPromptStyle) {
+        if let index = styles.firstIndex(where: { $0.id == style.id }) {
+            styles[index] = style
+        } else {
+            guard canAddMore else { return }
+            styles.append(style)
+        }
+        persist()
+    }
+
+    func delete(_ style: CustomPromptStyle) {
+        styles.removeAll { $0.id == style.id }
+        persist()
+    }
+
+    private func persist() {
+        if let data = try? JSONEncoder().encode(styles) {
+            UserDefaults.standard.set(data, forKey: userDefaultsKey)
+        }
+    }
+}

--- a/Pilgrim/Models/CustomPromptStyleStore.swift
+++ b/Pilgrim/Models/CustomPromptStyleStore.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct CustomPromptStyle: Codable, Identifiable {
+    let id: UUID
+    var title: String
+    var icon: String
+    var instruction: String
+}

--- a/Pilgrim/Models/Data/DataManager.swift
+++ b/Pilgrim/Models/Data/DataManager.swift
@@ -260,6 +260,7 @@ struct DataManager {
                     recording._duration .= tempRecording.duration
                     recording._fileRelativePath .= tempRecording.fileRelativePath
                     recording._transcription .= tempRecording.transcription
+                    recording._wordsPerMinute .= tempRecording.wordsPerMinute
 
                     recording._workout .= walk
                 }
@@ -403,6 +404,7 @@ struct DataManager {
                     recording._duration .= tempRecording.duration
                     recording._fileRelativePath .= tempRecording.fileRelativePath
                     recording._transcription .= tempRecording.transcription
+                    recording._wordsPerMinute .= tempRecording.wordsPerMinute
 
                     recording._workout .= walk
                 }
@@ -471,6 +473,20 @@ struct DataManager {
         }) { result in
             if case .failure(let error) = result {
                 print("[DataManager] Failed to update transcription: \(error)")
+            }
+        }
+    }
+
+    public static func updateVoiceRecordingWordsPerMinute(uuid: UUID, wordsPerMinute: Double) {
+        dataStack.perform(asynchronous: { transaction -> Void in
+            if let recording = transaction.edit(
+                queryObject(from: uuid, transaction: transaction) as VoiceRecording?
+            ) {
+                recording._wordsPerMinute .= wordsPerMinute
+            }
+        }) { result in
+            if case .failure(let error) = result {
+                print("[DataManager] Failed to update WPM for \(uuid): \(error)")
             }
         }
     }

--- a/Pilgrim/Models/Data/DataManager.swift
+++ b/Pilgrim/Models/Data/DataManager.swift
@@ -52,7 +52,7 @@ struct DataManager {
      - parameter migration: the closure being called on the event of a migration happening, including a `Progress` object indicating the progress of the migration
      - warning: If this method fails it does so in a fatal error, the app will crash as a result.
      */
-    public static func setup(dataModel: DataModelProtocol.Type = PilgrimV2.self, completion: @escaping (DataManager.SetupError?) -> Void, migration: @escaping (Progress) -> Void) {
+    public static func setup(dataModel: DataModelProtocol.Type = PilgrimV3.self, completion: @escaping (DataManager.SetupError?) -> Void, migration: @escaping (Progress) -> Void) {
         
         let completion = safeClosure(from: completion)
         

--- a/Pilgrim/Models/Data/DataModels/ActivityInterval.swift
+++ b/Pilgrim/Models/Data/DataModels/ActivityInterval.swift
@@ -1,11 +1,11 @@
 import Foundation
 import CoreStore
 
-public typealias ActivityInterval = PilgrimV2.ActivityInterval
+public typealias ActivityInterval = PilgrimV3.ActivityInterval
 
-public extension ActivityInterval {
+extension PilgrimV2.ActivityInterval {
 
-    enum ActivityType: RawRepresentable, ImportableAttributeType, Codable {
+    public enum ActivityType: RawRepresentable, ImportableAttributeType, Codable {
 
         case unknown
         case meditation
@@ -28,6 +28,12 @@ public extension ActivityInterval {
             }
         }
     }
+
+}
+
+public extension ActivityInterval {
+
+    typealias ActivityType = PilgrimV2.ActivityInterval.ActivityType
 
 }
 

--- a/Pilgrim/Models/Data/DataModels/Event.swift
+++ b/Pilgrim/Models/Data/DataModels/Event.swift
@@ -21,7 +21,7 @@
 
 import Foundation
 
-public typealias Event = PilgrimV2.Event
+public typealias Event = PilgrimV3.Event
 
 // MARK: CustomStringConvertible
 

--- a/Pilgrim/Models/Data/DataModels/HeartRateDataSample.swift
+++ b/Pilgrim/Models/Data/DataModels/HeartRateDataSample.swift
@@ -21,7 +21,7 @@
 
 import Foundation
 
-public typealias HeartRateDataSample = PilgrimV2.WorkoutHeartRateDataSample
+public typealias HeartRateDataSample = PilgrimV3.WorkoutHeartRateDataSample
 
 // MARK: - CustomStringConvertible
 

--- a/Pilgrim/Models/Data/DataModels/RouteDataSample.swift
+++ b/Pilgrim/Models/Data/DataModels/RouteDataSample.swift
@@ -22,7 +22,7 @@
 import Foundation
 import CoreLocation
 
-public typealias RouteDataSample = PilgrimV2.WorkoutRouteDataSample
+public typealias RouteDataSample = PilgrimV3.WorkoutRouteDataSample
 
 // MARK: - CustomStringConvertible
 

--- a/Pilgrim/Models/Data/DataModels/Versions/PilgrimV3.swift
+++ b/Pilgrim/Models/Data/DataModels/Versions/PilgrimV3.swift
@@ -1,0 +1,197 @@
+import CoreStore
+
+public enum PilgrimV3: DataModelProtocol {
+
+    static let identifier = "PilgrimV3"
+    static let schema = CoreStoreSchema(
+        modelVersion: PilgrimV3.identifier,
+        entities: [
+            Entity<PilgrimV3.Workout>(PilgrimV3.Workout.identifier),
+            Entity<PilgrimV3.WorkoutPause>(PilgrimV3.WorkoutPause.identifier),
+            Entity<PilgrimV3.WorkoutEvent>(PilgrimV3.WorkoutEvent.identifier),
+            Entity<PilgrimV3.WorkoutRouteDataSample>(PilgrimV3.WorkoutRouteDataSample.identifier),
+            Entity<PilgrimV3.WorkoutHeartRateDataSample>(PilgrimV3.WorkoutHeartRateDataSample.identifier),
+            Entity<PilgrimV3.Event>(PilgrimV3.Event.identifier),
+            Entity<PilgrimV3.VoiceRecording>(PilgrimV3.VoiceRecording.identifier),
+            Entity<PilgrimV3.ActivityInterval>(PilgrimV3.ActivityInterval.identifier)
+        ]
+    )
+
+    static let mappingProvider: CustomSchemaMappingProvider? = CustomSchemaMappingProvider(
+        from: PilgrimV2.identifier,
+        to: PilgrimV3.identifier,
+        entityMappings: [
+            .copyEntity(sourceEntity: PilgrimV2.Workout.identifier, destinationEntity: PilgrimV3.Workout.identifier),
+            .copyEntity(sourceEntity: PilgrimV2.WorkoutPause.identifier, destinationEntity: PilgrimV3.WorkoutPause.identifier),
+            .copyEntity(sourceEntity: PilgrimV2.WorkoutEvent.identifier, destinationEntity: PilgrimV3.WorkoutEvent.identifier),
+            .copyEntity(sourceEntity: PilgrimV2.WorkoutRouteDataSample.identifier, destinationEntity: PilgrimV3.WorkoutRouteDataSample.identifier),
+            .copyEntity(sourceEntity: PilgrimV2.WorkoutHeartRateDataSample.identifier, destinationEntity: PilgrimV3.WorkoutHeartRateDataSample.identifier),
+            .copyEntity(sourceEntity: PilgrimV2.Event.identifier, destinationEntity: PilgrimV3.Event.identifier),
+            .transformEntity(
+                sourceEntity: PilgrimV2.VoiceRecording.identifier,
+                destinationEntity: PilgrimV3.VoiceRecording.identifier,
+                transformer: { (sourceObject: CustomSchemaMappingProvider.UnsafeSourceObject, createDestinationObject: () -> CustomSchemaMappingProvider.UnsafeDestinationObject) in
+                    let destinationObject = createDestinationObject()
+                    destinationObject.enumerateAttributes { (attribute, sourceAttribute) in
+                        if let sourceAttribute = sourceAttribute {
+                            destinationObject[attribute] = sourceObject[sourceAttribute]
+                        }
+                    }
+                }
+            ),
+            .copyEntity(sourceEntity: PilgrimV2.ActivityInterval.identifier, destinationEntity: PilgrimV3.ActivityInterval.identifier)
+        ]
+    )
+
+    static let migrationChain: [DataModelProtocol.Type] = [
+        OutRunV1.self, OutRunV2.self, OutRunV3.self, OutRunV3to4.self, OutRunV4.self, PilgrimV1.self, PilgrimV2.self, PilgrimV3.self
+    ]
+
+    // MARK: Workout
+    public final class Workout: CoreStoreObject, DataTypeProtocol {
+
+        static let identifier = "Workout"
+
+        let _uuid = Value.Optional<UUID>("id")
+        let _workoutType = Value.Required<PilgrimV2.Workout.WalkType>("workoutType", initial: .unknown)
+        let _distance = Value.Required<Double>("distance", initial: -1)
+        let _steps = Value.Optional<Int>("steps")
+        let _startDate = Value.Required<Date>("startDate", initial: .init(timeIntervalSince1970: 0))
+        let _endDate = Value.Required<Date>("endDate", initial: .init(timeIntervalSince1970: 0))
+        let _burnedEnergy = Value.Optional<Double>("burnedEnergy")
+        let _isRace = Value.Required<Bool>("isRace", initial: false)
+        let _comment = Value.Optional<String>("comment")
+        let _isUserModified = Value.Required<Bool>("isUserModified", initial: false)
+        let _healthKitUUID = Value.Optional<UUID>("healthKitID")
+        let _finishedRecording = Value.Required<Bool>("finishedRecording", initial: true)
+
+        let _ascend = Value.Required<Double>("ascendingAltitude", initial: 0)
+        let _descend = Value.Required<Double>("descendingAltitude", initial: 0)
+        let _activeDuration = Value.Required<Double>("activeDuration", initial: 0)
+        let _pauseDuration = Value.Required<Double>("pauseDuration", initial: 0)
+        let _dayIdentifier = Value.Required<String>("dayIdentifier", initial: "")
+
+        let _talkDuration = Value.Required<Double>("talkDuration", initial: 0)
+        let _meditateDuration = Value.Required<Double>("meditateDuration", initial: 0)
+
+        let _weatherTemperature = Value.Optional<Double>("weatherTemperature")
+        let _weatherCondition = Value.Optional<String>("weatherCondition")
+        let _weatherHumidity = Value.Optional<Double>("weatherHumidity")
+        let _weatherWindSpeed = Value.Optional<Double>("weatherWindSpeed")
+
+        let _heartRates = Relationship.ToManyOrdered<PilgrimV3.WorkoutHeartRateDataSample>("heartRates", inverse: { $0._workout })
+        let _routeData = Relationship.ToManyOrdered<PilgrimV3.WorkoutRouteDataSample>("routeData", inverse: { $0._workout })
+        let _pauses = Relationship.ToManyOrdered<PilgrimV3.WorkoutPause>("pauses", inverse: { $0._workout })
+        let _workoutEvents = Relationship.ToManyOrdered<PilgrimV3.WorkoutEvent>("workoutEvents", inverse: { $0._workout })
+        let _events = Relationship.ToManyUnordered<PilgrimV3.Event>("events", inverse: { $0._workouts })
+        let _voiceRecordings = Relationship.ToManyOrdered<PilgrimV3.VoiceRecording>("voiceRecordings", inverse: { $0._workout })
+        let _activityIntervals = Relationship.ToManyOrdered<PilgrimV3.ActivityInterval>("activityIntervals", inverse: { $0._workout })
+
+    }
+
+    // MARK: WorkoutPause
+    public final class WorkoutPause: CoreStoreObject, DataTypeProtocol {
+
+        static let identifier = "WorkoutPause"
+
+        let _uuid = Value.Optional<UUID>("id")
+        let _startDate = Value.Required<Date>("startDate", initial: .init(timeIntervalSince1970: 0))
+        let _endDate = Value.Required<Date>("endDate", initial: .init(timeIntervalSince1970: 0))
+        let _pauseType = Value.Required<PilgrimV2.WorkoutPause.PauseType>("pauseType", initial: .manual)
+
+        let _workout = Relationship.ToOne<PilgrimV3.Workout>("workout")
+
+    }
+
+    // MARK: WorkoutEvent
+    public final class WorkoutEvent: CoreStoreObject, DataTypeProtocol {
+
+        static let identifier = "WorkoutEvent"
+
+        let _uuid = Value.Optional<UUID>("id")
+        let _eventType = Value.Required<PilgrimV2.WorkoutEvent.EventType>("eventType", initial: .unknown)
+        let _timestamp = Value.Required<Date>("timestamp", initial: .init(timeIntervalSince1970: 0), renamingIdentifier: "startDate")
+
+        let _workout = Relationship.ToOne<PilgrimV3.Workout>("workout")
+
+    }
+
+    // MARK: WorkoutRouteDataSample
+    public final class WorkoutRouteDataSample: CoreStoreObject, DataTypeProtocol {
+
+        static let identifier = "WorkoutRouteDataSample"
+
+        let _uuid = Value.Optional<UUID>("id")
+        let _timestamp = Value.Required<Date>("timestamp", initial: .init(timeIntervalSince1970: 0))
+        let _latitude = Value.Required<Double>("latitude", initial: -1)
+        let _longitude = Value.Required<Double>("longitude", initial: -1)
+        let _altitude = Value.Required<Double>("altitude", initial: -1)
+        let _horizontalAccuracy = Value.Required<Double>("horizontalAccuracy", initial: 0)
+        let _verticalAccuracy = Value.Required<Double>("verticalAccuracy", initial: 0)
+        let _speed = Value.Required<Double>("speed", initial: -1)
+        let _direction = Value.Required<Double>("direction", initial: -1)
+
+        let _workout = Relationship.ToOne<PilgrimV3.Workout>("workout")
+
+    }
+
+    // MARK: WorkoutHeartRateDataSample
+    public final class WorkoutHeartRateDataSample: CoreStoreObject, DataTypeProtocol {
+
+        static let identifier = "WorkoutHeartRateSample"
+
+        let _uuid = Value.Optional<UUID>("id")
+        let _heartRate = Value.Required<Int>("heartRate", initial: 0)
+        let _timestamp = Value.Required<Date>("timestamp", initial: .init(timeIntervalSince1970: 0))
+
+        let _workout = Relationship.ToOne<PilgrimV3.Workout>("workout")
+
+    }
+
+    // MARK: Event
+    public final class Event: CoreStoreObject, DataTypeProtocol {
+
+        static let identifier = "Event"
+
+        let _uuid = Value.Optional<UUID>("id")
+        let _title = Value.Required<String>("eventTitle", initial: "")
+        let _comment = Value.Optional<String>("comment")
+        let _startDate = Value.Optional<Date>("startDate")
+        let _endDate = Value.Optional<Date>("endDate")
+
+        let _workouts = Relationship.ToManyOrdered<PilgrimV3.Workout>("workouts")
+
+    }
+
+    // MARK: VoiceRecording
+    public final class VoiceRecording: CoreStoreObject, DataTypeProtocol {
+
+        static let identifier = "VoiceRecording"
+
+        let _uuid = Value.Optional<UUID>("id")
+        let _startDate = Value.Required<Date>("startDate", initial: .init(timeIntervalSince1970: 0))
+        let _endDate = Value.Required<Date>("endDate", initial: .init(timeIntervalSince1970: 0))
+        let _duration = Value.Required<Double>("duration", initial: 0)
+        let _fileRelativePath = Value.Required<String>("fileRelativePath", initial: "")
+        let _transcription = Value.Optional<String>("transcription")
+        let _wordsPerMinute = Value.Optional<Double>("wordsPerMinute")
+
+        let _workout = Relationship.ToOne<PilgrimV3.Workout>("workout")
+
+    }
+
+    // MARK: ActivityInterval
+    public final class ActivityInterval: CoreStoreObject, DataTypeProtocol {
+
+        static let identifier = "ActivityInterval"
+
+        let _uuid = Value.Optional<UUID>("id")
+        let _activityType = Value.Required<PilgrimV2.ActivityInterval.ActivityType>("activityType", initial: .unknown)
+        let _startDate = Value.Required<Date>("startDate", initial: .init(timeIntervalSince1970: 0))
+        let _endDate = Value.Required<Date>("endDate", initial: .init(timeIntervalSince1970: 0))
+
+        let _workout = Relationship.ToOne<PilgrimV3.Workout>("workout")
+
+    }
+
+}

--- a/Pilgrim/Models/Data/DataModels/VoiceRecording.swift
+++ b/Pilgrim/Models/Data/DataModels/VoiceRecording.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CoreStore
 
-public typealias VoiceRecording = PilgrimV2.VoiceRecording
+public typealias VoiceRecording = PilgrimV3.VoiceRecording
 
 extension VoiceRecording: VoiceRecordingInterface {
 
@@ -11,7 +11,8 @@ extension VoiceRecording: VoiceRecordingInterface {
     public var duration: Double { threadSafeSyncReturn { self._duration.value } }
     public var fileRelativePath: String { threadSafeSyncReturn { self._fileRelativePath.value } }
     public var transcription: String? { threadSafeSyncReturn { self._transcription.value } }
-    public var workout: WalkInterface? { self._workout.value }
+    public var wordsPerMinute: Double? { threadSafeSyncReturn { self._wordsPerMinute.value } }
+    public var workout: WalkInterface? { self._workout.value as? WalkInterface }
 
 }
 
@@ -24,7 +25,8 @@ extension VoiceRecording: TempValueConvertible {
             endDate: endDate,
             duration: duration,
             fileRelativePath: fileRelativePath,
-            transcription: transcription
+            transcription: transcription,
+            wordsPerMinute: wordsPerMinute
         )
     }
 

--- a/Pilgrim/Models/Data/DataModels/Walk.swift
+++ b/Pilgrim/Models/Data/DataModels/Walk.swift
@@ -23,15 +23,11 @@ import Foundation
 import CoreLocation
 import CoreStore
 
-public typealias Walk = PilgrimV2.Workout
+public typealias Walk = PilgrimV3.Workout
 
-public extension Walk {
+extension PilgrimV2.Workout {
 
-    var hasRouteData: Bool {
-        return !self.routeData.isEmpty
-    }
-
-    enum WalkType: CaseIterable, CustomStringConvertible, CustomDebugStringConvertible, RawRepresentable, ImportableAttributeType, Codable {
+    public enum WalkType: CaseIterable, CustomStringConvertible, CustomDebugStringConvertible, RawRepresentable, ImportableAttributeType, Codable {
 
         case walking, unknown
 
@@ -81,6 +77,16 @@ public extension Walk {
         }
 
     }
+
+}
+
+public extension Walk {
+
+    var hasRouteData: Bool {
+        return !self.routeData.isEmpty
+    }
+
+    typealias WalkType = PilgrimV2.Workout.WalkType
 
 }
 

--- a/Pilgrim/Models/Data/DataModels/WalkEvent.swift
+++ b/Pilgrim/Models/Data/DataModels/WalkEvent.swift
@@ -22,13 +22,13 @@
 import Foundation
 import CoreStore
 
-public typealias WalkEvent = PilgrimV2.WorkoutEvent
+public typealias WalkEvent = PilgrimV3.WorkoutEvent
 
-public extension WalkEvent {
-    
-    enum EventType: CustomStringConvertible, CustomDebugStringConvertible, RawRepresentable, ImportableAttributeType, Codable {
+extension PilgrimV2.WorkoutEvent {
+
+    public enum EventType: CustomStringConvertible, CustomDebugStringConvertible, RawRepresentable, ImportableAttributeType, Codable {
         case lap, marker, segment, unknown
-        
+
         public init(rawValue: Int) {
             switch rawValue {
             case 0:
@@ -41,7 +41,7 @@ public extension WalkEvent {
                 self = .unknown
             }
         }
-        
+
         public var rawValue: Int {
             switch self {
             case .lap:
@@ -54,7 +54,7 @@ public extension WalkEvent {
                 return -1
             }
         }
-        
+
         public var description: String {
             switch self {
             case .lap:
@@ -67,7 +67,7 @@ public extension WalkEvent {
                 return LS["WalkEvent.Type.Unknown"]
             }
         }
-        
+
         public var debugDescription: String {
             switch self {
             case .lap:
@@ -80,9 +80,15 @@ public extension WalkEvent {
                 return "Unknown"
             }
         }
-        
+
     }
-    
+
+}
+
+public extension WalkEvent {
+
+    typealias EventType = PilgrimV2.WorkoutEvent.EventType
+
 }
 
 // MARK: - CustomStringConvertible

--- a/Pilgrim/Models/Data/DataModels/WalkPause.swift
+++ b/Pilgrim/Models/Data/DataModels/WalkPause.swift
@@ -22,15 +22,15 @@
 import Foundation
 import CoreStore
 
-public typealias WalkPause = PilgrimV2.WorkoutPause
+public typealias WalkPause = PilgrimV3.WorkoutPause
 
-public extension WalkPause {
-    
-    enum PauseType: RawRepresentable, ImportableAttributeType, Codable {
-        
+extension PilgrimV2.WorkoutPause {
+
+    public enum PauseType: RawRepresentable, ImportableAttributeType, Codable {
+
         case manual
         case automatic
-        
+
         public init(rawValue: Int) {
             switch rawValue {
             case 1:
@@ -39,7 +39,7 @@ public extension WalkPause {
                 self = .manual
             }
         }
-        
+
         public var rawValue: Int {
             switch self {
             case .manual:
@@ -49,7 +49,13 @@ public extension WalkPause {
             }
         }
     }
-    
+
+}
+
+public extension WalkPause {
+
+    typealias PauseType = PilgrimV2.WorkoutPause.PauseType
+
 }
 
 // MARK: - CustomStringConvertible

--- a/Pilgrim/Models/Data/Temp/Temp.swift
+++ b/Pilgrim/Models/Data/Temp/Temp.swift
@@ -162,7 +162,8 @@ extension TempVoiceRecording: VoiceRecordingInterface {
             endDate: object.endDate,
             duration: object.duration,
             fileRelativePath: object.fileRelativePath,
-            transcription: object.transcription
+            transcription: object.transcription,
+            wordsPerMinute: object.wordsPerMinute
         )
     }
 }

--- a/Pilgrim/Models/Data/Temp/Versions/TempV4.swift
+++ b/Pilgrim/Models/Data/Temp/Versions/TempV4.swift
@@ -184,14 +184,16 @@ public enum TempV4 {
         public var duration: Double
         public var fileRelativePath: String
         public var transcription: String?
+        public var wordsPerMinute: Double?
 
-        public init(uuid: UUID?, startDate: Date, endDate: Date, duration: Double, fileRelativePath: String, transcription: String? = nil) {
+        public init(uuid: UUID?, startDate: Date, endDate: Date, duration: Double, fileRelativePath: String, transcription: String? = nil, wordsPerMinute: Double? = nil) {
             self.uuid = uuid
             self.startDate = startDate
             self.endDate = endDate
             self.duration = duration
             self.fileRelativePath = fileRelativePath
             self.transcription = transcription
+            self.wordsPerMinute = wordsPerMinute
         }
 
         public var asTemp: TempVoiceRecording {

--- a/Pilgrim/Models/PromptGenerator.swift
+++ b/Pilgrim/Models/PromptGenerator.swift
@@ -348,6 +348,8 @@ struct PromptGenerator {
         }
     }
 
+    // MARK: - Prompt Builder
+
     private static func buildPrompt(preamble: String, instruction: String, transcription: String, meditations: String?, metadata: String, location: String?, pace: String?, recentWalks: String?) -> String {
         var sections = """
             \(preamble)
@@ -400,5 +402,16 @@ struct PromptGenerator {
             """
 
         return sections
+    }
+}
+
+extension String {
+    func truncatedAtWordBoundary(maxLength: Int = 200) -> String {
+        guard count > maxLength else { return self }
+        let truncated = prefix(maxLength)
+        if let lastSpace = truncated.lastIndex(of: " ") {
+            return String(truncated[..<lastSpace]) + "..."
+        }
+        return String(truncated) + "..."
     }
 }

--- a/Pilgrim/Models/PromptGenerator.swift
+++ b/Pilgrim/Models/PromptGenerator.swift
@@ -50,9 +50,9 @@ struct GeneratedPrompt: Identifiable {
     let customStyle: CustomPromptStyle?
     let text: String
 
-    var title: String { customStyle?.title ?? style!.title }
-    var icon: String { customStyle?.icon ?? style!.icon }
-    var subtitle: String { customStyle?.instruction ?? style!.description }
+    var title: String { customStyle?.title ?? style?.title ?? "" }
+    var icon: String { customStyle?.icon ?? style?.icon ?? "questionmark" }
+    var subtitle: String { customStyle?.instruction ?? style?.description ?? "" }
 }
 
 struct PromptGenerator {
@@ -71,7 +71,7 @@ struct PromptGenerator {
         let duration: TimeInterval
     }
 
-    enum PlaceRole { case start, end, midpoint }
+    enum PlaceRole { case start, end }
 
     struct PlaceContext {
         let name: String
@@ -291,8 +291,7 @@ struct PromptGenerator {
         let moving = speeds.filter { $0 >= 0.3 }
         guard moving.count >= 10 else { return nil }
         let avgSpeed = moving.reduce(0, +) / Double(moving.count)
-        let minSpeed = moving.min()!
-        let maxSpeed = moving.max()!
+        guard let minSpeed = moving.min(), let maxSpeed = moving.max() else { return nil }
         let avgPace = formatPace(metersPerSecond: avgSpeed)
         let slowPace = formatPace(metersPerSecond: minSpeed)
         let fastPace = formatPace(metersPerSecond: maxSpeed)

--- a/Pilgrim/Models/PromptGenerator.swift
+++ b/Pilgrim/Models/PromptGenerator.swift
@@ -79,6 +79,12 @@ struct PromptGenerator {
         let role: PlaceRole
     }
 
+    struct WalkSnippet {
+        let date: Date
+        let placeName: String?
+        let transcriptionPreview: String
+    }
+
     static func generate(
         style: PromptStyle,
         recordings: [RecordingContext],
@@ -87,20 +93,23 @@ struct PromptGenerator {
         distance: Double,
         startDate: Date,
         placeNames: [PlaceContext] = [],
-        routeSpeeds: [Double] = []
+        routeSpeeds: [Double] = [],
+        recentWalkSnippets: [WalkSnippet] = []
     ) -> GeneratedPrompt {
         let combinedText = formatRecordings(recordings)
         let meditationText = formatMeditations(meditations)
         let metadata = formatMetadata(duration: duration, distance: distance, startDate: startDate)
         let location = formatPlaceNames(placeNames)
         let pace = formatPaceContext(speeds: routeSpeeds)
+        let recentWalks = formatRecentWalks(recentWalkSnippets)
         let prompt = buildPrompt(
             style: style,
             transcription: combinedText,
             meditations: meditationText,
             metadata: metadata,
             location: location,
-            pace: pace
+            pace: pace,
+            recentWalks: recentWalks
         )
         return GeneratedPrompt(style: style, customStyle: nil, text: prompt)
     }
@@ -219,6 +228,24 @@ struct PromptGenerator {
         return String(format: "%d:%02d %@", minutes, seconds, label)
     }
 
+    private static let shortDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"
+        return f
+    }()
+
+    private static func formatRecentWalks(_ snippets: [WalkSnippet]) -> String? {
+        guard !snippets.isEmpty else { return nil }
+        let lines = snippets.map { snippet in
+            let dateStr = shortDateFormatter.string(from: snippet.date)
+            if let place = snippet.placeName {
+                return "[\(dateStr) – \(place)] \"\(snippet.transcriptionPreview)\""
+            }
+            return "[\(dateStr)] \"\(snippet.transcriptionPreview)\""
+        }
+        return "**Recent Walk Context (for continuity):**\n\n" + lines.joined(separator: "\n\n")
+    }
+
     private static func formatMetadata(duration: Double, distance: Double, startDate: Date) -> String {
         let durationMin = Int(duration / 60)
         let distanceStr = distanceFormatter.string(from: Measurement(value: distance, unit: UnitLength.meters))
@@ -239,7 +266,7 @@ struct PromptGenerator {
         }
     }
 
-    private static func buildPrompt(style: PromptStyle, transcription: String, meditations: String?, metadata: String, location: String?, pace: String?) -> String {
+    private static func buildPrompt(style: PromptStyle, transcription: String, meditations: String?, metadata: String, location: String?, pace: String?, recentWalks: String?) -> String {
         let preamble: String
         let instruction: String
 
@@ -312,6 +339,14 @@ struct PromptGenerator {
             **Meditation Sessions:**
 
             \(meditations)
+            """
+        }
+
+        if let recentWalks = recentWalks {
+            sections += """
+
+
+            \(recentWalks)
             """
         }
 

--- a/Pilgrim/Models/PromptGenerator.swift
+++ b/Pilgrim/Models/PromptGenerator.swift
@@ -71,18 +71,28 @@ struct PromptGenerator {
         let duration: TimeInterval
     }
 
+    enum PlaceRole { case start, end, midpoint }
+
+    struct PlaceContext {
+        let name: String
+        let coordinate: (lat: Double, lon: Double)
+        let role: PlaceRole
+    }
+
     static func generate(
         style: PromptStyle,
         recordings: [RecordingContext],
         meditations: [MeditationContext],
         duration: Double,
         distance: Double,
-        startDate: Date
+        startDate: Date,
+        placeNames: [PlaceContext] = []
     ) -> GeneratedPrompt {
         let combinedText = formatRecordings(recordings)
         let meditationText = formatMeditations(meditations)
         let metadata = formatMetadata(duration: duration, distance: distance, startDate: startDate)
-        let prompt = buildPrompt(style: style, transcription: combinedText, meditations: meditationText, metadata: metadata)
+        let location = formatPlaceNames(placeNames)
+        let prompt = buildPrompt(style: style, transcription: combinedText, meditations: meditationText, metadata: metadata, location: location)
         return GeneratedPrompt(style: style, customStyle: nil, text: prompt)
     }
 
@@ -135,6 +145,18 @@ struct PromptGenerator {
         }.joined(separator: "\n\n")
     }
 
+    private static func formatPlaceNames(_ places: [PlaceContext]) -> String? {
+        guard !places.isEmpty else { return nil }
+        let start = places.first { $0.role == .start }
+        let end = places.first { $0.role == .end }
+        if let start = start, let end = end {
+            return "**Location:** Started near \(start.name) → ended near \(end.name)"
+        } else if let start = start {
+            return "**Location:** Near \(start.name)"
+        }
+        return nil
+    }
+
     private static func speakingPaceLabel(_ wpm: Double) -> String {
         switch wpm {
         case ..<100: return "slow/thoughtful"
@@ -185,7 +207,7 @@ struct PromptGenerator {
         }
     }
 
-    private static func buildPrompt(style: PromptStyle, transcription: String, meditations: String?, metadata: String) -> String {
+    private static func buildPrompt(style: PromptStyle, transcription: String, meditations: String?, metadata: String, location: String?) -> String {
         let preamble: String
         let instruction: String
 
@@ -233,6 +255,14 @@ struct PromptGenerator {
             ---
 
             **Context:** \(metadata)
+            """
+
+        if let location = location {
+            sections += "\n\n\(location)"
+        }
+
+        sections += """
+
 
             **Walking Transcription:**
 

--- a/Pilgrim/Models/PromptGenerator.swift
+++ b/Pilgrim/Models/PromptGenerator.swift
@@ -102,8 +102,51 @@ struct PromptGenerator {
         let location = formatPlaceNames(placeNames)
         let pace = formatPaceContext(speeds: routeSpeeds)
         let recentWalks = formatRecentWalks(recentWalkSnippets)
+
+        let preamble: String
+        let instruction: String
+
+        switch style {
+        case .contemplative:
+            preamble = "During a walking meditation, these words arose naturally from the rhythm of movement and breath. They were not planned or curated — they emerged as the body moved through space."
+            instruction = """
+                Please receive these walking thoughts with gentleness. Help me sit with what emerged, without rushing to analyze or fix. What was my body and spirit trying to tell me through these words? What wants to be noticed, held, or simply acknowledged? Respond in a contemplative, unhurried tone.
+                """
+
+        case .reflective:
+            preamble = "These are voice recordings captured during a walk, transcribed as spoken. They represent unfiltered thoughts, observations, and feelings that surfaced while moving."
+            instruction = """
+                Please analyze these walking reflections for patterns, recurring themes, and emotional undercurrents. What connections do you see between the different moments? What might I be processing or working through? What contradictions or tensions are present? Offer observations that help me understand myself better.
+                """
+
+        case .creative:
+            preamble = "A walker spoke these words into the open air while moving through the world. They are raw material — fragments of observation, feeling, and thought gathered by a body in motion."
+            instruction = """
+                Transform these walking fragments into something creative. You might compose a poem, write a short prose piece, create a series of haiku, or craft a brief narrative. Let the rhythm of the walk inform the rhythm of the writing. Preserve the essence but elevate the expression.
+                """
+
+        case .gratitude:
+            preamble = "These words were spoken during a walk — a time of moving through the world with awareness. Somewhere in these observations and thoughts are seeds of gratitude, even if not explicitly stated."
+            instruction = """
+                Help me find the gratitude woven through these walking thoughts. What am I thankful for, even if I didn't say it directly? What blessings are hiding in my observations? What can I appreciate about this moment in my life, this body that walks, this world I moved through? Frame your response as a practice of thanksgiving.
+                """
+
+        case .philosophical:
+            preamble = "Walking has long been a companion to philosophical thought — from Aristotle's peripatetic school to Kierkegaard's daily constitutionals. These words emerged during such a walk, where movement and thought intertwined."
+            instruction = """
+                Engage with these walking thoughts philosophically. What deeper questions are being asked? What assumptions about life, meaning, or existence are being explored? Connect my observations to broader wisdom traditions, philosophical concepts, or universal human experiences. Help me think more deeply about what I was already beginning to think.
+                """
+
+        case .journaling:
+            preamble = "The following are raw, unedited voice recordings from a walk. They capture thoughts as they occurred — scattered, honest, and in the moment."
+            instruction = """
+                Help me turn these scattered walking thoughts into a coherent journal entry. Organize the themes, add transitions between ideas, and create a narrative flow while preserving my authentic voice. The result should read as a thoughtful, personal journal entry that I could return to and understand. Include a brief summary of the walk's key themes at the end.
+                """
+        }
+
         let prompt = buildPrompt(
-            style: style,
+            preamble: preamble,
+            instruction: instruction,
             transcription: combinedText,
             meditations: meditationText,
             metadata: metadata,
@@ -114,12 +157,48 @@ struct PromptGenerator {
         return GeneratedPrompt(style: style, customStyle: nil, text: prompt)
     }
 
+    static func generateCustom(
+        customStyle: CustomPromptStyle,
+        recordings: [RecordingContext],
+        meditations: [MeditationContext],
+        duration: Double,
+        distance: Double,
+        startDate: Date,
+        placeNames: [PlaceContext] = [],
+        routeSpeeds: [Double] = [],
+        recentWalkSnippets: [WalkSnippet] = []
+    ) -> GeneratedPrompt {
+        let combinedText = formatRecordings(recordings)
+        let meditationText = formatMeditations(meditations)
+        let metadata = formatMetadata(duration: duration, distance: distance, startDate: startDate)
+        let location = formatPlaceNames(placeNames)
+        let pace = formatPaceContext(speeds: routeSpeeds)
+        let recentWalks = formatRecentWalks(recentWalkSnippets)
+
+        let preamble = "These are voice recordings captured during a walk, transcribed as spoken. They represent unfiltered thoughts, observations, and feelings that surfaced while moving."
+
+        let prompt = buildPrompt(
+            preamble: preamble,
+            instruction: customStyle.instruction,
+            transcription: combinedText,
+            meditations: meditationText,
+            metadata: metadata,
+            location: location,
+            pace: pace,
+            recentWalks: recentWalks
+        )
+        return GeneratedPrompt(style: nil, customStyle: customStyle, text: prompt)
+    }
+
     static func generateAll(
         recordings: [RecordingContext],
         meditations: [MeditationContext],
         duration: Double,
         distance: Double,
-        startDate: Date
+        startDate: Date,
+        placeNames: [PlaceContext] = [],
+        routeSpeeds: [Double] = [],
+        recentWalkSnippets: [WalkSnippet] = []
     ) -> [GeneratedPrompt] {
         PromptStyle.allCases.map { style in
             generate(
@@ -128,7 +207,10 @@ struct PromptGenerator {
                 meditations: meditations,
                 duration: duration,
                 distance: distance,
-                startDate: startDate
+                startDate: startDate,
+                placeNames: placeNames,
+                routeSpeeds: routeSpeeds,
+                recentWalkSnippets: recentWalkSnippets
             )
         }
     }
@@ -266,48 +348,7 @@ struct PromptGenerator {
         }
     }
 
-    private static func buildPrompt(style: PromptStyle, transcription: String, meditations: String?, metadata: String, location: String?, pace: String?, recentWalks: String?) -> String {
-        let preamble: String
-        let instruction: String
-
-        switch style {
-        case .contemplative:
-            preamble = "During a walking meditation, these words arose naturally from the rhythm of movement and breath. They were not planned or curated — they emerged as the body moved through space."
-            instruction = """
-                Please receive these walking thoughts with gentleness. Help me sit with what emerged, without rushing to analyze or fix. What was my body and spirit trying to tell me through these words? What wants to be noticed, held, or simply acknowledged? Respond in a contemplative, unhurried tone.
-                """
-
-        case .reflective:
-            preamble = "These are voice recordings captured during a walk, transcribed as spoken. They represent unfiltered thoughts, observations, and feelings that surfaced while moving."
-            instruction = """
-                Please analyze these walking reflections for patterns, recurring themes, and emotional undercurrents. What connections do you see between the different moments? What might I be processing or working through? What contradictions or tensions are present? Offer observations that help me understand myself better.
-                """
-
-        case .creative:
-            preamble = "A walker spoke these words into the open air while moving through the world. They are raw material — fragments of observation, feeling, and thought gathered by a body in motion."
-            instruction = """
-                Transform these walking fragments into something creative. You might compose a poem, write a short prose piece, create a series of haiku, or craft a brief narrative. Let the rhythm of the walk inform the rhythm of the writing. Preserve the essence but elevate the expression.
-                """
-
-        case .gratitude:
-            preamble = "These words were spoken during a walk — a time of moving through the world with awareness. Somewhere in these observations and thoughts are seeds of gratitude, even if not explicitly stated."
-            instruction = """
-                Help me find the gratitude woven through these walking thoughts. What am I thankful for, even if I didn't say it directly? What blessings are hiding in my observations? What can I appreciate about this moment in my life, this body that walks, this world I moved through? Frame your response as a practice of thanksgiving.
-                """
-
-        case .philosophical:
-            preamble = "Walking has long been a companion to philosophical thought — from Aristotle's peripatetic school to Kierkegaard's daily constitutionals. These words emerged during such a walk, where movement and thought intertwined."
-            instruction = """
-                Engage with these walking thoughts philosophically. What deeper questions are being asked? What assumptions about life, meaning, or existence are being explored? Connect my observations to broader wisdom traditions, philosophical concepts, or universal human experiences. Help me think more deeply about what I was already beginning to think.
-                """
-
-        case .journaling:
-            preamble = "The following are raw, unedited voice recordings from a walk. They capture thoughts as they occurred — scattered, honest, and in the moment."
-            instruction = """
-                Help me turn these scattered walking thoughts into a coherent journal entry. Organize the themes, add transitions between ideas, and create a narrative flow while preserving my authentic voice. The result should read as a thoughtful, personal journal entry that I could return to and understand. Include a brief summary of the walk's key themes at the end.
-                """
-        }
-
+    private static func buildPrompt(preamble: String, instruction: String, transcription: String, meditations: String?, metadata: String, location: String?, pace: String?, recentWalks: String?) -> String {
         var sections = """
             \(preamble)
 

--- a/Pilgrim/Models/PromptGenerator.swift
+++ b/Pilgrim/Models/PromptGenerator.swift
@@ -24,7 +24,7 @@ enum PromptStyle: String, CaseIterable, Identifiable {
     var icon: String {
         switch self {
         case .contemplative: return "leaf.fill"
-        case .reflective: return "mirror.fill"
+        case .reflective: return "eye.fill"
         case .creative: return "paintbrush.fill"
         case .gratitude: return "heart.fill"
         case .philosophical: return "books.vertical.fill"
@@ -46,8 +46,13 @@ enum PromptStyle: String, CaseIterable, Identifiable {
 
 struct GeneratedPrompt: Identifiable {
     let id = UUID()
-    let style: PromptStyle
+    let style: PromptStyle?
+    let customStyle: CustomPromptStyle?
     let text: String
+
+    var title: String { customStyle?.title ?? style!.title }
+    var icon: String { customStyle?.icon ?? style!.icon }
+    var subtitle: String { customStyle?.instruction ?? style!.description }
 }
 
 struct PromptGenerator {
@@ -59,21 +64,30 @@ struct PromptGenerator {
         let endCoordinate: (lat: Double, lon: Double)?
     }
 
+    struct MeditationContext {
+        let startDate: Date
+        let endDate: Date
+        let duration: TimeInterval
+    }
+
     static func generate(
         style: PromptStyle,
         recordings: [RecordingContext],
+        meditations: [MeditationContext],
         duration: Double,
         distance: Double,
         startDate: Date
     ) -> GeneratedPrompt {
         let combinedText = formatRecordings(recordings)
+        let meditationText = formatMeditations(meditations)
         let metadata = formatMetadata(duration: duration, distance: distance, startDate: startDate)
-        let prompt = buildPrompt(style: style, transcription: combinedText, metadata: metadata)
-        return GeneratedPrompt(style: style, text: prompt)
+        let prompt = buildPrompt(style: style, transcription: combinedText, meditations: meditationText, metadata: metadata)
+        return GeneratedPrompt(style: style, customStyle: nil, text: prompt)
     }
 
     static func generateAll(
         recordings: [RecordingContext],
+        meditations: [MeditationContext],
         duration: Double,
         distance: Double,
         startDate: Date
@@ -82,6 +96,7 @@ struct PromptGenerator {
             generate(
                 style: style,
                 recordings: recordings,
+                meditations: meditations,
                 duration: duration,
                 distance: distance,
                 startDate: startDate
@@ -127,6 +142,16 @@ struct PromptGenerator {
         return f
     }()
 
+    private static func formatMeditations(_ meditations: [MeditationContext]) -> String? {
+        guard !meditations.isEmpty else { return nil }
+        let lines = meditations.map { m in
+            let durationSec = Int(m.duration)
+            let durationStr = durationSec < 60 ? "\(durationSec) sec" : "\(durationSec / 60) min \(durationSec % 60) sec"
+            return "[\(timeFormatter.string(from: m.startDate)) – \(timeFormatter.string(from: m.endDate))] Meditated for \(durationStr)"
+        }
+        return lines.joined(separator: "\n")
+    }
+
     private static func formatMetadata(duration: Double, distance: Double, startDate: Date) -> String {
         let durationMin = Int(duration / 60)
         let distanceStr = distanceFormatter.string(from: Measurement(value: distance, unit: UnitLength.meters))
@@ -147,7 +172,7 @@ struct PromptGenerator {
         }
     }
 
-    private static func buildPrompt(style: PromptStyle, transcription: String, metadata: String) -> String {
+    private static func buildPrompt(style: PromptStyle, transcription: String, meditations: String?, metadata: String) -> String {
         let preamble: String
         let instruction: String
 
@@ -189,7 +214,7 @@ struct PromptGenerator {
                 """
         }
 
-        return """
+        var sections = """
             \(preamble)
 
             ---
@@ -199,10 +224,26 @@ struct PromptGenerator {
             **Walking Transcription:**
 
             \(transcription)
+            """
+
+        if let meditations = meditations {
+            sections += """
+
+
+            **Meditation Sessions:**
+
+            \(meditations)
+            """
+        }
+
+        sections += """
+
 
             ---
 
             \(instruction)
             """
+
+        return sections
     }
 }

--- a/Pilgrim/Models/PromptGenerator.swift
+++ b/Pilgrim/Models/PromptGenerator.swift
@@ -62,6 +62,7 @@ struct PromptGenerator {
         let timestamp: Date
         let startCoordinate: (lat: Double, lon: Double)?
         let endCoordinate: (lat: Double, lon: Double)?
+        let wordsPerMinute: Double?
     }
 
     struct MeditationContext {
@@ -127,8 +128,20 @@ struct PromptGenerator {
                 }
                 header += "]"
             }
+            if let wpm = item.wordsPerMinute {
+                header += " [~\(Int(wpm)) wpm, \(speakingPaceLabel(wpm))]"
+            }
             return "\(header) \(item.text)"
         }.joined(separator: "\n\n")
+    }
+
+    private static func speakingPaceLabel(_ wpm: Double) -> String {
+        switch wpm {
+        case ..<100: return "slow/thoughtful"
+        case 100..<140: return "measured"
+        case 140..<170: return "conversational"
+        default: return "rapid/energized"
+        }
     }
 
     private static func formatCoord(_ lat: Double, _ lon: Double) -> String {

--- a/Pilgrim/Models/PromptGenerator.swift
+++ b/Pilgrim/Models/PromptGenerator.swift
@@ -86,13 +86,22 @@ struct PromptGenerator {
         duration: Double,
         distance: Double,
         startDate: Date,
-        placeNames: [PlaceContext] = []
+        placeNames: [PlaceContext] = [],
+        routeSpeeds: [Double] = []
     ) -> GeneratedPrompt {
         let combinedText = formatRecordings(recordings)
         let meditationText = formatMeditations(meditations)
         let metadata = formatMetadata(duration: duration, distance: distance, startDate: startDate)
         let location = formatPlaceNames(placeNames)
-        let prompt = buildPrompt(style: style, transcription: combinedText, meditations: meditationText, metadata: metadata, location: location)
+        let pace = formatPaceContext(speeds: routeSpeeds)
+        let prompt = buildPrompt(
+            style: style,
+            transcription: combinedText,
+            meditations: meditationText,
+            metadata: metadata,
+            location: location,
+            pace: pace
+        )
         return GeneratedPrompt(style: style, customStyle: nil, text: prompt)
     }
 
@@ -187,6 +196,29 @@ struct PromptGenerator {
         return lines.joined(separator: "\n")
     }
 
+    private static func formatPaceContext(speeds: [Double]) -> String? {
+        let moving = speeds.filter { $0 >= 0.3 }
+        guard moving.count >= 10 else { return nil }
+        let avgSpeed = moving.reduce(0, +) / Double(moving.count)
+        let minSpeed = moving.min()!
+        let maxSpeed = moving.max()!
+        let avgPace = formatPace(metersPerSecond: avgSpeed)
+        let slowPace = formatPace(metersPerSecond: minSpeed)
+        let fastPace = formatPace(metersPerSecond: maxSpeed)
+        return "**Pace:** Average \(avgPace) (range: \(fastPace)–\(slowPace))"
+    }
+
+    private static func formatPace(metersPerSecond: Double) -> String {
+        guard metersPerSecond > 0 else { return "—" }
+        let usesMiles = Locale.current.measurementSystem == .us
+        let metersPerUnit: Double = usesMiles ? 1609.34 : 1000.0
+        let label = usesMiles ? "min/mi" : "min/km"
+        let secondsPerUnit = metersPerUnit / metersPerSecond
+        let minutes = Int(secondsPerUnit) / 60
+        let seconds = Int(secondsPerUnit) % 60
+        return String(format: "%d:%02d %@", minutes, seconds, label)
+    }
+
     private static func formatMetadata(duration: Double, distance: Double, startDate: Date) -> String {
         let durationMin = Int(duration / 60)
         let distanceStr = distanceFormatter.string(from: Measurement(value: distance, unit: UnitLength.meters))
@@ -207,7 +239,7 @@ struct PromptGenerator {
         }
     }
 
-    private static func buildPrompt(style: PromptStyle, transcription: String, meditations: String?, metadata: String, location: String?) -> String {
+    private static func buildPrompt(style: PromptStyle, transcription: String, meditations: String?, metadata: String, location: String?, pace: String?) -> String {
         let preamble: String
         let instruction: String
 
@@ -259,6 +291,10 @@ struct PromptGenerator {
 
         if let location = location {
             sections += "\n\n\(location)"
+        }
+
+        if let pace = pace {
+            sections += "\n\n\(pace)"
         }
 
         sections += """

--- a/Pilgrim/Models/TranscriptionService.swift
+++ b/Pilgrim/Models/TranscriptionService.swift
@@ -134,6 +134,9 @@ final class TranscriptionService: ObservableObject {
                 if !text.isEmpty {
                     results[uuid] = text
                     DataManager.updateVoiceRecordingTranscription(uuid: uuid, transcription: text)
+                    if let wpm = computeWordsPerMinute(from: transcriptionResults) {
+                        DataManager.updateVoiceRecordingWordsPerMinute(uuid: uuid, wordsPerMinute: wpm)
+                    }
                 }
             } catch {
                 print("[TranscriptionService] Failed to transcribe recording \(uuid): \(error)")
@@ -182,6 +185,9 @@ final class TranscriptionService: ObservableObject {
             await MainActor.run { state = .completed; isTranscribing = false }
             if !text.isEmpty {
                 DataManager.updateVoiceRecordingTranscription(uuid: uuid, transcription: text)
+                if let wpm = computeWordsPerMinute(from: results) {
+                    DataManager.updateVoiceRecordingWordsPerMinute(uuid: uuid, wordsPerMinute: wpm)
+                }
                 return text
             }
             return nil
@@ -190,6 +196,23 @@ final class TranscriptionService: ObservableObject {
             await MainActor.run { state = .failed("Transcription failed"); isTranscribing = false }
             return nil
         }
+    }
+
+    private func computeWordsPerMinute(from results: [TranscriptionResult]) -> Double? {
+        let segments = results.flatMap { $0.segments }
+        guard let first = segments.first, let last = segments.last,
+              last.end > first.start else { return nil }
+        let words = segments.flatMap { $0.words }
+        let wordCount: Int
+        if !words.isEmpty {
+            wordCount = words.count
+        } else {
+            wordCount = segments.flatMap { $0.text.split(separator: " ") }.count
+        }
+        guard wordCount > 0 else { return nil }
+        let durationMinutes = Double(last.end - first.start) / 60.0
+        guard durationMinutes > 0 else { return nil }
+        return Double(wordCount) / durationMinutes
     }
 
     @MainActor

--- a/Pilgrim/Protocols/DataInterfaces/VoiceRecordingInterface.swift
+++ b/Pilgrim/Protocols/DataInterfaces/VoiceRecordingInterface.swift
@@ -7,6 +7,7 @@ public protocol VoiceRecordingInterface: DataInterface {
     var duration: Double { get }
     var fileRelativePath: String { get }
     var transcription: String? { get }
+    var wordsPerMinute: Double? { get }
 
 }
 
@@ -17,5 +18,6 @@ public extension VoiceRecordingInterface {
     var duration: Double { throwOnAccess() }
     var fileRelativePath: String { throwOnAccess() }
     var transcription: String? { throwOnAccess() }
+    var wordsPerMinute: Double? { throwOnAccess() }
 
 }

--- a/Pilgrim/Scenes/Prompts/CustomPromptEditorView.swift
+++ b/Pilgrim/Scenes/Prompts/CustomPromptEditorView.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+
+struct CustomPromptEditorView: View {
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var store: CustomPromptStyleStore
+
+    var editingStyle: CustomPromptStyle?
+
+    @State private var title: String = ""
+    @State private var selectedIcon: String = "pencil.line"
+    @State private var instruction: String = ""
+
+    private let iconOptions = [
+        "pencil.line", "text.quote", "envelope.fill", "lightbulb.fill",
+        "flame.fill", "leaf.fill", "wind", "drop.fill",
+        "sun.max.fill", "moon.fill", "star.fill", "sparkles",
+        "figure.walk", "mountain.2.fill", "water.waves", "bird.fill",
+        "hands.clap.fill", "brain.head.profile", "book.fill", "music.note"
+    ]
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: Constants.UI.Padding.big) {
+                    titleSection
+                    iconSection
+                    instructionSection
+                }
+                .padding(Constants.UI.Padding.normal)
+            }
+            .background(Color.parchment)
+            .navigationTitle(editingStyle == nil ? "New Prompt Style" : "Edit Prompt Style")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundColor(.stone)
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Save") { saveAndDismiss() }
+                        .foregroundColor(.stone)
+                        .disabled(title.trimmingCharacters(in: .whitespaces).isEmpty ||
+                                  instruction.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+            }
+        }
+        .onAppear {
+            if let editing = editingStyle {
+                title = editing.title
+                selectedIcon = editing.icon
+                instruction = editing.instruction
+            }
+        }
+    }
+
+    private var titleSection: some View {
+        VStack(alignment: .leading, spacing: Constants.UI.Padding.small) {
+            Text("Title")
+                .font(Constants.Typography.heading)
+                .foregroundColor(.ink)
+            TextField("e.g., Letter to Future Self", text: $title)
+                .font(Constants.Typography.body)
+                .textFieldStyle(.roundedBorder)
+        }
+    }
+
+    private var iconSection: some View {
+        VStack(alignment: .leading, spacing: Constants.UI.Padding.small) {
+            Text("Icon")
+                .font(Constants.Typography.heading)
+                .foregroundColor(.ink)
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 5), spacing: 12) {
+                ForEach(iconOptions, id: \.self) { icon in
+                    Button {
+                        selectedIcon = icon
+                    } label: {
+                        Image(systemName: icon)
+                            .font(.title3)
+                            .frame(width: 44, height: 44)
+                            .foregroundColor(selectedIcon == icon ? .parchment : .stone)
+                            .background(selectedIcon == icon ? Color.stone : Color.parchmentSecondary)
+                            .cornerRadius(Constants.UI.CornerRadius.small)
+                    }
+                }
+            }
+        }
+    }
+
+    private var instructionSection: some View {
+        VStack(alignment: .leading, spacing: Constants.UI.Padding.small) {
+            Text("Instruction")
+                .font(Constants.Typography.heading)
+                .foregroundColor(.ink)
+            TextEditor(text: $instruction)
+                .font(Constants.Typography.body)
+                .frame(minHeight: 120)
+                .scrollContentBackground(.hidden)
+                .padding(Constants.UI.Padding.small)
+                .background(Color.parchmentSecondary)
+                .cornerRadius(Constants.UI.CornerRadius.small)
+                .overlay(
+                    Group {
+                        if instruction.isEmpty {
+                            Text("Tell the AI what to do with your walking thoughts...")
+                                .font(Constants.Typography.body)
+                                .foregroundColor(.fog)
+                                .padding(Constants.UI.Padding.small + 4)
+                        }
+                    },
+                    alignment: .topLeading
+                )
+
+            Text("\(store.styles.count + (editingStyle == nil ? 1 : 0)) of \(CustomPromptStyleStore.maxStyles)")
+                .font(Constants.Typography.caption)
+                .foregroundColor(.fog)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+        }
+    }
+
+    private func saveAndDismiss() {
+        let style = CustomPromptStyle(
+            id: editingStyle?.id ?? UUID(),
+            title: title.trimmingCharacters(in: .whitespaces),
+            icon: selectedIcon,
+            instruction: instruction.trimmingCharacters(in: .whitespaces)
+        )
+        store.save(style)
+        dismiss()
+    }
+}

--- a/Pilgrim/Scenes/Prompts/PromptDetailView.swift
+++ b/Pilgrim/Scenes/Prompts/PromptDetailView.swift
@@ -7,6 +7,7 @@ struct PromptDetailView: View {
     @State private var showCopiedFeedback = false
     @State private var showShareSheet = false
     @State private var copyScale: CGFloat = 1.0
+    @State private var showAIPills = false
 
     var body: some View {
         NavigationView {
@@ -45,42 +46,83 @@ struct PromptDetailView: View {
     }
 
     private var actionButtons: some View {
-        HStack(spacing: Constants.UI.Padding.normal) {
-            Button {
-                UIPasteboard.general.string = prompt.text
-                withAnimation(.easeOut(duration: 0.15)) { copyScale = 0.95 }
-                withAnimation(.easeOut(duration: 0.15).delay(0.15)) { copyScale = 1.0 }
-                showCopiedFeedback = true
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                    showCopiedFeedback = false
-                }
-            } label: {
-                Label(
-                    showCopiedFeedback ? "Copied!" : "Copy",
-                    systemImage: showCopiedFeedback ? "checkmark" : "doc.on.doc"
-                )
-                .font(Constants.Typography.button)
-                .foregroundColor(.parchment)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 12)
-                .background(Color.stone)
-                .cornerRadius(Constants.UI.CornerRadius.normal)
-            }
-            .scaleEffect(copyScale)
-
-            Button {
-                showShareSheet = true
-            } label: {
-                Label("Share", systemImage: "square.and.arrow.up")
+        VStack(spacing: Constants.UI.Padding.small) {
+            HStack(spacing: Constants.UI.Padding.normal) {
+                Button {
+                    UIPasteboard.general.string = prompt.text
+                    withAnimation(.easeOut(duration: 0.15)) { copyScale = 0.95 }
+                    withAnimation(.easeOut(duration: 0.15).delay(0.15)) { copyScale = 1.0 }
+                    showCopiedFeedback = true
+                    withAnimation(.easeOut(duration: 0.3)) { showAIPills = true }
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 8) {
+                        withAnimation {
+                            showCopiedFeedback = false
+                            showAIPills = false
+                        }
+                    }
+                } label: {
+                    Label(
+                        showCopiedFeedback ? "Copied!" : "Copy",
+                        systemImage: showCopiedFeedback ? "checkmark" : "doc.on.doc"
+                    )
                     .font(Constants.Typography.button)
-                    .foregroundColor(.stone)
+                    .foregroundColor(.parchment)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 12)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: Constants.UI.CornerRadius.normal)
-                            .stroke(Color.stone, lineWidth: 1.5)
-                    )
+                    .background(Color.stone)
+                    .cornerRadius(Constants.UI.CornerRadius.normal)
+                }
+                .scaleEffect(copyScale)
+
+                Button {
+                    showShareSheet = true
+                } label: {
+                    Label("Share", systemImage: "square.and.arrow.up")
+                        .font(Constants.Typography.button)
+                        .foregroundColor(.stone)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: Constants.UI.CornerRadius.normal)
+                                .stroke(Color.stone, lineWidth: 1.5)
+                        )
+                }
             }
+
+            if showAIPills {
+                VStack(spacing: Constants.UI.Padding.small) {
+                    Text("Paste in your favorite AI")
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.fog)
+
+                    HStack(spacing: Constants.UI.Padding.small) {
+                        aiPill(name: "ChatGPT", url: "https://chat.openai.com/")
+                        aiPill(name: "Claude", url: "https://claude.ai/new")
+                    }
+                }
+                .transition(.move(edge: .bottom).combined(with: .opacity))
+            }
+        }
+    }
+
+    private func aiPill(name: String, url: String) -> some View {
+        Button {
+            if let url = URL(string: url) {
+                UIApplication.shared.open(url)
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Text(name)
+                    .font(Constants.Typography.caption)
+                    .fontWeight(.semibold)
+                Image(systemName: "arrow.up.right")
+                    .font(.caption2)
+            }
+            .foregroundColor(.stone)
+            .padding(.horizontal, Constants.UI.Padding.normal)
+            .padding(.vertical, Constants.UI.Padding.small)
+            .background(Color.parchmentSecondary)
+            .clipShape(Capsule())
         }
     }
 }

--- a/Pilgrim/Scenes/Prompts/PromptDetailView.swift
+++ b/Pilgrim/Scenes/Prompts/PromptDetailView.swift
@@ -8,6 +8,7 @@ struct PromptDetailView: View {
     @State private var showShareSheet = false
     @State private var copyScale: CGFloat = 1.0
     @State private var showAIPills = false
+    @State private var copyResetWorkItem: DispatchWorkItem?
 
     var body: some View {
         NavigationView {
@@ -54,12 +55,15 @@ struct PromptDetailView: View {
                     withAnimation(.easeOut(duration: 0.15).delay(0.15)) { copyScale = 1.0 }
                     showCopiedFeedback = true
                     withAnimation(.easeOut(duration: 0.3)) { showAIPills = true }
-                    DispatchQueue.main.asyncAfter(deadline: .now() + 8) {
+                    copyResetWorkItem?.cancel()
+                    let workItem = DispatchWorkItem {
                         withAnimation {
                             showCopiedFeedback = false
                             showAIPills = false
                         }
                     }
+                    copyResetWorkItem = workItem
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 8, execute: workItem)
                 } label: {
                     Label(
                         showCopiedFeedback ? "Copied!" : "Copy",

--- a/Pilgrim/Scenes/Prompts/PromptDetailView.swift
+++ b/Pilgrim/Scenes/Prompts/PromptDetailView.swift
@@ -13,10 +13,10 @@ struct PromptDetailView: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: Constants.UI.Padding.big) {
                     HStack {
-                        Image(systemName: prompt.style.icon)
+                        Image(systemName: prompt.icon)
                             .font(.title2)
                             .foregroundColor(.stone)
-                        Text(prompt.style.title)
+                        Text(prompt.title)
                             .font(Constants.Typography.displayMedium)
                             .foregroundColor(.ink)
                     }

--- a/Pilgrim/Scenes/Prompts/PromptListView.swift
+++ b/Pilgrim/Scenes/Prompts/PromptListView.swift
@@ -32,10 +32,23 @@ struct PromptListView: View {
                             PromptStyleRow(prompt: prompt)
                         }
                         .listRowBackground(Color.parchment)
+                        .swipeActions(edge: .leading) {
+                            if let customStyle = prompt.customStyle {
+                                Button {
+                                    editingStyle = customStyle
+                                    showEditor = true
+                                } label: {
+                                    Label("Edit", systemImage: "pencil")
+                                }
+                                .tint(.stone)
+                            }
+                        }
                     }
                     .onDelete { offsets in
                         for index in offsets {
-                            customStyleStore.delete(customStyleStore.styles[index])
+                            if let customStyle = customPrompts[index].customStyle {
+                                customStyleStore.delete(customStyle)
+                            }
                         }
                         regenerateCustomPrompts()
                     }
@@ -143,14 +156,6 @@ struct PromptListView: View {
             .distance(from: CLLocation(latitude: last.latitude, longitude: last.longitude))
         if distance > 500, let name = await reverseGeocode(geocoder: geocoder, lat: last.latitude, lon: last.longitude) {
             places.append(PromptGenerator.PlaceContext(name: name, coordinate: (lat: last.latitude, lon: last.longitude), role: .end))
-        }
-
-        if walk.distance > 2000 {
-            let midIndex = samples.count / 2
-            let mid = samples[midIndex]
-            if let name = await reverseGeocode(geocoder: geocoder, lat: mid.latitude, lon: mid.longitude) {
-                places.append(PromptGenerator.PlaceContext(name: name, coordinate: (lat: mid.latitude, lon: mid.longitude), role: .midpoint))
-            }
         }
 
         return places

--- a/Pilgrim/Scenes/Prompts/PromptListView.swift
+++ b/Pilgrim/Scenes/Prompts/PromptListView.swift
@@ -40,7 +40,8 @@ struct PromptListView: View {
                 text: text,
                 timestamp: recording.startDate,
                 startCoordinate: startCoord,
-                endCoordinate: endCoord
+                endCoordinate: endCoord,
+                wordsPerMinute: recording.wordsPerMinute
             )
         }.sorted { $0.timestamp < $1.timestamp }
 

--- a/Pilgrim/Scenes/Prompts/PromptListView.swift
+++ b/Pilgrim/Scenes/Prompts/PromptListView.swift
@@ -44,8 +44,18 @@ struct PromptListView: View {
             )
         }.sorted { $0.timestamp < $1.timestamp }
 
+        let meditations = walk.activityIntervals
+            .filter { $0.activityType == .meditation }
+            .sorted { $0.startDate < $1.startDate }
+            .map { PromptGenerator.MeditationContext(
+                startDate: $0.startDate,
+                endDate: $0.endDate,
+                duration: $0.duration
+            )}
+
         prompts = PromptGenerator.generateAll(
             recordings: recordings,
+            meditations: meditations,
             duration: walk.activeDuration,
             distance: walk.distance,
             startDate: walk.startDate
@@ -65,16 +75,16 @@ struct PromptStyleRow: View {
 
     var body: some View {
         HStack(spacing: 12) {
-            Image(systemName: prompt.style.icon)
+            Image(systemName: prompt.icon)
                 .font(.title2)
                 .foregroundColor(.stone)
                 .frame(width: 40)
 
             VStack(alignment: .leading, spacing: 4) {
-                Text(prompt.style.title)
+                Text(prompt.title)
                     .font(Constants.Typography.heading)
                     .foregroundColor(.ink)
-                Text(prompt.style.description)
+                Text(prompt.subtitle)
                     .font(Constants.Typography.caption)
                     .foregroundColor(.fog)
                     .lineLimit(2)

--- a/Pilgrim/Scenes/Prompts/PromptListView.swift
+++ b/Pilgrim/Scenes/Prompts/PromptListView.swift
@@ -1,21 +1,50 @@
 import SwiftUI
+import CoreLocation
 
 struct PromptListView: View {
 
     let walk: WalkInterface
     let transcriptions: [UUID: String]
+    let recentWalkSnippets: [PromptGenerator.WalkSnippet]
     @State private var selectedPrompt: GeneratedPrompt?
     @State private var prompts: [GeneratedPrompt] = []
+    @StateObject private var customStyleStore = CustomPromptStyleStore()
+    @State private var showEditor = false
+    @State private var editingStyle: CustomPromptStyle?
+    @State private var geocodedPlaces: [PromptGenerator.PlaceContext] = []
+    @State private var customPrompts: [GeneratedPrompt] = []
 
     var body: some View {
         List {
-            ForEach(prompts) { prompt in
-                Button {
-                    selectedPrompt = prompt
-                } label: {
-                    PromptStyleRow(prompt: prompt)
+            Section {
+                ForEach(prompts) { prompt in
+                    Button { selectedPrompt = prompt } label: {
+                        PromptStyleRow(prompt: prompt)
+                    }
+                    .listRowBackground(Color.parchment)
                 }
-                .listRowBackground(Color.parchment)
+            }
+
+            if !customStyleStore.styles.isEmpty {
+                Section {
+                    ForEach(customPrompts) { prompt in
+                        Button { selectedPrompt = prompt } label: {
+                            PromptStyleRow(prompt: prompt)
+                        }
+                        .listRowBackground(Color.parchment)
+                    }
+                    .onDelete { offsets in
+                        for index in offsets {
+                            customStyleStore.delete(customStyleStore.styles[index])
+                        }
+                        regenerateCustomPrompts()
+                    }
+                }
+            }
+
+            Section {
+                createYourOwnRow
+                    .listRowBackground(Color.parchment)
             }
         }
         .listStyle(.plain)
@@ -25,42 +54,154 @@ struct PromptListView: View {
         .sheet(item: $selectedPrompt) { prompt in
             PromptDetailView(prompt: prompt)
         }
+        .sheet(isPresented: $showEditor) {
+            CustomPromptEditorView(store: customStyleStore, editingStyle: editingStyle)
+        }
+        .onChange(of: showEditor) { showing in
+            if !showing { regenerateCustomPrompts() }
+        }
         .onAppear { generatePrompts() }
+    }
+
+    private var createYourOwnRow: some View {
+        Button {
+            guard customStyleStore.canAddMore else { return }
+            editingStyle = nil
+            showEditor = true
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: "plus.circle.fill")
+                    .font(.title2)
+                    .foregroundColor(customStyleStore.canAddMore ? .stone : .fog)
+                    .frame(width: 40)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Create Your Own")
+                        .font(Constants.Typography.heading)
+                        .foregroundColor(customStyleStore.canAddMore ? .ink : .fog)
+                    Text("\(customStyleStore.styles.count) of \(CustomPromptStyleStore.maxStyles) custom styles")
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.fog)
+                }
+                Spacer()
+            }
+            .padding(.vertical, Constants.UI.Padding.small)
+        }
+        .disabled(!customStyleStore.canAddMore)
     }
 
     private func generatePrompts() {
         guard prompts.isEmpty else { return }
+        Task {
+            let routeSamples = walk.routeData
+            let placeNames = await geocodeWalkRoute(routeSamples)
+            geocodedPlaces = placeNames
+            let routeSpeeds = routeSamples.map { $0.speed }
+
+            let recordings = walk.voiceRecordings.compactMap { recording -> PromptGenerator.RecordingContext? in
+                guard let uuid = recording.uuid,
+                      let text = transcriptions[uuid] else { return nil }
+                let startCoord = closestCoordinate(to: recording.startDate, in: routeSamples)
+                let endCoord = closestCoordinate(to: recording.endDate, in: routeSamples)
+                return PromptGenerator.RecordingContext(
+                    text: text,
+                    timestamp: recording.startDate,
+                    startCoordinate: startCoord,
+                    endCoordinate: endCoord,
+                    wordsPerMinute: recording.wordsPerMinute
+                )
+            }.sorted { $0.timestamp < $1.timestamp }
+
+            let meditations = walk.activityIntervals
+                .filter { $0.activityType == .meditation }
+                .sorted { $0.startDate < $1.startDate }
+                .map { PromptGenerator.MeditationContext(startDate: $0.startDate, endDate: $0.endDate, duration: $0.duration) }
+
+            prompts = PromptGenerator.generateAll(
+                recordings: recordings,
+                meditations: meditations,
+                duration: walk.activeDuration,
+                distance: walk.distance,
+                startDate: walk.startDate,
+                placeNames: placeNames,
+                routeSpeeds: routeSpeeds,
+                recentWalkSnippets: recentWalkSnippets
+            )
+            regenerateCustomPrompts()
+        }
+    }
+
+    private func geocodeWalkRoute(_ samples: [RouteDataSampleInterface]) async -> [PromptGenerator.PlaceContext] {
+        guard let first = samples.first, let last = samples.last else { return [] }
+        let geocoder = CLGeocoder()
+        var places: [PromptGenerator.PlaceContext] = []
+
+        if let name = await reverseGeocode(geocoder: geocoder, lat: first.latitude, lon: first.longitude, delay: false) {
+            places.append(PromptGenerator.PlaceContext(name: name, coordinate: (lat: first.latitude, lon: first.longitude), role: .start))
+        }
+
+        let distance = CLLocation(latitude: first.latitude, longitude: first.longitude)
+            .distance(from: CLLocation(latitude: last.latitude, longitude: last.longitude))
+        if distance > 500, let name = await reverseGeocode(geocoder: geocoder, lat: last.latitude, lon: last.longitude) {
+            places.append(PromptGenerator.PlaceContext(name: name, coordinate: (lat: last.latitude, lon: last.longitude), role: .end))
+        }
+
+        if walk.distance > 2000 {
+            let midIndex = samples.count / 2
+            let mid = samples[midIndex]
+            if let name = await reverseGeocode(geocoder: geocoder, lat: mid.latitude, lon: mid.longitude) {
+                places.append(PromptGenerator.PlaceContext(name: name, coordinate: (lat: mid.latitude, lon: mid.longitude), role: .midpoint))
+            }
+        }
+
+        return places
+    }
+
+    private func reverseGeocode(geocoder: CLGeocoder, lat: Double, lon: Double, delay: Bool = true) async -> String? {
+        do {
+            if delay {
+                try await Task.sleep(nanoseconds: 1_100_000_000)
+            }
+            let placemarks = try await geocoder.reverseGeocodeLocation(CLLocation(latitude: lat, longitude: lon))
+            guard let pm = placemarks.first else { return nil }
+            let parts = [pm.name, pm.locality].compactMap { $0 }
+            return parts.isEmpty ? nil : parts.joined(separator: ", ")
+        } catch {
+            return nil
+        }
+    }
+
+    private func regenerateCustomPrompts() {
         let routeSamples = walk.routeData
+        let routeSpeeds = routeSamples.map { $0.speed }
         let recordings = walk.voiceRecordings.compactMap { recording -> PromptGenerator.RecordingContext? in
             guard let uuid = recording.uuid,
                   let text = transcriptions[uuid] else { return nil }
-            let startCoord = closestCoordinate(to: recording.startDate, in: routeSamples)
-            let endCoord = closestCoordinate(to: recording.endDate, in: routeSamples)
             return PromptGenerator.RecordingContext(
                 text: text,
                 timestamp: recording.startDate,
-                startCoordinate: startCoord,
-                endCoordinate: endCoord,
+                startCoordinate: closestCoordinate(to: recording.startDate, in: routeSamples),
+                endCoordinate: closestCoordinate(to: recording.endDate, in: routeSamples),
                 wordsPerMinute: recording.wordsPerMinute
             )
         }.sorted { $0.timestamp < $1.timestamp }
-
         let meditations = walk.activityIntervals
             .filter { $0.activityType == .meditation }
             .sorted { $0.startDate < $1.startDate }
-            .map { PromptGenerator.MeditationContext(
-                startDate: $0.startDate,
-                endDate: $0.endDate,
-                duration: $0.duration
-            )}
+            .map { PromptGenerator.MeditationContext(startDate: $0.startDate, endDate: $0.endDate, duration: $0.duration) }
 
-        prompts = PromptGenerator.generateAll(
-            recordings: recordings,
-            meditations: meditations,
-            duration: walk.activeDuration,
-            distance: walk.distance,
-            startDate: walk.startDate
-        )
+        customPrompts = customStyleStore.styles.map { customStyle in
+            PromptGenerator.generateCustom(
+                customStyle: customStyle,
+                recordings: recordings,
+                meditations: meditations,
+                duration: walk.activeDuration,
+                distance: walk.distance,
+                startDate: walk.startDate,
+                placeNames: geocodedPlaces,
+                routeSpeeds: routeSpeeds,
+                recentWalkSnippets: recentWalkSnippets
+            )
+        }
     }
 
     private func closestCoordinate(to date: Date, in samples: [RouteDataSampleInterface]) -> (lat: Double, lon: Double)? {

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
@@ -12,6 +12,7 @@ struct WalkSummaryView: View {
     @State private var transcriptions: [UUID: String] = [:]
     @State private var showPrompts = false
     @State private var mapRegion: MKCoordinateRegion?
+    @State private var recentWalkSnippets: [PromptGenerator.WalkSnippet] = []
 
     var body: some View {
         NavigationView {
@@ -49,6 +50,7 @@ struct WalkSummaryView: View {
             }
             .onAppear {
                 loadExistingTranscriptions()
+                loadRecentWalkSnippets()
                 if routeCoordinates.count > 1 {
                     mapRegion = regionForRoute(routeCoordinates)
                 }
@@ -97,21 +99,22 @@ struct WalkSummaryView: View {
         }
     }
 
-    private var recentWalkSnippets: [PromptGenerator.WalkSnippet] {
+    private func loadRecentWalkSnippets() {
         guard let walks = try? DataManager.dataStack.fetchAll(
             From<Walk>()
                 .where(\._startDate < walk.startDate)
                 .orderBy(.descending(\._startDate))
-        ) else { return [] }
+                .tweak { $0.fetchLimit = 20 }
+        ) else { return }
 
-        return walks
+        recentWalkSnippets = walks
             .filter { w in w.voiceRecordings.contains { $0.transcription != nil } }
             .prefix(3)
             .map { w in
                 let allText = w.voiceRecordings
                     .compactMap { $0.transcription }
                     .joined(separator: " ")
-                let preview = String(allText.prefix(200)).truncatedAtWordBoundary()
+                let preview = allText.truncatedAtWordBoundary()
                 return PromptGenerator.WalkSnippet(date: w.startDate, placeName: nil, transcriptionPreview: preview)
             }
     }

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import MapKit
 import AVFoundation
+import CoreStore
 
 struct WalkSummaryView: View {
 
@@ -54,7 +55,7 @@ struct WalkSummaryView: View {
             }
             .sheet(isPresented: $showPrompts) {
                 NavigationView {
-                    PromptListView(walk: walk, transcriptions: transcriptions)
+                    PromptListView(walk: walk, transcriptions: transcriptions, recentWalkSnippets: recentWalkSnippets)
                 }
             }
         }
@@ -94,6 +95,25 @@ struct WalkSummaryView: View {
             .background(Color.parchmentSecondary)
             .cornerRadius(Constants.UI.CornerRadius.normal)
         }
+    }
+
+    private var recentWalkSnippets: [PromptGenerator.WalkSnippet] {
+        guard let walks = try? DataManager.dataStack.fetchAll(
+            From<Walk>()
+                .where(\._startDate < walk.startDate)
+                .orderBy(.descending(\._startDate))
+        ) else { return [] }
+
+        return walks
+            .filter { w in w.voiceRecordings.contains { $0.transcription != nil } }
+            .prefix(3)
+            .map { w in
+                let allText = w.voiceRecordings
+                    .compactMap { $0.transcription }
+                    .joined(separator: " ")
+                let preview = String(allText.prefix(200)).truncatedAtWordBoundary()
+                return PromptGenerator.WalkSnippet(date: w.startDate, placeName: nil, transcriptionPreview: preview)
+            }
     }
 
     private func loadExistingTranscriptions() {

--- a/UnitTests/CustomPromptStyleStoreTests.swift
+++ b/UnitTests/CustomPromptStyleStoreTests.swift
@@ -1,0 +1,61 @@
+import XCTest
+@testable import Pilgrim
+
+final class CustomPromptStyleStoreTests: XCTestCase {
+
+    private var store: CustomPromptStyleStore!
+    private let testKey = "TestCustomPromptStyles"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: testKey)
+        store = CustomPromptStyleStore(userDefaultsKey: testKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: testKey)
+        super.tearDown()
+    }
+
+    func testInitialState_empty() {
+        XCTAssertTrue(store.styles.isEmpty)
+        XCTAssertTrue(store.canAddMore)
+    }
+
+    func testSave_addsStyle() {
+        let style = CustomPromptStyle(id: UUID(), title: "Test", icon: "star", instruction: "Do a thing")
+        store.save(style)
+        XCTAssertEqual(store.styles.count, 1)
+        XCTAssertEqual(store.styles.first?.title, "Test")
+    }
+
+    func testSave_persistsToUserDefaults() {
+        let style = CustomPromptStyle(id: UUID(), title: "Persisted", icon: "star", instruction: "Persist")
+        store.save(style)
+        let reloaded = CustomPromptStyleStore(userDefaultsKey: testKey)
+        XCTAssertEqual(reloaded.styles.count, 1)
+        XCTAssertEqual(reloaded.styles.first?.title, "Persisted")
+    }
+
+    func testCanAddMore_falseAtMax() {
+        for i in 0..<CustomPromptStyleStore.maxStyles {
+            store.save(CustomPromptStyle(id: UUID(), title: "Style \(i)", icon: "star", instruction: "Inst"))
+        }
+        XCTAssertFalse(store.canAddMore)
+    }
+
+    func testDelete_removesStyle() {
+        let style = CustomPromptStyle(id: UUID(), title: "Delete Me", icon: "star", instruction: "Inst")
+        store.save(style)
+        store.delete(style)
+        XCTAssertTrue(store.styles.isEmpty)
+    }
+
+    func testSave_existingId_updatesInPlace() {
+        let id = UUID()
+        store.save(CustomPromptStyle(id: id, title: "Original", icon: "star", instruction: "V1"))
+        store.save(CustomPromptStyle(id: id, title: "Updated", icon: "star", instruction: "V2"))
+        XCTAssertEqual(store.styles.count, 1)
+        XCTAssertEqual(store.styles.first?.title, "Updated")
+    }
+}

--- a/UnitTests/PromptGeneratorTests.swift
+++ b/UnitTests/PromptGeneratorTests.swift
@@ -233,4 +233,46 @@ final class PromptGeneratorTests: XCTestCase {
         )
         XCTAssertFalse(prompt.text.contains("Location"))
     }
+
+    // MARK: - Task 8: Pace Context
+
+    func testFormatPaceContext_withSpeedData_containsAveragePace() {
+        let prompt = PromptGenerator.generate(
+            style: .reflective,
+            recordings: [],
+            meditations: [],
+            duration: 1800,
+            distance: 2000,
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            routeSpeeds: [1.5, 1.6, 1.4, 1.5, 1.3, 1.7, 1.5, 1.4, 1.6, 1.5, 1.5]
+        )
+        XCTAssertTrue(prompt.text.contains("Pace"))
+        XCTAssertTrue(prompt.text.contains("min/"))
+    }
+
+    func testFormatPaceContext_sparseData_omitsPaceSection() {
+        let prompt = PromptGenerator.generate(
+            style: .reflective,
+            recordings: [],
+            meditations: [],
+            duration: 1800,
+            distance: 2000,
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            routeSpeeds: [1.5, 1.6]
+        )
+        XCTAssertFalse(prompt.text.contains("Pace"))
+    }
+
+    func testFormatPaceContext_empty_omitsPaceSection() {
+        let prompt = PromptGenerator.generate(
+            style: .reflective,
+            recordings: [],
+            meditations: [],
+            duration: 1800,
+            distance: 2000,
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            routeSpeeds: []
+        )
+        XCTAssertFalse(prompt.text.contains("Pace"))
+    }
 }

--- a/UnitTests/PromptGeneratorTests.swift
+++ b/UnitTests/PromptGeneratorTests.swift
@@ -6,12 +6,13 @@ final class PromptGeneratorTests: XCTestCase {
     func testGenerateAll_returnsOnePerStyle() {
         let prompts = PromptGenerator.generateAll(
             recordings: [],
+            meditations: [],
             duration: 1800,
             distance: 2000,
             startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
         )
         XCTAssertEqual(prompts.count, 6)
-        let styles = Set(prompts.map { $0.style })
+        let styles = Set(prompts.compactMap { $0.style })
         XCTAssertEqual(styles.count, PromptStyle.allCases.count)
     }
 
@@ -25,6 +26,7 @@ final class PromptGeneratorTests: XCTestCase {
         let prompt = PromptGenerator.generate(
             style: .reflective,
             recordings: [recording],
+            meditations: [],
             duration: 1800,
             distance: 2000,
             startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
@@ -36,6 +38,7 @@ final class PromptGeneratorTests: XCTestCase {
         let prompt = PromptGenerator.generate(
             style: .contemplative,
             recordings: [],
+            meditations: [],
             duration: 1800,
             distance: 2000,
             startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
@@ -47,6 +50,7 @@ final class PromptGeneratorTests: XCTestCase {
         let prompt = PromptGenerator.generate(
             style: .contemplative,
             recordings: [],
+            meditations: [],
             duration: 1800,
             distance: 2000,
             startDate: DateFactory.makeLocalDate(2024, 6, 15, 5, 0, 0)
@@ -58,6 +62,7 @@ final class PromptGeneratorTests: XCTestCase {
         let prompt = PromptGenerator.generate(
             style: .contemplative,
             recordings: [],
+            meditations: [],
             duration: 1800,
             distance: 2000,
             startDate: DateFactory.makeLocalDate(2024, 6, 15, 12, 0, 0)
@@ -69,6 +74,7 @@ final class PromptGeneratorTests: XCTestCase {
         let prompt = PromptGenerator.generate(
             style: .contemplative,
             recordings: [],
+            meditations: [],
             duration: 1800,
             distance: 2000,
             startDate: DateFactory.makeLocalDate(2024, 6, 15, 22, 0, 0)
@@ -86,6 +92,7 @@ final class PromptGeneratorTests: XCTestCase {
         let prompt = PromptGenerator.generate(
             style: .reflective,
             recordings: [recording],
+            meditations: [],
             duration: 1800,
             distance: 2000,
             startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
@@ -104,6 +111,7 @@ final class PromptGeneratorTests: XCTestCase {
         let prompt = PromptGenerator.generate(
             style: .reflective,
             recordings: [recording],
+            meditations: [],
             duration: 1800,
             distance: 2000,
             startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
@@ -115,11 +123,27 @@ final class PromptGeneratorTests: XCTestCase {
         let prompt = PromptGenerator.generate(
             style: .journaling,
             recordings: [],
+            meditations: [],
             duration: 1800,
             distance: 2000,
             startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
         )
         XCTAssertFalse(prompt.text.isEmpty)
         XCTAssertTrue(prompt.text.contains("Walking Transcription"))
+    }
+
+    func testGeneratedPrompt_builtInStyle_titleFromStyle() {
+        let prompt = GeneratedPrompt(style: .reflective, customStyle: nil, text: "test")
+        XCTAssertEqual(prompt.title, "Reflective")
+        XCTAssertEqual(prompt.icon, "eye.fill")
+        XCTAssertEqual(prompt.subtitle, "Identify patterns and emotional undercurrents")
+    }
+
+    func testGeneratedPrompt_customStyle_titleFromCustom() {
+        let custom = CustomPromptStyle(id: UUID(), title: "My Style", icon: "star.fill", instruction: "Do something creative")
+        let prompt = GeneratedPrompt(style: nil, customStyle: custom, text: "test")
+        XCTAssertEqual(prompt.title, "My Style")
+        XCTAssertEqual(prompt.icon, "star.fill")
+        XCTAssertEqual(prompt.subtitle, "Do something creative")
     }
 }

--- a/UnitTests/PromptGeneratorTests.swift
+++ b/UnitTests/PromptGeneratorTests.swift
@@ -188,4 +188,49 @@ final class PromptGeneratorTests: XCTestCase {
         )
         XCTAssertFalse(prompt.text.contains("wpm"))
     }
+
+    func testFormatPlaceNames_startOnly_containsNear() {
+        let prompt = PromptGenerator.generate(
+            style: .reflective,
+            recordings: [],
+            meditations: [],
+            duration: 1800,
+            distance: 2000,
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            placeNames: [
+                PromptGenerator.PlaceContext(name: "Riverside Park, Manhattan", coordinate: (lat: 40.8, lon: -73.97), role: .start)
+            ]
+        )
+        XCTAssertTrue(prompt.text.contains("Near Riverside Park, Manhattan"))
+    }
+
+    func testFormatPlaceNames_startAndEnd_containsArrow() {
+        let prompt = PromptGenerator.generate(
+            style: .reflective,
+            recordings: [],
+            meditations: [],
+            duration: 1800,
+            distance: 2000,
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            placeNames: [
+                PromptGenerator.PlaceContext(name: "Riverside Park", coordinate: (lat: 40.8, lon: -73.97), role: .start),
+                PromptGenerator.PlaceContext(name: "Central Park", coordinate: (lat: 40.78, lon: -73.96), role: .end)
+            ]
+        )
+        XCTAssertTrue(prompt.text.contains("Started near Riverside Park"))
+        XCTAssertTrue(prompt.text.contains("Central Park"))
+    }
+
+    func testFormatPlaceNames_empty_omitsLocationSection() {
+        let prompt = PromptGenerator.generate(
+            style: .reflective,
+            recordings: [],
+            meditations: [],
+            duration: 1800,
+            distance: 2000,
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            placeNames: []
+        )
+        XCTAssertFalse(prompt.text.contains("Location"))
+    }
 }

--- a/UnitTests/PromptGeneratorTests.swift
+++ b/UnitTests/PromptGeneratorTests.swift
@@ -21,7 +21,8 @@ final class PromptGeneratorTests: XCTestCase {
             text: "The birds are singing beautifully today",
             timestamp: DateFactory.makeDate(2024, 6, 15, 9, 5, 0),
             startCoordinate: nil,
-            endCoordinate: nil
+            endCoordinate: nil,
+            wordsPerMinute: nil
         )
         let prompt = PromptGenerator.generate(
             style: .reflective,
@@ -87,7 +88,8 @@ final class PromptGeneratorTests: XCTestCase {
             text: "Walking in the park",
             timestamp: DateFactory.makeDate(2024, 6, 15, 9, 5, 0),
             startCoordinate: (lat: 48.85660, lon: 2.35220),
-            endCoordinate: nil
+            endCoordinate: nil,
+            wordsPerMinute: nil
         )
         let prompt = PromptGenerator.generate(
             style: .reflective,
@@ -106,7 +108,8 @@ final class PromptGeneratorTests: XCTestCase {
             text: "Walking in the park",
             timestamp: DateFactory.makeDate(2024, 6, 15, 9, 5, 0),
             startCoordinate: nil,
-            endCoordinate: nil
+            endCoordinate: nil,
+            wordsPerMinute: nil
         )
         let prompt = PromptGenerator.generate(
             style: .reflective,
@@ -145,5 +148,44 @@ final class PromptGeneratorTests: XCTestCase {
         XCTAssertEqual(prompt.title, "My Style")
         XCTAssertEqual(prompt.icon, "star.fill")
         XCTAssertEqual(prompt.subtitle, "Do something creative")
+    }
+
+    func testGenerate_recordingWithWPM_containsPaceLabel() {
+        let recording = PromptGenerator.RecordingContext(
+            text: "Quick excited thoughts",
+            timestamp: DateFactory.makeDate(2024, 6, 15, 9, 5, 0),
+            startCoordinate: nil,
+            endCoordinate: nil,
+            wordsPerMinute: 85
+        )
+        let prompt = PromptGenerator.generate(
+            style: .reflective,
+            recordings: [recording],
+            meditations: [],
+            duration: 1800,
+            distance: 2000,
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        )
+        XCTAssertTrue(prompt.text.contains("~85 wpm"))
+        XCTAssertTrue(prompt.text.contains("slow/thoughtful"))
+    }
+
+    func testGenerate_recordingWithoutWPM_omitsPaceLabel() {
+        let recording = PromptGenerator.RecordingContext(
+            text: "Just walking",
+            timestamp: DateFactory.makeDate(2024, 6, 15, 9, 5, 0),
+            startCoordinate: nil,
+            endCoordinate: nil,
+            wordsPerMinute: nil
+        )
+        let prompt = PromptGenerator.generate(
+            style: .reflective,
+            recordings: [recording],
+            meditations: [],
+            duration: 1800,
+            distance: 2000,
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        )
+        XCTAssertFalse(prompt.text.contains("wpm"))
     }
 }

--- a/UnitTests/PromptGeneratorTests.swift
+++ b/UnitTests/PromptGeneratorTests.swift
@@ -316,4 +316,21 @@ final class PromptGeneratorTests: XCTestCase {
         )
         XCTAssertFalse(prompt.text.contains("Recent Walk Context"))
     }
+
+    // MARK: - Task 10: Custom Prompt Generation
+
+    func testGenerateCustom_usesCustomInstruction() {
+        let custom = CustomPromptStyle(id: UUID(), title: "Letter", icon: "envelope.fill", instruction: "Write this as a letter to my future self")
+        let prompt = PromptGenerator.generateCustom(
+            customStyle: custom,
+            recordings: [],
+            meditations: [],
+            duration: 1800,
+            distance: 2000,
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        )
+        XCTAssertTrue(prompt.text.contains("letter to my future self"))
+        XCTAssertNil(prompt.style)
+        XCTAssertEqual(prompt.customStyle?.title, "Letter")
+    }
 }

--- a/UnitTests/PromptGeneratorTests.swift
+++ b/UnitTests/PromptGeneratorTests.swift
@@ -275,4 +275,45 @@ final class PromptGeneratorTests: XCTestCase {
         )
         XCTAssertFalse(prompt.text.contains("Pace"))
     }
+
+    // MARK: - Task 9: Walk-to-Walk Threading
+
+    func testFormatRecentWalks_withSnippets_containsContinuitySection() {
+        let snippets = [
+            PromptGenerator.WalkSnippet(
+                date: DateFactory.makeDate(2024, 6, 12, 9, 0, 0),
+                placeName: nil,
+                transcriptionPreview: "I keep thinking about how the river reminds me of home"
+            ),
+            PromptGenerator.WalkSnippet(
+                date: DateFactory.makeDate(2024, 6, 10, 9, 0, 0),
+                placeName: nil,
+                transcriptionPreview: "Today I noticed I was walking faster than usual"
+            )
+        ]
+        let prompt = PromptGenerator.generate(
+            style: .reflective,
+            recordings: [],
+            meditations: [],
+            duration: 1800,
+            distance: 2000,
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            recentWalkSnippets: snippets
+        )
+        XCTAssertTrue(prompt.text.contains("Recent Walk Context"))
+        XCTAssertTrue(prompt.text.contains("river reminds me of home"))
+    }
+
+    func testFormatRecentWalks_empty_omitsSection() {
+        let prompt = PromptGenerator.generate(
+            style: .reflective,
+            recordings: [],
+            meditations: [],
+            duration: 1800,
+            distance: 2000,
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            recentWalkSnippets: []
+        )
+        XCTAssertFalse(prompt.text.contains("Recent Walk Context"))
+    }
 }

--- a/docs/superpowers/plans/2026-03-13-prompt-enhancements.md
+++ b/docs/superpowers/plans/2026-03-13-prompt-enhancements.md
@@ -1,0 +1,1710 @@
+# Prompt Enhancements Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enrich prompt generation with reverse geocoding, pace context, walk threading, AI deep links, custom styles, and speaking pace metadata.
+
+**Architecture:** Layer new context formatters onto existing PromptGenerator using the same nil-return optional section pattern. One schema migration (PilgrimV3) for wordsPerMinute. Custom styles in UserDefaults. UI changes to PromptDetailView for deep links and PromptListView for custom styles.
+
+**Tech Stack:** SwiftUI, CoreStore, CoreLocation (CLGeocoder), WhisperKit, UserDefaults
+
+**Spec:** `docs/superpowers/specs/2026-03-13-prompt-enhancements-design.md`
+
+---
+
+## Chunk 1: PilgrimV3 Schema + Speaking Pace Data Layer
+
+### Task 1: PilgrimV3 Schema
+
+**Files:**
+- Create: `Pilgrim/Models/Data/DataModels/Versions/PilgrimV3.swift`
+- Reference: `Pilgrim/Models/Data/DataModels/Versions/PilgrimV2.swift`
+
+- [ ] **Step 1: Create PilgrimV3.swift**
+
+Copy PilgrimV2.swift as the starting template. Change all internal references from `PilgrimV2` to `PilgrimV3`. Set `static let identifier = "PilgrimV3"`. Add one new field to the VoiceRecording entity:
+
+```swift
+let _wordsPerMinute = Value.Optional<Double>("wordsPerMinute")
+```
+
+Add this after `_transcription` (line 176 in PilgrimV2). Keep all other entities identical.
+
+- [ ] **Step 2: Write migration provider**
+
+In PilgrimV3's `migrationProvider`, migrate from PilgrimV2:
+- `.transformEntity` for VoiceRecording (new attribute changes version hash)
+- `.copyEntity` for all other entities (Workout, WorkoutPause, WorkoutEvent, RouteDataSample, HeartRateDataSample, Event, ActivityInterval)
+
+Pattern — follow PilgrimV2.swift lines 20-44, replacing source `PilgrimV1` → `PilgrimV2`.
+
+The transformEntity for VoiceRecording:
+```swift
+.transformEntity(
+    sourceEntity: PilgrimV2.VoiceRecording.self,
+    destinationEntity: PilgrimV3.VoiceRecording.self,
+    transformer: { source, dest in
+        dest[\.._uuid] = source[\.._uuid]
+        dest[\.._startDate] = source[\.._startDate]
+        dest[\.._endDate] = source[\.._endDate]
+        dest[\.._duration] = source[\.._duration]
+        dest[\.._fileRelativePath] = source[\.._fileRelativePath]
+        dest[\.._transcription] = source[\.._transcription]
+    }
+)
+```
+
+- [ ] **Step 3: Verify project compiles**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Pilgrim/Models/Data/DataModels/Versions/PilgrimV3.swift
+git commit -m "feat: add PilgrimV3 schema with wordsPerMinute on VoiceRecording"
+```
+
+---
+
+### Task 2: VoiceRecording Type Alias + Interface + Temp Layer
+
+**Files:**
+- Modify: `Pilgrim/Models/Data/DataModels/VoiceRecording.swift:4` (type alias)
+- Modify: `Pilgrim/Protocols/DataInterfaces/VoiceRecordingInterface.swift:3-11` (protocol)
+- Modify: `Pilgrim/Models/Data/Temp/Versions/TempV4.swift:179-200` (TempV4.VoiceRecording)
+- Modify: `Pilgrim/Models/Data/Temp/Temp.swift:155-168` (TempVoiceRecording)
+
+- [ ] **Step 1: Update type alias**
+
+In `VoiceRecording.swift` line 4, change:
+```swift
+typealias VoiceRecording = PilgrimV2.VoiceRecording
+```
+to:
+```swift
+typealias VoiceRecording = PilgrimV3.VoiceRecording
+```
+
+Add `wordsPerMinute` to the VoiceRecordingInterface conformance extension (after `transcription`):
+```swift
+var wordsPerMinute: Double? { threadSafeSyncReturn { self._wordsPerMinute.value } }
+```
+
+- [ ] **Step 2: Update VoiceRecordingInterface protocol**
+
+In `VoiceRecordingInterface.swift`, add to the protocol (after `transcription`):
+```swift
+var wordsPerMinute: Double? { get }
+```
+
+Add default implementation in the extension:
+```swift
+var wordsPerMinute: Double? { throwOnAccess() }
+```
+
+- [ ] **Step 3: Update TempV4.VoiceRecording**
+
+In `TempV4.swift` VoiceRecording class (line 179), add property:
+```swift
+var wordsPerMinute: Double?
+```
+
+Update the initializer to accept the new parameter (default nil):
+```swift
+init(uuid: UUID?, startDate: Date, endDate: Date, duration: Double,
+     fileRelativePath: String, transcription: String? = nil, wordsPerMinute: Double? = nil) {
+    // ... existing assignments ...
+    self.wordsPerMinute = wordsPerMinute
+}
+```
+
+- [ ] **Step 4: Update Temp.swift TempVoiceRecording**
+
+In `Temp.swift` line 155-168, update the VoiceRecordingInterface conformance extension's convenience init to pass `wordsPerMinute`:
+```swift
+convenience init(from interface: VoiceRecordingInterface) {
+    self.init(
+        uuid: interface.uuid,
+        startDate: interface.startDate,
+        endDate: interface.endDate,
+        duration: interface.duration,
+        fileRelativePath: interface.fileRelativePath,
+        transcription: interface.transcription,
+        wordsPerMinute: interface.wordsPerMinute
+    )
+}
+```
+
+- [ ] **Step 5: Update VoiceRecording.asTemp conversion**
+
+In `VoiceRecording.swift` lines 18-31 (TempValueConvertible extension), update the TempVoiceRecording init call to include `wordsPerMinute`:
+```swift
+TempVoiceRecording(
+    uuid: uuid,
+    startDate: startDate,
+    endDate: endDate,
+    duration: duration,
+    fileRelativePath: fileRelativePath,
+    transcription: transcription,
+    wordsPerMinute: wordsPerMinute
+)
+```
+
+- [ ] **Step 6: Verify project compiles**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Pilgrim/Models/Data/DataModels/VoiceRecording.swift \
+        Pilgrim/Protocols/DataInterfaces/VoiceRecordingInterface.swift \
+        Pilgrim/Models/Data/Temp/Versions/TempV4.swift \
+        Pilgrim/Models/Data/Temp/Temp.swift
+git commit -m "feat: add wordsPerMinute to VoiceRecording type alias, interface, and temp layer"
+```
+
+---
+
+### Task 3: DataManager Updates
+
+**Files:**
+- Modify: `Pilgrim/Models/Data/DataManager.swift:55` (setup default parameter)
+- Modify: `Pilgrim/Models/Data/DataManager.swift:255-265` (saveWalks voiceRecordings section)
+- Modify: `Pilgrim/Models/Data/DataManager.swift:464-476` (add updateWordsPerMinute near updateTranscription)
+
+- [ ] **Step 1: Update setup default parameter**
+
+Line 55, change default `dataModel` from `PilgrimV2.self` to `PilgrimV3.self`.
+
+- [ ] **Step 2: Update saveWalks voiceRecordings persistence**
+
+In the saveWalks method (lines 255-265), after the existing field assignments for each voice recording, add:
+```swift
+recording._wordsPerMinute.value = tempRecording.wordsPerMinute
+```
+
+- [ ] **Step 3: Add updateVoiceRecordingWordsPerMinute method**
+
+Add near `updateVoiceRecordingTranscription` (line 464), following the same pattern:
+
+```swift
+static func updateVoiceRecordingWordsPerMinute(uuid: UUID, wordsPerMinute: Double) {
+    dataStack.perform(asynchronous: { transaction in
+        guard let recording = try transaction.fetchOne(
+            From<VoiceRecording>().where(\._uuid == uuid)
+        ) else { return }
+        recording._wordsPerMinute.value = wordsPerMinute
+    }, completion: { result in
+        if case .failure(let error) = result {
+            print("[DataManager] Failed to update WPM for \(uuid): \(error)")
+        }
+    })
+}
+```
+
+- [ ] **Step 4: Verify project compiles**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Models/Data/DataManager.swift
+git commit -m "feat: update DataManager for PilgrimV3 migration and WPM persistence"
+```
+
+---
+
+### Task 4: TranscriptionService WPM Computation
+
+**Files:**
+- Modify: `Pilgrim/Models/TranscriptionService.swift:130-137` (transcribeRecordings inner loop)
+- Modify: `Pilgrim/Models/TranscriptionService.swift:178-186` (transcribeSingle)
+
+- [ ] **Step 1: Add WPM computation helper**
+
+Add a private method to TranscriptionService:
+
+```swift
+private func computeWordsPerMinute(from results: [TranscriptionResult]) -> Double? {
+    let segments = results.flatMap { $0.segments }
+    guard let first = segments.first, let last = segments.last,
+          last.end > first.start else { return nil }
+    let words = segments.flatMap { $0.words }
+    let wordCount: Int
+    if !words.isEmpty {
+        wordCount = words.count
+    } else {
+        wordCount = segments.flatMap { $0.text.split(separator: " ") }.count
+    }
+    guard wordCount > 0 else { return nil }
+    let durationMinutes = (last.end - first.start) / 60.0
+    guard durationMinutes > 0 else { return nil }
+    return Double(wordCount) / durationMinutes
+}
+```
+
+- [ ] **Step 2: Integrate into transcribeRecordings**
+
+In the `transcribeRecordings` method (line 130-137), after extracting text and before `DataManager.updateVoiceRecordingTranscription`, add WPM computation:
+
+```swift
+let transcriptionResults = try await pipe.transcribe(audioPath: audioURL.path)
+let text = transcriptionResults.map(\.text).joined(separator: " ")
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+if !text.isEmpty {
+    results[uuid] = text
+    DataManager.updateVoiceRecordingTranscription(uuid: uuid, transcription: text)
+    if let wpm = computeWordsPerMinute(from: transcriptionResults) {
+        DataManager.updateVoiceRecordingWordsPerMinute(uuid: uuid, wordsPerMinute: wpm)
+    }
+}
+```
+
+- [ ] **Step 3: Integrate into transcribeSingle**
+
+Same pattern in `transcribeSingle` (line 178-186):
+
+```swift
+let results = try await pipe.transcribe(audioPath: audioURL.path)
+let text = results.map(\.text).joined(separator: " ")
+    .trimmingCharacters(in: .whitespacesAndNewlines)
+await MainActor.run { state = .completed; isTranscribing = false }
+if !text.isEmpty {
+    DataManager.updateVoiceRecordingTranscription(uuid: uuid, transcription: text)
+    if let wpm = computeWordsPerMinute(from: results) {
+        DataManager.updateVoiceRecordingWordsPerMinute(uuid: uuid, wordsPerMinute: wpm)
+    }
+    return text
+}
+```
+
+- [ ] **Step 4: Verify project compiles**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Models/TranscriptionService.swift
+git commit -m "feat: compute and store words-per-minute during transcription"
+```
+
+---
+
+## Chunk 2: PromptGenerator Enhancements
+
+### Task 5: GeneratedPrompt Model Update
+
+**Files:**
+- Modify: `Pilgrim/Models/PromptGenerator.swift:47-51` (GeneratedPrompt struct)
+
+- [ ] **Step 1: Write failing test for custom style support**
+
+In `UnitTests/PromptGeneratorTests.swift`, add:
+
+```swift
+func testGeneratedPrompt_builtInStyle_titleFromStyle() {
+    let prompt = GeneratedPrompt(style: .reflective, customStyle: nil, text: "test")
+    XCTAssertEqual(prompt.title, "Reflective")
+    XCTAssertEqual(prompt.icon, "eye.fill")
+    XCTAssertEqual(prompt.subtitle, "Identify patterns and emotional undercurrents")
+}
+
+func testGeneratedPrompt_customStyle_titleFromCustom() {
+    let custom = CustomPromptStyle(id: UUID(), title: "My Style", icon: "star.fill", instruction: "Do something creative")
+    let prompt = GeneratedPrompt(style: nil, customStyle: custom, text: "test")
+    XCTAssertEqual(prompt.title, "My Style")
+    XCTAssertEqual(prompt.icon, "star.fill")
+    XCTAssertEqual(prompt.subtitle, "Do something creative")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | grep -E '(Test Case|BUILD|error:)'`
+Expected: FAIL — GeneratedPrompt doesn't have these initializer parameters yet
+
+- [ ] **Step 3: Update GeneratedPrompt struct**
+
+Replace the struct at lines 47-51:
+
+```swift
+struct GeneratedPrompt: Identifiable {
+    let id = UUID()
+    let style: PromptStyle?
+    let customStyle: CustomPromptStyle?
+    let text: String
+
+    var title: String { customStyle?.title ?? style!.title }
+    var icon: String { customStyle?.icon ?? style!.icon }
+    var subtitle: String { customStyle?.instruction ?? style!.description }
+}
+```
+
+- [ ] **Step 4: Create CustomPromptStyle struct**
+
+Create `Pilgrim/Models/CustomPromptStyleStore.swift` with just the struct for now (store comes in Task 11):
+
+```swift
+import Foundation
+
+struct CustomPromptStyle: Codable, Identifiable {
+    let id: UUID
+    var title: String
+    var icon: String
+    var instruction: String
+}
+```
+
+- [ ] **Step 5: Fix existing code that uses GeneratedPrompt**
+
+Update `PromptGenerator.generate()` return at line 80:
+```swift
+return GeneratedPrompt(style: style, customStyle: nil, text: prompt)
+```
+
+Update `PromptDetailView.swift` lines 16 and 19:
+```swift
+Image(systemName: prompt.icon)
+// ...
+Text(prompt.title)
+```
+
+Update `PromptStyleRow` lines 78, 84, 87:
+```swift
+Image(systemName: prompt.icon)
+// ...
+Text(prompt.title)
+// ...
+Text(prompt.subtitle)
+```
+
+Fix existing test `testGenerateAll_returnsOnePerStyle` — the `Set(prompts.map { $0.style })` line needs updating since `style` is now optional:
+```swift
+let styles = Set(prompts.compactMap { $0.style })
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | grep -E '(Test Case|BUILD|Executed)'`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Pilgrim/Models/PromptGenerator.swift \
+        Pilgrim/Models/CustomPromptStyleStore.swift \
+        Pilgrim/Scenes/Prompts/PromptDetailView.swift \
+        Pilgrim/Scenes/Prompts/PromptListView.swift \
+        UnitTests/PromptGeneratorTests.swift
+git commit -m "feat: update GeneratedPrompt to support custom styles"
+```
+
+---
+
+### Task 6: RecordingContext WPM + WPM Formatting
+
+**Files:**
+- Modify: `Pilgrim/Models/PromptGenerator.swift:55-60` (RecordingContext)
+- Modify: `Pilgrim/Models/PromptGenerator.swift:115-127` (formatRecordings)
+- Test: `UnitTests/PromptGeneratorTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+```swift
+func testGenerate_recordingWithWPM_containsPaceLabel() {
+    let recording = PromptGenerator.RecordingContext(
+        text: "Quick excited thoughts",
+        timestamp: DateFactory.makeDate(2024, 6, 15, 9, 5, 0),
+        startCoordinate: nil,
+        endCoordinate: nil,
+        wordsPerMinute: 85
+    )
+    let prompt = PromptGenerator.generate(
+        style: .reflective,
+        recordings: [recording],
+        meditations: [],
+        duration: 1800,
+        distance: 2000,
+        startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+    )
+    XCTAssertTrue(prompt.text.contains("~85 wpm"))
+    XCTAssertTrue(prompt.text.contains("slow/thoughtful"))
+}
+
+func testGenerate_recordingWithoutWPM_omitsPaceLabel() {
+    let recording = PromptGenerator.RecordingContext(
+        text: "Just walking",
+        timestamp: DateFactory.makeDate(2024, 6, 15, 9, 5, 0),
+        startCoordinate: nil,
+        endCoordinate: nil,
+        wordsPerMinute: nil
+    )
+    let prompt = PromptGenerator.generate(
+        style: .reflective,
+        recordings: [recording],
+        meditations: [],
+        duration: 1800,
+        distance: 2000,
+        startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+    )
+    XCTAssertFalse(prompt.text.contains("wpm"))
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Expected: FAIL — RecordingContext doesn't have `wordsPerMinute` parameter yet
+
+- [ ] **Step 3: Add wordsPerMinute to RecordingContext**
+
+At line 55-60, add the field:
+```swift
+struct RecordingContext {
+    let text: String
+    let timestamp: Date
+    let startCoordinate: (lat: Double, lon: Double)?
+    let endCoordinate: (lat: Double, lon: Double)?
+    let wordsPerMinute: Double?
+}
+```
+
+- [ ] **Step 4: Fix existing call sites**
+
+Update `PromptListView.generatePrompts()` RecordingContext creation (line 39-44) to include `wordsPerMinute`:
+```swift
+return PromptGenerator.RecordingContext(
+    text: text,
+    timestamp: recording.startDate,
+    startCoordinate: startCoord,
+    endCoordinate: endCoord,
+    wordsPerMinute: recording.wordsPerMinute
+)
+```
+
+Update all existing test RecordingContext creations in `PromptGeneratorTests.swift` to add `wordsPerMinute: nil`.
+
+- [ ] **Step 5: Add WPM label helper and update formatRecordings**
+
+Add to PromptGenerator:
+```swift
+private static func speakingPaceLabel(_ wpm: Double) -> String {
+    switch wpm {
+    case ..<100: return "slow/thoughtful"
+    case 100..<140: return "measured"
+    case 140..<170: return "conversational"
+    default: return "rapid/energized"
+    }
+}
+```
+
+In `formatRecordings` (line 115-127), after the GPS header, add WPM:
+```swift
+if let wpm = item.wordsPerMinute {
+    header += " [~\(Int(wpm)) wpm, \(speakingPaceLabel(wpm))]"
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | grep -E '(Test Case|BUILD|Executed)'`
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Pilgrim/Models/PromptGenerator.swift \
+        Pilgrim/Scenes/Prompts/PromptListView.swift \
+        UnitTests/PromptGeneratorTests.swift
+git commit -m "feat: add speaking pace labels to prompt recording headers"
+```
+
+---
+
+### Task 7: Reverse Geocoding Formatter
+
+**Files:**
+- Modify: `Pilgrim/Models/PromptGenerator.swift` (add PlaceContext, PlaceRole, formatPlaceNames)
+- Test: `UnitTests/PromptGeneratorTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+```swift
+func testFormatPlaceNames_startOnly_containsNear() {
+    let prompt = PromptGenerator.generate(
+        style: .reflective,
+        recordings: [],
+        meditations: [],
+        duration: 1800,
+        distance: 2000,
+        startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+        placeNames: [
+            PromptGenerator.PlaceContext(name: "Riverside Park, Manhattan", coordinate: (lat: 40.8, lon: -73.97), role: .start)
+        ]
+    )
+    XCTAssertTrue(prompt.text.contains("Near Riverside Park, Manhattan"))
+}
+
+func testFormatPlaceNames_startAndEnd_containsArrow() {
+    let prompt = PromptGenerator.generate(
+        style: .reflective,
+        recordings: [],
+        meditations: [],
+        duration: 1800,
+        distance: 2000,
+        startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+        placeNames: [
+            PromptGenerator.PlaceContext(name: "Riverside Park", coordinate: (lat: 40.8, lon: -73.97), role: .start),
+            PromptGenerator.PlaceContext(name: "Central Park", coordinate: (lat: 40.78, lon: -73.96), role: .end)
+        ]
+    )
+    XCTAssertTrue(prompt.text.contains("Started near Riverside Park"))
+    XCTAssertTrue(prompt.text.contains("Central Park"))
+}
+
+func testFormatPlaceNames_empty_omitsLocationSection() {
+    let prompt = PromptGenerator.generate(
+        style: .reflective,
+        recordings: [],
+        meditations: [],
+        duration: 1800,
+        distance: 2000,
+        startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+        placeNames: []
+    )
+    XCTAssertFalse(prompt.text.contains("Location"))
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Expected: FAIL — `placeNames` parameter doesn't exist yet
+
+- [ ] **Step 3: Add types and formatter**
+
+Add to PromptGenerator:
+
+```swift
+enum PlaceRole { case start, end, midpoint }
+
+struct PlaceContext {
+    let name: String
+    let coordinate: (lat: Double, lon: Double)
+    let role: PlaceRole
+}
+```
+
+Add formatter:
+```swift
+private static func formatPlaceNames(_ places: [PlaceContext]) -> String? {
+    guard !places.isEmpty else { return nil }
+    let start = places.first { $0.role == .start }
+    let end = places.first { $0.role == .end }
+    if let start = start, let end = end {
+        return "**Location:** Started near \(start.name) → ended near \(end.name)"
+    } else if let start = start {
+        return "**Location:** Near \(start.name)"
+    }
+    return nil
+}
+```
+
+- [ ] **Step 4: Update generate() signature**
+
+Add `placeNames: [PlaceContext] = []` parameter. Pass it through to `buildPrompt`. Update `buildPrompt` to accept and insert location section after metadata.
+
+- [ ] **Step 5: Update buildPrompt to include location**
+
+Add `location: String?` parameter to `buildPrompt`. Insert after the metadata Context line:
+```swift
+if let location = location {
+    sections += "\n\n\(location)"
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Pilgrim/Models/PromptGenerator.swift UnitTests/PromptGeneratorTests.swift
+git commit -m "feat: add reverse geocoding place names to prompts"
+```
+
+---
+
+### Task 8: Pace Context Formatter
+
+**Files:**
+- Modify: `Pilgrim/Models/PromptGenerator.swift` (add formatPaceContext)
+- Test: `UnitTests/PromptGeneratorTests.swift`
+- Reference: `Pilgrim/Protocols/DataInterfaces/RouteDataSampleInterface.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+```swift
+func testFormatPaceContext_withSpeedData_containsAveragePace() {
+    let prompt = PromptGenerator.generate(
+        style: .reflective,
+        recordings: [],
+        meditations: [],
+        duration: 1800,
+        distance: 2000,
+        startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+        routeSpeeds: [1.5, 1.6, 1.4, 1.5, 1.3, 1.7, 1.5, 1.4, 1.6, 1.5, 1.5]
+    )
+    XCTAssertTrue(prompt.text.contains("Pace"))
+    XCTAssertTrue(prompt.text.contains("min/"))
+}
+
+func testFormatPaceContext_sparseData_omitsPaceSection() {
+    let prompt = PromptGenerator.generate(
+        style: .reflective,
+        recordings: [],
+        meditations: [],
+        duration: 1800,
+        distance: 2000,
+        startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+        routeSpeeds: [1.5, 1.6]
+    )
+    XCTAssertFalse(prompt.text.contains("Pace"))
+}
+
+func testFormatPaceContext_empty_omitsPaceSection() {
+    let prompt = PromptGenerator.generate(
+        style: .reflective,
+        recordings: [],
+        meditations: [],
+        duration: 1800,
+        distance: 2000,
+        startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+        routeSpeeds: []
+    )
+    XCTAssertFalse(prompt.text.contains("Pace"))
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Expected: FAIL — `routeSpeeds` parameter doesn't exist
+
+- [ ] **Step 3: Add pace formatter**
+
+For testability, accept two parameters: `routeSpeeds: [Double]` (m/s values for overall pace) and `routeSpeedTimestamps: [(Date, Double)]` (timestamp + speed pairs for per-recording analysis). The call site in PromptListView extracts these from route samples.
+
+Add `routeSpeeds: [Double] = []` and `routeSpeedTimestamps: [(Date, Double)] = []` parameters to `generate()`.
+
+```swift
+private static func formatPaceContext(speeds: [Double], speedTimestamps: [(Date, Double)], recordings: [RecordingContext]) -> String? {
+    let moving = speeds.filter { $0 >= 0.3 }
+    guard moving.count >= 10 else { return nil }
+    let avgSpeed = moving.reduce(0, +) / Double(moving.count)
+    let minSpeed = moving.min()!
+    let maxSpeed = moving.max()!
+    let avgPace = formatPace(metersPerSecond: avgSpeed)
+    let slowPace = formatPace(metersPerSecond: minSpeed)
+    let fastPace = formatPace(metersPerSecond: maxSpeed)
+    var result = "**Pace:** Average \(avgPace) (range: \(fastPace)–\(slowPace))"
+
+    for recording in recordings {
+        let windowBefore = speedTimestamps.filter {
+            $0.0 >= recording.timestamp.addingTimeInterval(-30) &&
+            $0.0 <= recording.timestamp && $0.1 >= 0.3
+        }
+        let windowAfter = speedTimestamps.filter {
+            $0.0 >= recording.timestamp &&
+            $0.0 <= recording.timestamp.addingTimeInterval(30) && $0.1 >= 0.3
+        }
+        guard !windowBefore.isEmpty || !windowAfter.isEmpty else { continue }
+        let beforeAvg = windowBefore.isEmpty ? nil : windowBefore.map(\.1).reduce(0, +) / Double(windowBefore.count)
+        let afterAvg = windowAfter.isEmpty ? nil : windowAfter.map(\.1).reduce(0, +) / Double(windowAfter.count)
+        let timeStr = timeFormatter.string(from: recording.timestamp)
+        if let before = beforeAvg, let after = afterAvg {
+            let beforePace = formatPace(metersPerSecond: before)
+            let afterPace = formatPace(metersPerSecond: after)
+            if abs(before - after) / before > 0.15 {
+                result += "\n[\(timeStr)] pace changed from \(beforePace) to \(afterPace)"
+            } else {
+                result += "\n[\(timeStr)] steady at \(formatPace(metersPerSecond: (before + after) / 2))"
+            }
+        } else if let speed = beforeAvg ?? afterAvg {
+            result += "\n[\(timeStr)] at \(formatPace(metersPerSecond: speed))"
+        }
+    }
+    return result
+}
+
+private static func formatPace(metersPerSecond: Double) -> String {
+    guard metersPerSecond > 0 else { return "—" }
+    let usesMiles = Locale.current.measurementSystem == .us
+    let metersPerUnit: Double = usesMiles ? 1609.34 : 1000.0
+    let label = usesMiles ? "min/mi" : "min/km"
+    let secondsPerUnit = metersPerUnit / metersPerSecond
+    let minutes = Int(secondsPerUnit) / 60
+    let seconds = Int(secondsPerUnit) % 60
+    return String(format: "%d:%02d %@", minutes, seconds, label)
+}
+```
+
+Pass through to `buildPrompt` and insert after location section.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Models/PromptGenerator.swift UnitTests/PromptGeneratorTests.swift
+git commit -m "feat: add pace context to prompts"
+```
+
+---
+
+### Task 9: Walk-to-Walk Threading Formatter
+
+**Files:**
+- Modify: `Pilgrim/Models/PromptGenerator.swift` (add WalkSnippet, formatRecentWalks)
+- Test: `UnitTests/PromptGeneratorTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+```swift
+func testFormatRecentWalks_withSnippets_containsContinuitySection() {
+    let snippets = [
+        PromptGenerator.WalkSnippet(
+            date: DateFactory.makeDate(2024, 6, 12, 9, 0, 0),
+            placeName: nil,
+            transcriptionPreview: "I keep thinking about how the river reminds me of home"
+        ),
+        PromptGenerator.WalkSnippet(
+            date: DateFactory.makeDate(2024, 6, 10, 9, 0, 0),
+            placeName: nil,
+            transcriptionPreview: "Today I noticed I was walking faster than usual"
+        )
+    ]
+    let prompt = PromptGenerator.generate(
+        style: .reflective,
+        recordings: [],
+        meditations: [],
+        duration: 1800,
+        distance: 2000,
+        startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+        recentWalkSnippets: snippets
+    )
+    XCTAssertTrue(prompt.text.contains("Recent Walk Context"))
+    XCTAssertTrue(prompt.text.contains("river reminds me of home"))
+}
+
+func testFormatRecentWalks_empty_omitsSection() {
+    let prompt = PromptGenerator.generate(
+        style: .reflective,
+        recordings: [],
+        meditations: [],
+        duration: 1800,
+        distance: 2000,
+        startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+        recentWalkSnippets: []
+    )
+    XCTAssertFalse(prompt.text.contains("Recent Walk Context"))
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Expected: FAIL — `recentWalkSnippets` parameter doesn't exist
+
+- [ ] **Step 3: Add WalkSnippet and formatter**
+
+```swift
+struct WalkSnippet {
+    let date: Date
+    let placeName: String?
+    let transcriptionPreview: String
+}
+
+private static let shortDateFormatter: DateFormatter = {
+    let f = DateFormatter()
+    f.dateFormat = "MMM d"
+    return f
+}()
+
+private static func formatRecentWalks(_ snippets: [WalkSnippet]) -> String? {
+    guard !snippets.isEmpty else { return nil }
+    let lines = snippets.map { snippet in
+        let dateStr = shortDateFormatter.string(from: snippet.date)
+        if let place = snippet.placeName {
+            return "[\(dateStr) – \(place)] \"\(snippet.transcriptionPreview)\""
+        }
+        return "[\(dateStr)] \"\(snippet.transcriptionPreview)\""
+    }
+    return "**Recent Walk Context (for continuity):**\n\n" + lines.joined(separator: "\n\n")
+}
+```
+
+Add `recentWalkSnippets: [WalkSnippet] = []` to `generate()`. Pass through to `buildPrompt` and insert after meditation sessions, before the `---` divider.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Models/PromptGenerator.swift UnitTests/PromptGeneratorTests.swift
+git commit -m "feat: add walk-to-walk threading context to prompts"
+```
+
+---
+
+### Task 10: Custom Prompt Generation + generateAll Update
+
+**Files:**
+- Modify: `Pilgrim/Models/PromptGenerator.swift` (add generateCustom, update generateAll)
+- Test: `UnitTests/PromptGeneratorTests.swift`
+
+- [ ] **Step 1: Write failing test**
+
+```swift
+func testGenerateCustom_usesCustomInstruction() {
+    let custom = CustomPromptStyle(id: UUID(), title: "Letter", icon: "envelope.fill", instruction: "Write this as a letter to my future self")
+    let prompt = PromptGenerator.generateCustom(
+        customStyle: custom,
+        recordings: [],
+        meditations: [],
+        duration: 1800,
+        distance: 2000,
+        startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+    )
+    XCTAssertTrue(prompt.text.contains("letter to my future self"))
+    XCTAssertNil(prompt.style)
+    XCTAssertEqual(prompt.customStyle?.title, "Letter")
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Expected: FAIL — `generateCustom` doesn't exist
+
+- [ ] **Step 3: Add generateCustom method**
+
+```swift
+static func generateCustom(
+    customStyle: CustomPromptStyle,
+    recordings: [RecordingContext],
+    meditations: [MeditationContext],
+    duration: Double,
+    distance: Double,
+    startDate: Date,
+    placeNames: [PlaceContext] = [],
+    routeSpeeds: [Double] = [],
+    recentWalkSnippets: [WalkSnippet] = []
+) -> GeneratedPrompt {
+    let combinedText = formatRecordings(recordings)
+    let meditationText = formatMeditations(meditations)
+    let metadata = formatMetadata(duration: duration, distance: distance, startDate: startDate)
+    let location = formatPlaceNames(placeNames)
+    let pace = formatPaceContext(speeds: routeSpeeds)
+    let recentWalks = formatRecentWalks(recentWalkSnippets)
+
+    let preamble = "These are voice recordings captured during a walk, transcribed as spoken. They represent unfiltered thoughts, observations, and feelings that surfaced while moving."
+
+    let prompt = buildPrompt(
+        preamble: preamble,
+        instruction: customStyle.instruction,
+        transcription: combinedText,
+        meditations: meditationText,
+        metadata: metadata,
+        location: location,
+        pace: pace,
+        recentWalks: recentWalks
+    )
+    return GeneratedPrompt(style: nil, customStyle: customStyle, text: prompt)
+}
+```
+
+This requires refactoring `buildPrompt` to accept `preamble` and `instruction` as strings instead of deriving them from `PromptStyle`. Extract the style switch into the caller (`generate`), and have `buildPrompt` be purely about assembling sections.
+
+- [ ] **Step 4: Refactor buildPrompt signature**
+
+Change `buildPrompt` from:
+```swift
+private static func buildPrompt(style: PromptStyle, transcription: String, meditations: String?, metadata: String) -> String
+```
+to:
+```swift
+private static func buildPrompt(preamble: String, instruction: String, transcription: String, meditations: String?, metadata: String, location: String?, pace: String?, recentWalks: String?) -> String
+```
+
+Move the style switch (preamble/instruction lookup) into `generate()`, then call `buildPrompt` with extracted strings.
+
+- [ ] **Step 5: Update generateAll to forward new parameters**
+
+Update `generateAll` to accept and forward all new parameters:
+```swift
+static func generateAll(
+    recordings: [RecordingContext],
+    meditations: [MeditationContext],
+    duration: Double,
+    distance: Double,
+    startDate: Date,
+    placeNames: [PlaceContext] = [],
+    routeSpeeds: [Double] = [],
+    recentWalkSnippets: [WalkSnippet] = []
+) -> [GeneratedPrompt] {
+    PromptStyle.allCases.map { style in
+        generate(
+            style: style,
+            recordings: recordings,
+            meditations: meditations,
+            duration: duration,
+            distance: distance,
+            startDate: startDate,
+            placeNames: placeNames,
+            routeSpeeds: routeSpeeds,
+            recentWalkSnippets: recentWalkSnippets
+        )
+    }
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Expected: All tests PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Pilgrim/Models/PromptGenerator.swift UnitTests/PromptGeneratorTests.swift
+git commit -m "feat: add custom prompt generation and refactor buildPrompt"
+```
+
+---
+
+## Chunk 3: Custom Prompt Styles UI
+
+### Task 11: CustomPromptStyleStore
+
+**Files:**
+- Modify: `Pilgrim/Models/CustomPromptStyleStore.swift` (add store class)
+- Test: `UnitTests/CustomPromptStyleStoreTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `UnitTests/CustomPromptStyleStoreTests.swift`:
+
+```swift
+import XCTest
+@testable import Pilgrim
+
+final class CustomPromptStyleStoreTests: XCTestCase {
+
+    private var store: CustomPromptStyleStore!
+    private let testKey = "TestCustomPromptStyles"
+
+    override func setUp() {
+        super.setUp()
+        UserDefaults.standard.removeObject(forKey: testKey)
+        store = CustomPromptStyleStore(userDefaultsKey: testKey)
+    }
+
+    override func tearDown() {
+        UserDefaults.standard.removeObject(forKey: testKey)
+        super.tearDown()
+    }
+
+    func testInitialState_empty() {
+        XCTAssertTrue(store.styles.isEmpty)
+        XCTAssertTrue(store.canAddMore)
+    }
+
+    func testSave_addsStyle() {
+        let style = CustomPromptStyle(id: UUID(), title: "Test", icon: "star", instruction: "Do a thing")
+        store.save(style)
+        XCTAssertEqual(store.styles.count, 1)
+        XCTAssertEqual(store.styles.first?.title, "Test")
+    }
+
+    func testSave_persistsToUserDefaults() {
+        let style = CustomPromptStyle(id: UUID(), title: "Persisted", icon: "star", instruction: "Persist")
+        store.save(style)
+        let reloaded = CustomPromptStyleStore(userDefaultsKey: testKey)
+        XCTAssertEqual(reloaded.styles.count, 1)
+        XCTAssertEqual(reloaded.styles.first?.title, "Persisted")
+    }
+
+    func testCanAddMore_falseAtMax() {
+        for i in 0..<CustomPromptStyleStore.maxStyles {
+            store.save(CustomPromptStyle(id: UUID(), title: "Style \(i)", icon: "star", instruction: "Inst"))
+        }
+        XCTAssertFalse(store.canAddMore)
+    }
+
+    func testDelete_removesStyle() {
+        let style = CustomPromptStyle(id: UUID(), title: "Delete Me", icon: "star", instruction: "Inst")
+        store.save(style)
+        store.delete(style)
+        XCTAssertTrue(store.styles.isEmpty)
+    }
+
+    func testSave_existingId_updatesInPlace() {
+        let id = UUID()
+        store.save(CustomPromptStyle(id: id, title: "Original", icon: "star", instruction: "V1"))
+        store.save(CustomPromptStyle(id: id, title: "Updated", icon: "star", instruction: "V2"))
+        XCTAssertEqual(store.styles.count, 1)
+        XCTAssertEqual(store.styles.first?.title, "Updated")
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Expected: FAIL — CustomPromptStyleStore class doesn't exist
+
+- [ ] **Step 3: Implement CustomPromptStyleStore**
+
+In `Pilgrim/Models/CustomPromptStyleStore.swift`, add below the existing struct:
+
+```swift
+final class CustomPromptStyleStore: ObservableObject {
+    static let maxStyles = 3
+
+    @Published private(set) var styles: [CustomPromptStyle]
+
+    private let userDefaultsKey: String
+
+    init(userDefaultsKey: String = "CustomPromptStyles") {
+        self.userDefaultsKey = userDefaultsKey
+        if let data = UserDefaults.standard.data(forKey: userDefaultsKey),
+           let decoded = try? JSONDecoder().decode([CustomPromptStyle].self, from: data) {
+            styles = decoded
+        } else {
+            styles = []
+        }
+    }
+
+    var canAddMore: Bool { styles.count < Self.maxStyles }
+
+    func save(_ style: CustomPromptStyle) {
+        if let index = styles.firstIndex(where: { $0.id == style.id }) {
+            styles[index] = style
+        } else {
+            guard canAddMore else { return }
+            styles.append(style)
+        }
+        persist()
+    }
+
+    func delete(_ style: CustomPromptStyle) {
+        styles.removeAll { $0.id == style.id }
+        persist()
+    }
+
+    private func persist() {
+        if let data = try? JSONEncoder().encode(styles) {
+            UserDefaults.standard.set(data, forKey: userDefaultsKey)
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Expected: All tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Models/CustomPromptStyleStore.swift UnitTests/CustomPromptStyleStoreTests.swift
+git commit -m "feat: add CustomPromptStyleStore with UserDefaults persistence"
+```
+
+---
+
+### Task 12: CustomPromptEditorView
+
+**Files:**
+- Create: `Pilgrim/Scenes/Prompts/CustomPromptEditorView.swift`
+
+- [ ] **Step 1: Create the editor view**
+
+```swift
+import SwiftUI
+
+struct CustomPromptEditorView: View {
+    @Environment(\.dismiss) private var dismiss
+    @ObservedObject var store: CustomPromptStyleStore
+
+    var editingStyle: CustomPromptStyle?
+
+    @State private var title: String = ""
+    @State private var selectedIcon: String = "pencil.line"
+    @State private var instruction: String = ""
+
+    private let iconOptions = [
+        "pencil.line", "text.quote", "envelope.fill", "lightbulb.fill",
+        "flame.fill", "leaf.fill", "wind", "drop.fill",
+        "sun.max.fill", "moon.fill", "star.fill", "sparkles",
+        "figure.walk", "mountain.2.fill", "water.waves", "bird.fill",
+        "hands.clap.fill", "brain.head.profile", "book.fill", "music.note"
+    ]
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(alignment: .leading, spacing: Constants.UI.Padding.big) {
+                    titleSection
+                    iconSection
+                    instructionSection
+                }
+                .padding(Constants.UI.Padding.normal)
+            }
+            .background(Color.parchment)
+            .navigationTitle(editingStyle == nil ? "New Prompt Style" : "Edit Prompt Style")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundColor(.stone)
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Save") { saveAndDismiss() }
+                        .foregroundColor(.stone)
+                        .disabled(title.trimmingCharacters(in: .whitespaces).isEmpty ||
+                                  instruction.trimmingCharacters(in: .whitespaces).isEmpty)
+                }
+            }
+        }
+        .onAppear {
+            if let editing = editingStyle {
+                title = editing.title
+                selectedIcon = editing.icon
+                instruction = editing.instruction
+            }
+        }
+    }
+
+    private var titleSection: some View {
+        VStack(alignment: .leading, spacing: Constants.UI.Padding.small) {
+            Text("Title")
+                .font(Constants.Typography.heading)
+                .foregroundColor(.ink)
+            TextField("e.g., Letter to Future Self", text: $title)
+                .font(Constants.Typography.body)
+                .textFieldStyle(.roundedBorder)
+        }
+    }
+
+    private var iconSection: some View {
+        VStack(alignment: .leading, spacing: Constants.UI.Padding.small) {
+            Text("Icon")
+                .font(Constants.Typography.heading)
+                .foregroundColor(.ink)
+            LazyVGrid(columns: Array(repeating: GridItem(.flexible()), count: 5), spacing: 12) {
+                ForEach(iconOptions, id: \.self) { icon in
+                    Button {
+                        selectedIcon = icon
+                    } label: {
+                        Image(systemName: icon)
+                            .font(.title3)
+                            .frame(width: 44, height: 44)
+                            .foregroundColor(selectedIcon == icon ? .parchment : .stone)
+                            .background(selectedIcon == icon ? Color.stone : Color.parchmentSecondary)
+                            .cornerRadius(Constants.UI.CornerRadius.small)
+                    }
+                }
+            }
+        }
+    }
+
+    private var instructionSection: some View {
+        VStack(alignment: .leading, spacing: Constants.UI.Padding.small) {
+            Text("Instruction")
+                .font(Constants.Typography.heading)
+                .foregroundColor(.ink)
+            TextEditor(text: $instruction)
+                .font(Constants.Typography.body)
+                .frame(minHeight: 120)
+                .scrollContentBackground(.hidden)
+                .padding(Constants.UI.Padding.small)
+                .background(Color.parchmentSecondary)
+                .cornerRadius(Constants.UI.CornerRadius.small)
+                .overlay(
+                    Group {
+                        if instruction.isEmpty {
+                            Text("Tell the AI what to do with your walking thoughts...")
+                                .font(Constants.Typography.body)
+                                .foregroundColor(.fog)
+                                .padding(Constants.UI.Padding.small + 4)
+                        }
+                    },
+                    alignment: .topLeading
+                )
+
+            Text("\(store.styles.count + (editingStyle == nil ? 1 : 0)) of \(CustomPromptStyleStore.maxStyles)")
+                .font(Constants.Typography.caption)
+                .foregroundColor(.fog)
+                .frame(maxWidth: .infinity, alignment: .trailing)
+        }
+    }
+
+    private func saveAndDismiss() {
+        let style = CustomPromptStyle(
+            id: editingStyle?.id ?? UUID(),
+            title: title.trimmingCharacters(in: .whitespaces),
+            icon: selectedIcon,
+            instruction: instruction.trimmingCharacters(in: .whitespaces)
+        )
+        store.save(style)
+        dismiss()
+    }
+}
+```
+
+- [ ] **Step 2: Verify project compiles**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add Pilgrim/Scenes/Prompts/CustomPromptEditorView.swift
+git commit -m "feat: add CustomPromptEditorView with icon picker and instruction editor"
+```
+
+---
+
+### Task 13: PromptListView — Custom Styles + Async Geocoding + Threading
+
+**Files:**
+- Modify: `Pilgrim/Scenes/Prompts/PromptListView.swift`
+- Modify: `Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift:55-59` (pass recentWalkSnippets)
+
+- [ ] **Step 1: Update PromptListView to accept recentWalkSnippets and add custom style support**
+
+Add new properties:
+```swift
+let recentWalkSnippets: [PromptGenerator.WalkSnippet]
+@StateObject private var customStyleStore = CustomPromptStyleStore()
+@State private var showEditor = false
+@State private var editingStyle: CustomPromptStyle?
+@State private var geocodedPlaces: [PromptGenerator.PlaceContext] = []
+```
+
+- [ ] **Step 2: Update List body to show custom styles + create row**
+
+Replace the List body:
+```swift
+List {
+    Section {
+        ForEach(prompts) { prompt in
+            Button { selectedPrompt = prompt } label: {
+                PromptStyleRow(prompt: prompt)
+            }
+            .listRowBackground(Color.parchment)
+        }
+    }
+
+    if !customStyleStore.styles.isEmpty {
+        Section {
+            ForEach(customPrompts) { prompt in
+                Button { selectedPrompt = prompt } label: {
+                    PromptStyleRow(prompt: prompt)
+                }
+                .listRowBackground(Color.parchment)
+            }
+            .onDelete { offsets in
+                for index in offsets {
+                    customStyleStore.delete(customStyleStore.styles[index])
+                }
+                regenerateCustomPrompts()
+            }
+        }
+    }
+
+    Section {
+        createYourOwnRow
+            .listRowBackground(Color.parchment)
+    }
+}
+```
+
+- [ ] **Step 3: Add createYourOwnRow and custom prompts state**
+
+```swift
+@State private var customPrompts: [GeneratedPrompt] = []
+
+private var createYourOwnRow: some View {
+    Button {
+        guard customStyleStore.canAddMore else { return }
+        editingStyle = nil
+        showEditor = true
+    } label: {
+        HStack(spacing: 12) {
+            Image(systemName: "plus.circle.fill")
+                .font(.title2)
+                .foregroundColor(customStyleStore.canAddMore ? .stone : .fog)
+                .frame(width: 40)
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Create Your Own")
+                    .font(Constants.Typography.heading)
+                    .foregroundColor(customStyleStore.canAddMore ? .ink : .fog)
+                Text("\(customStyleStore.styles.count) of \(CustomPromptStyleStore.maxStyles) custom styles")
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog)
+            }
+            Spacer()
+        }
+        .padding(.vertical, Constants.UI.Padding.small)
+    }
+    .disabled(!customStyleStore.canAddMore)
+}
+```
+
+- [ ] **Step 4: Make generatePrompts async with geocoding**
+
+Convert `generatePrompts()` to async. Add geocoding:
+
+```swift
+private func generatePrompts() {
+    guard prompts.isEmpty else { return }
+    Task {
+        let routeSamples = walk.routeData
+        let placeNames = await geocodeWalkRoute(routeSamples)
+        geocodedPlaces = placeNames
+        let routeSpeeds = routeSamples.map { $0.speed }
+
+        let recordings = walk.voiceRecordings.compactMap { recording -> PromptGenerator.RecordingContext? in
+            guard let uuid = recording.uuid,
+                  let text = transcriptions[uuid] else { return nil }
+            let startCoord = closestCoordinate(to: recording.startDate, in: routeSamples)
+            let endCoord = closestCoordinate(to: recording.endDate, in: routeSamples)
+            return PromptGenerator.RecordingContext(
+                text: text,
+                timestamp: recording.startDate,
+                startCoordinate: startCoord,
+                endCoordinate: endCoord,
+                wordsPerMinute: recording.wordsPerMinute
+            )
+        }.sorted { $0.timestamp < $1.timestamp }
+
+        let meditations = walk.activityIntervals
+            .filter { $0.activityType == .meditation }
+            .sorted { $0.startDate < $1.startDate }
+            .map { PromptGenerator.MeditationContext(startDate: $0.startDate, endDate: $0.endDate, duration: $0.duration) }
+
+        prompts = PromptGenerator.generateAll(
+            recordings: recordings,
+            meditations: meditations,
+            duration: walk.activeDuration,
+            distance: walk.distance,
+            startDate: walk.startDate,
+            placeNames: placeNames,
+            routeSpeeds: routeSpeeds,
+            recentWalkSnippets: recentWalkSnippets
+        )
+        regenerateCustomPrompts()
+    }
+}
+```
+
+- [ ] **Step 5: Add geocoding helper**
+
+```swift
+private func geocodeWalkRoute(_ samples: [RouteDataSampleInterface]) async -> [PromptGenerator.PlaceContext] {
+    guard let first = samples.first, let last = samples.last else { return [] }
+    let geocoder = CLGeocoder()
+    var places: [PromptGenerator.PlaceContext] = []
+
+    if let name = await reverseGeocode(geocoder: geocoder, lat: first.latitude, lon: first.longitude, delay: false) {
+        places.append(PromptGenerator.PlaceContext(name: name, coordinate: (lat: first.latitude, lon: first.longitude), role: .start))
+    }
+
+    let distance = CLLocation(latitude: first.latitude, longitude: first.longitude)
+        .distance(from: CLLocation(latitude: last.latitude, longitude: last.longitude))
+    if distance > 500, let name = await reverseGeocode(geocoder: geocoder, lat: last.latitude, lon: last.longitude) {
+        places.append(PromptGenerator.PlaceContext(name: name, coordinate: (lat: last.latitude, lon: last.longitude), role: .end))
+    }
+
+    if walk.distance > 2000 {
+        let midIndex = samples.count / 2
+        let mid = samples[midIndex]
+        if let name = await reverseGeocode(geocoder: geocoder, lat: mid.latitude, lon: mid.longitude) {
+            places.append(PromptGenerator.PlaceContext(name: name, coordinate: (lat: mid.latitude, lon: mid.longitude), role: .midpoint))
+        }
+    }
+
+    return places
+}
+
+private func reverseGeocode(geocoder: CLGeocoder, lat: Double, lon: Double, delay: Bool = true) async -> String? {
+    do {
+        if delay {
+            try await Task.sleep(nanoseconds: 1_100_000_000)
+        }
+        let placemarks = try await geocoder.reverseGeocodeLocation(CLLocation(latitude: lat, longitude: lon))
+        guard let pm = placemarks.first else { return nil }
+        let parts = [pm.name, pm.locality].compactMap { $0 }
+        return parts.isEmpty ? nil : parts.joined(separator: ", ")
+    } catch {
+        return nil
+    }
+}
+```
+
+Add `import CoreLocation` at top of file.
+
+- [ ] **Step 6: Add regenerateCustomPrompts helper and sheet for editor**
+
+```swift
+private func regenerateCustomPrompts() {
+    // Uses same context as built-in prompts but with custom styles
+    let routeSamples = walk.routeData
+    let routeSpeeds = routeSamples.map { $0.speed }
+    let recordings = walk.voiceRecordings.compactMap { recording -> PromptGenerator.RecordingContext? in
+        guard let uuid = recording.uuid,
+              let text = transcriptions[uuid] else { return nil }
+        return PromptGenerator.RecordingContext(
+            text: text,
+            timestamp: recording.startDate,
+            startCoordinate: closestCoordinate(to: recording.startDate, in: routeSamples),
+            endCoordinate: closestCoordinate(to: recording.endDate, in: routeSamples),
+            wordsPerMinute: recording.wordsPerMinute
+        )
+    }.sorted { $0.timestamp < $1.timestamp }
+    let meditations = walk.activityIntervals
+        .filter { $0.activityType == .meditation }
+        .sorted { $0.startDate < $1.startDate }
+        .map { PromptGenerator.MeditationContext(startDate: $0.startDate, endDate: $0.endDate, duration: $0.duration) }
+
+    customPrompts = customStyleStore.styles.map { customStyle in
+        PromptGenerator.generateCustom(
+            customStyle: customStyle,
+            recordings: recordings,
+            meditations: meditations,
+            duration: walk.activeDuration,
+            distance: walk.distance,
+            startDate: walk.startDate,
+            placeNames: geocodedPlaces,
+            routeSpeeds: routeSpeeds,
+            recentWalkSnippets: recentWalkSnippets
+        )
+    }
+}
+```
+
+Add `.sheet(isPresented: $showEditor)` for the editor:
+```swift
+.sheet(isPresented: $showEditor) {
+    CustomPromptEditorView(store: customStyleStore, editingStyle: editingStyle)
+}
+.onChange(of: showEditor) { showing in
+    if !showing { regenerateCustomPrompts() }
+}
+```
+
+- [ ] **Step 7: Update WalkSummaryView to pass recentWalkSnippets**
+
+In `WalkSummaryView.swift` (lines 55-59), update the PromptListView call to fetch and pass recent walk snippets:
+
+Add a computed property or method that queries recent walks:
+```swift
+private var recentWalkSnippets: [PromptGenerator.WalkSnippet] {
+    guard let walks = try? DataManager.dataStack.fetchAll(
+        From<Walk>()
+            .where(\._startDate < walk.startDate)
+            .orderBy(.descending(\._startDate))
+    ) else { return [] }
+
+    let shortDateFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "MMM d"
+        return f
+    }()
+
+    return walks
+        .filter { w in w.voiceRecordings.contains { $0.transcription != nil } }
+        .prefix(3)
+        .map { w in
+            let allText = w.voiceRecordings
+                .compactMap { $0.transcription }
+                .joined(separator: " ")
+            let preview = String(allText.prefix(200)).truncatedAtWordBoundary()
+            return PromptGenerator.WalkSnippet(date: w.startDate, placeName: nil, transcriptionPreview: preview)
+        }
+}
+```
+
+Add a String extension for word-boundary truncation (in PromptGenerator.swift or as a small extension):
+```swift
+extension String {
+    func truncatedAtWordBoundary(maxLength: Int = 200) -> String {
+        guard count > maxLength else { return self }
+        let truncated = prefix(maxLength)
+        if let lastSpace = truncated.lastIndex(of: " ") {
+            return String(truncated[..<lastSpace]) + "..."
+        }
+        return String(truncated) + "..."
+    }
+}
+```
+
+Update the sheet:
+```swift
+PromptListView(walk: walk, transcriptions: transcriptions, recentWalkSnippets: recentWalkSnippets)
+```
+
+Add `import CoreStore` to WalkSummaryView if not already present.
+
+- [ ] **Step 8: Verify project compiles**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 9: Run all tests**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | grep -E '(Test Case|BUILD|Executed)'`
+Expected: All tests PASS
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add Pilgrim/Scenes/Prompts/PromptListView.swift \
+        Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift \
+        Pilgrim/Models/PromptGenerator.swift
+git commit -m "feat: add custom styles, geocoding, and walk threading to PromptListView"
+```
+
+---
+
+## Chunk 4: Deep Links UI
+
+### Task 14: PromptDetailView — AI Deep Link Pills
+
+**Files:**
+- Modify: `Pilgrim/Scenes/Prompts/PromptDetailView.swift`
+
+- [ ] **Step 1: Add state for AI pills**
+
+Add to PromptDetailView state:
+```swift
+@State private var showAIPills = false
+```
+
+- [ ] **Step 2: Update copy button action**
+
+Replace the copy button action (lines 49-56) to use 8-second unified timer:
+
+```swift
+Button {
+    UIPasteboard.general.string = prompt.text
+    withAnimation(.easeOut(duration: 0.15)) { copyScale = 0.95 }
+    withAnimation(.easeOut(duration: 0.15).delay(0.15)) { copyScale = 1.0 }
+    showCopiedFeedback = true
+    withAnimation(.easeOut(duration: 0.3)) { showAIPills = true }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 8) {
+        withAnimation {
+            showCopiedFeedback = false
+            showAIPills = false
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Add AI pills view below action buttons**
+
+Replace `actionButtons` with a VStack that includes the pills:
+
+```swift
+private var actionButtons: some View {
+    VStack(spacing: Constants.UI.Padding.small) {
+        HStack(spacing: Constants.UI.Padding.normal) {
+            // ... existing copy button ...
+            // ... existing share button ...
+        }
+
+        if showAIPills {
+            VStack(spacing: Constants.UI.Padding.small) {
+                Text("Paste in your favorite AI")
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog)
+
+                HStack(spacing: Constants.UI.Padding.small) {
+                    aiPill(name: "ChatGPT", url: "https://chat.openai.com/")
+                    aiPill(name: "Claude", url: "https://claude.ai/new")
+                }
+            }
+            .transition(.move(edge: .bottom).combined(with: .opacity))
+        }
+    }
+}
+
+private func aiPill(name: String, url: String) -> some View {
+    Button {
+        if let url = URL(string: url) {
+            UIApplication.shared.open(url)
+        }
+    } label: {
+        HStack(spacing: 4) {
+            Text(name)
+                .font(Constants.Typography.caption)
+                .fontWeight(.semibold)
+            Image(systemName: "arrow.up.right")
+                .font(.caption2)
+        }
+        .foregroundColor(.stone)
+        .padding(.horizontal, Constants.UI.Padding.normal)
+        .padding(.vertical, Constants.UI.Padding.small)
+        .background(Color.parchmentSecondary)
+        .clipShape(Capsule())
+    }
+}
+```
+
+- [ ] **Step 4: Verify project compiles**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 5: Run all tests**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | grep -E '(Test Case|BUILD|Executed)'`
+Expected: All tests PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Pilgrim/Scenes/Prompts/PromptDetailView.swift
+git commit -m "feat: add AI deep link pills to PromptDetailView"
+```
+
+---
+
+### Task 15: Final Integration Test
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | grep -E '(Test Case|BUILD|Executed)'`
+Expected: All tests PASS, BUILD SUCCEEDED
+
+- [ ] **Step 2: Run SwiftLint**
+
+Run: `Pods/SwiftLint/swiftlint lint --config .swiftlint.yml 2>&1 | tail -10`
+Expected: No errors (warnings acceptable)
+
+- [ ] **Step 3: Commit any lint fixes if needed**
+
+Stage only the specific files that were modified for lint fixes, then commit:
+```bash
+git commit -m "chore: fix lint warnings"
+```

--- a/docs/superpowers/specs/2026-03-13-prompt-enhancements-design.md
+++ b/docs/superpowers/specs/2026-03-13-prompt-enhancements-design.md
@@ -1,0 +1,310 @@
+# Prompt Enhancements Design
+
+Enhance the AI prompt generation system with richer context, sharing options, and user customization.
+
+## Features
+
+### 1. Reverse Geocoding
+
+Convert GPS coordinates to human-readable place names using `CLGeocoder`.
+
+**Data source:** Existing route GPS samples — no new storage.
+
+**Geocoding targets:**
+- Start location (first route sample)
+- End location (last route sample, only if > 500m from start)
+- Midpoint (middle route sample, only if walk > 2km)
+
+**Implementation:**
+- `PromptListView.generatePrompts()` becomes async
+- Geocodes 1–3 points sequentially (CLGeocoder rate limit: ~1 req/sec)
+- Extracts neighborhood + city from `CLPlacemark`
+- Passes `[PlaceContext]` to `PromptGenerator.generate()`
+
+**New type:**
+```swift
+struct PlaceContext {
+    let name: String
+    let coordinate: (lat: Double, lon: Double)
+    let role: PlaceRole // .start, .end, .midpoint
+}
+
+enum PlaceRole { case start, end, midpoint }
+```
+
+**Prompt output:**
+```
+**Location:** Started near Riverside Park, Manhattan → ended near Central Park West
+```
+Loop walk (start ≈ end):
+```
+**Location:** Near Riverside Park, Manhattan
+```
+
+**Offline behavior:** Best-effort. CLGeocoder may use cached data offline. If geocoding fails, the section is omitted — GPS coordinates on individual recordings still appear (local data, no network). No error state, no loading spinner that hangs.
+
+**New PromptGenerator method:** `formatPlaceNames(_ places: [PlaceContext]) -> String?` — returns `nil` when empty.
+
+---
+
+### 2. Pace Context
+
+Include walking pace and per-recording speed changes in prompt context.
+
+**Data source:** `RouteDataSampleInterface.speed` (meters/second) on existing GPS samples.
+
+**Computed metrics:**
+- Average pace (min/km or min/mi based on locale)
+- Pace range (slowest/fastest, excluding stops)
+- Per-recording pace: average speed in 30-second window before and after each voice recording
+
+**Filtering:** Samples with speed < 0.3 m/s treated as stationary, excluded from calculations.
+
+**Prompt output:**
+```
+**Pace:** Average 12:30 min/km (range: 9:45–18:20)
+[9:05 AM] Recording 1: pace slowed from 11:00 to 15:30 min/km
+[9:12 AM] Recording 2: walking steadily at 12:00 min/km
+```
+
+**Graceful degradation:** Sparse GPS data (e.g., future battery-saver mode) produces simpler output — just average pace if < 10 samples, nothing if no speed data. Same `nil`-return pattern as other optional sections.
+
+**New PromptGenerator method:** `formatPaceContext(routeData: [RouteDataSampleInterface], recordings: [RecordingContext]) -> String?`
+
+---
+
+### 3. Walk-to-Walk Threading
+
+Include transcription snippets from recent walks so the AI can identify patterns across walks.
+
+**Data source:** CoreStore query of recent walks with transcriptions. No new storage.
+
+**Query:** Up to 3 most recent completed walks (before current walk's start date) that have at least one voice recording with a non-nil transcription.
+
+```swift
+From<Walk>()
+    .orderBy(.descending(\._startDate))
+    .where(\._startDate < currentWalk.startDate)
+```
+
+Filter to walks with transcribed recordings, take first 3.
+
+**Truncation:** 200 characters per walk, cut at nearest word boundary, append ellipsis.
+
+**Prompt output:**
+```
+**Recent Walk Context (for continuity):**
+
+[Jun 12 – Riverside Park] "I keep thinking about how the river reminds me of home. There's something about water that..."
+
+[Jun 10 – Central Park] "Today I noticed I was walking faster than usual. Maybe it's the anxiety about..."
+```
+
+Place name included if reverse geocoding is available for that walk (from its route data start point). Falls back to date only.
+
+**No prior walks:** Section omitted.
+
+**New PromptGenerator parameter:** `recentWalkSnippets: [WalkSnippet]`
+
+```swift
+struct WalkSnippet {
+    let date: Date
+    let placeName: String?
+    let transcriptionPreview: String // truncated to ~200 chars
+}
+```
+
+**New method:** `formatRecentWalks(_ snippets: [WalkSnippet]) -> String?`
+
+---
+
+### 4. Copy-to-Clipboard with AI Deep Links
+
+Replace single Copy button behavior with progressive disclosure of AI app shortcuts.
+
+**Layout:** Keep existing Copy + Share buttons side by side (unchanged). After tapping Copy:
+1. Prompt text copies to clipboard immediately
+2. Copy button shows "Copied!" with checkmark
+3. Below the buttons, hint pills animate in: "Paste in your favorite AI" label with "ChatGPT" and "Claude" pill buttons
+4. Pills auto-hide after ~8 seconds, Copy button resets
+
+**Deep link behavior:**
+- ChatGPT pill: `UIApplication.shared.open(URL(string: "https://chat.openai.com/")!)`
+- Claude pill: `UIApplication.shared.open(URL(string: "https://claude.ai/new")!)`
+- If app installed → opens app. If not → opens Safari.
+- Prompt is already on clipboard — user pastes manually.
+
+**Styling:**
+- Pills use `parchmentSecondary` background, `stone` text, `Constants.Typography.caption` font
+- Pill shape: `Capsule()` clip with horizontal padding
+- Slide-in animation: `.transition(.move(edge: .bottom).combined(with: .opacity))`
+
+**Share button:** Unchanged — still opens native `UIActivityViewController`.
+
+**Files modified:** `Pilgrim/Scenes/Prompts/PromptDetailView.swift` only.
+
+---
+
+### 5. Custom Prompt Styles
+
+Let users create up to 3 custom prompt styles with their own instruction.
+
+**Storage:** `[CustomPromptStyle]` JSON-encoded in UserDefaults via `CustomPromptStyleStore`.
+
+```swift
+struct CustomPromptStyle: Codable, Identifiable {
+    let id: UUID
+    var title: String
+    var icon: String        // SF Symbol name
+    var instruction: String
+}
+```
+
+```swift
+final class CustomPromptStyleStore: ObservableObject {
+    static let maxStyles = 3
+    @Published var styles: [CustomPromptStyle]
+
+    func save(_ style: CustomPromptStyle) { ... }
+    func delete(_ style: CustomPromptStyle) { ... }
+    func canAddMore: Bool { styles.count < Self.maxStyles }
+}
+```
+
+**Prompt generation:** Custom styles use a generic preamble:
+> "These are voice recordings captured during a walk, transcribed as spoken. They represent unfiltered thoughts, observations, and feelings that surfaced while moving."
+
+The user's `instruction` field replaces the style-specific instruction block. All context sections (transcriptions, GPS, pace, meditations, metadata, place names, recent walks) are included identically to built-in styles.
+
+**UI — Prompt list:**
+- Built-in styles listed first (6 rows)
+- Custom styles listed below with a section divider
+- "Create Your Own" row at the bottom with "+" icon
+- Soft counter below: "1 of 3" in caption style, fog color
+- When 3/3 used: row shows "3 of 3 custom styles", add action disabled (no alert, just visually settled)
+- Swipe-to-delete and tap-to-edit on custom style rows
+
+**UI — Creation form (sheet):**
+- Title text field
+- SF Symbol picker: grid of ~20 curated icons (walking, writing, nature, thought-related)
+- Instruction text editor (multi-line) with placeholder: "Tell the AI what to do with your walking thoughts..."
+- "1 of 3" counter near save button
+- Save and Cancel buttons
+
+**Files:**
+- New: `Pilgrim/Models/CustomPromptStyleStore.swift`
+- New: `Pilgrim/Scenes/Prompts/CustomPromptEditorView.swift`
+- Modified: `Pilgrim/Scenes/Prompts/PromptListView.swift`
+- Modified: `Pilgrim/Models/PromptGenerator.swift` (add `generateCustom()` method)
+
+---
+
+### 6. Speaking Pace Metadata
+
+Compute words-per-minute from WhisperKit transcription segments, store on VoiceRecording.
+
+**Schema change:** PilgrimV3 adds `_wordsPerMinute: Value.Optional<Double>("wordsPerMinute")` to VoiceRecording entity.
+
+**Migration:** PilgrimV2 → PilgrimV3:
+- `.transformEntity` for VoiceRecording (new attribute)
+- `.copyEntity` for all other entities (unchanged)
+
+**Computation in TranscriptionService:** After `pipe.transcribe(audioPath:)`:
+
+```swift
+let segments = results.flatMap { $0.segments }
+guard let first = segments.first, let last = segments.last,
+      last.end > first.start else { return nil }
+let wordCount = segments.flatMap { $0.words }.count
+let durationMinutes = (last.end - first.start) / 60.0
+let wpm = Double(wordCount) / durationMinutes
+```
+
+Stored via `DataManager.updateVoiceRecordingWPM(uuid:wpm:)`.
+
+**Prompt format:** Appended to each recording's header line:
+```
+[9:05 AM] [~142 wpm, measured] "The birds are singing..."
+[9:12 AM] [~85 wpm, slow/thoughtful] "Something shifted..."
+```
+
+**Qualitative labels:**
+| WPM range | Label |
+|-----------|-------|
+| < 100 | slow/thoughtful |
+| 100–140 | measured |
+| 140–170 | conversational |
+| > 170 | rapid/energized |
+
+**Backwards compatibility:** Recordings transcribed before PilgrimV3 have `nil` WPM. Header line omits the pace tag — no backfill needed.
+
+**Files modified:**
+- New: `Pilgrim/Models/Data/DataModels/Versions/PilgrimV3.swift`
+- Modified: `Pilgrim/Models/TranscriptionService.swift`
+- Modified: `Pilgrim/Models/Data/DataManager.swift` (migration chain + updateWPM method)
+- Modified: `Pilgrim/Models/Data/DataModels/VoiceRecording.swift` (type alias → PilgrimV3, interface property)
+- Modified: `Pilgrim/Protocols/DataInterfaces/VoiceRecordingInterface.swift` (add `wordsPerMinute`)
+- Modified: `Pilgrim/Models/PromptGenerator.swift` (format WPM in recording headers)
+
+---
+
+## Data Layer Summary
+
+| Feature | Storage | Source |
+|---------|---------|--------|
+| Reverse geocoding | None | Route GPS + CLGeocoder (async, best-effort) |
+| Pace context | None | Route speed samples |
+| Walk-to-walk threading | None | CoreStore query of recent walks |
+| Copy + deep links | None | UI-only |
+| Custom prompt styles | UserDefaults (JSON) | User input |
+| Speaking pace | PilgrimV3: `wordsPerMinute` on VoiceRecording | WhisperKit segments |
+
+One schema migration (PilgrimV3) for one new field. Everything else is computed or UI.
+
+---
+
+## PromptGenerator.generate() — Updated Signature
+
+```swift
+static func generate(
+    style: PromptStyle,
+    recordings: [RecordingContext],
+    meditations: [MeditationContext],
+    duration: Double,
+    distance: Double,
+    startDate: Date,
+    placeNames: [PlaceContext] = [],
+    routeData: [RouteDataSampleInterface] = [],
+    recentWalkSnippets: [WalkSnippet] = []
+) -> GeneratedPrompt
+```
+
+All new parameters default to empty — existing call sites continue to work unchanged.
+
+**buildPrompt() section order:**
+1. Preamble (style-specific or generic for custom)
+2. `---`
+3. Context: metadata line
+4. Location (if geocoded)
+5. Pace (if route data available)
+6. Walking Transcription (with WPM tags on headers)
+7. Meditation Sessions (if any)
+8. Recent Walk Context (if any)
+9. `---`
+10. Instruction (style-specific or custom)
+
+---
+
+## Key Design Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Geocoding timing | On-the-fly in PromptListView | No storage, always fresh, graceful offline fallback |
+| Pace filtering | < 0.3 m/s = stationary | Excludes GPS drift at rest |
+| Threading depth | 3 recent walks, 200 chars each | Small prompt footprint, enough for pattern detection |
+| Deep link method | Universal links + clipboard | Always works, no undocumented URL schemes |
+| Custom style storage | UserDefaults JSON | Lightweight, not walk data, no schema change |
+| Custom style cap | 3 maximum | Keeps list manageable, surfaced via soft counter |
+| WPM storage | Single Double on VoiceRecording | Word-level timestamps discarded after computation |
+| WPM backfill | None | Enrichment, not critical — nil means no tag shown |
+| Silence gaps | Removed | Meditation sessions already capture intentional silence |

--- a/docs/superpowers/specs/2026-03-13-prompt-enhancements-design.md
+++ b/docs/superpowers/specs/2026-03-13-prompt-enhancements-design.md
@@ -99,12 +99,12 @@ Post-filter in memory: keep only walks with at least one voice recording where `
 ```
 **Recent Walk Context (for continuity):**
 
-[Jun 12 – Riverside Park] "I keep thinking about how the river reminds me of home. There's something about water that..."
+[Jun 12] "I keep thinking about how the river reminds me of home. There's something about water that..."
 
-[Jun 10 – Central Park] "Today I noticed I was walking faster than usual. Maybe it's the anxiety about..."
+[Jun 10] "Today I noticed I was walking faster than usual. Maybe it's the anxiety about..."
 ```
 
-Place name included if reverse geocoding is available for that walk (from its route data start point). Falls back to date only.
+Date-only headers for prior walks (no geocoding to avoid rate-limit delays).
 
 **No prior walks:** Section omitted.
 
@@ -318,6 +318,8 @@ static func generate(
 ```
 
 All new parameters default to empty — existing call sites continue to work unchanged.
+
+**RecordingContext extension:** Add `wordsPerMinute: Double?` field (default `nil`) to `PromptGenerator.RecordingContext` so WPM data flows from `VoiceRecordingInterface` through to the prompt formatter.
 
 **buildPrompt() section order:**
 1. Preamble (style-specific or generic for custom)

--- a/docs/superpowers/specs/2026-03-13-prompt-enhancements-design.md
+++ b/docs/superpowers/specs/2026-03-13-prompt-enhancements-design.md
@@ -13,7 +13,7 @@ Convert GPS coordinates to human-readable place names using `CLGeocoder`.
 **Geocoding targets:**
 - Start location (first route sample)
 - End location (last route sample, only if > 500m from start)
-- Midpoint (middle route sample, only if walk > 2km)
+- Midpoint (route sample at median index, only if walk > 2km)
 
 **Implementation:**
 - `PromptListView.generatePrompts()` becomes async
@@ -79,15 +79,19 @@ Include transcription snippets from recent walks so the AI can identify patterns
 
 **Data source:** CoreStore query of recent walks with transcriptions. No new storage.
 
-**Query:** Up to 3 most recent completed walks (before current walk's start date) that have at least one voice recording with a non-nil transcription.
+**Query location:** `PromptListView` does not have direct DataManager access. The parent view (`WalkSummaryView`) fetches recent walk snippets and passes them to `PromptListView` as a new `recentWalkSnippets: [WalkSnippet]` init parameter. The query uses `dataStack.fetchAll` directly (not `queryObjects`, which lacks `orderBy` support):
 
 ```swift
-From<Walk>()
-    .orderBy(.descending(\._startDate))
-    .where(\._startDate < currentWalk.startDate)
+let recentWalks = DataManager.dataStack.fetchAll(
+    From<Walk>()
+        .where(\._startDate < currentWalk.startDate)
+        .orderBy(.descending(\._startDate))
+)
 ```
 
-Filter to walks with transcribed recordings, take first 3.
+Post-filter in memory: keep only walks with at least one voice recording where `transcription != nil`. Take first 3. For each, concatenate transcriptions and truncate to 200 characters at nearest word boundary.
+
+**Recent walk place names:** Skip geocoding for prior walks to avoid rate-limit delays. Use date-only headers (`[Jun 12]`). Place names are only geocoded for the current walk.
 
 **Truncation:** 200 characters per walk, cut at nearest word boundary, append ellipsis.
 
@@ -126,7 +130,7 @@ Replace single Copy button behavior with progressive disclosure of AI app shortc
 1. Prompt text copies to clipboard immediately
 2. Copy button shows "Copied!" with checkmark
 3. Below the buttons, hint pills animate in: "Paste in your favorite AI" label with "ChatGPT" and "Claude" pill buttons
-4. Pills auto-hide after ~8 seconds, Copy button resets
+4. "Copied!" state and pills stay visible together for ~8 seconds, then both reset simultaneously (replaces the existing 2-second reset timer)
 
 **Deep link behavior:**
 - ChatGPT pill: `UIApplication.shared.open(URL(string: "https://chat.openai.com/")!)`
@@ -167,14 +171,33 @@ final class CustomPromptStyleStore: ObservableObject {
 
     func save(_ style: CustomPromptStyle) { ... }
     func delete(_ style: CustomPromptStyle) { ... }
-    func canAddMore: Bool { styles.count < Self.maxStyles }
+    var canAddMore: Bool { styles.count < Self.maxStyles }
 }
 ```
 
-**Prompt generation:** Custom styles use a generic preamble:
+**Integration with GeneratedPrompt:** `GeneratedPrompt` currently requires `style: PromptStyle`. To accommodate custom styles, extend the model:
+
+```swift
+struct GeneratedPrompt: Identifiable {
+    let id = UUID()
+    let style: PromptStyle?           // nil for custom styles
+    let customStyle: CustomPromptStyle? // nil for built-in styles
+    let text: String
+
+    var title: String { customStyle?.title ?? style!.title }
+    var icon: String { customStyle?.icon ?? style!.icon }
+    var subtitle: String { customStyle?.instruction ?? style!.description }
+}
+```
+
+`PromptStyleRow` and `PromptDetailView` read `prompt.title`, `prompt.icon`, and `prompt.subtitle` instead of `prompt.style.title`, `prompt.style.icon`, and `prompt.style.description`. For custom styles, `subtitle` shows the first line of the user's instruction as a preview.
+
+**Prompt generation:** A new `generateCustom()` method handles custom styles with a generic preamble:
 > "These are voice recordings captured during a walk, transcribed as spoken. They represent unfiltered thoughts, observations, and feelings that surfaced while moving."
 
 The user's `instruction` field replaces the style-specific instruction block. All context sections (transcriptions, GPS, pace, meditations, metadata, place names, recent walks) are included identically to built-in styles.
+
+**Store injection:** `CustomPromptStyleStore` is instantiated as a `@StateObject` in `PromptListView`.
 
 **UI — Prompt list:**
 - Built-in styles listed first (6 rows)
@@ -215,12 +238,25 @@ Compute words-per-minute from WhisperKit transcription segments, store on VoiceR
 let segments = results.flatMap { $0.segments }
 guard let first = segments.first, let last = segments.last,
       last.end > first.start else { return nil }
-let wordCount = segments.flatMap { $0.words }.count
+
+// Prefer word-level timestamps when available (model-dependent).
+// Fall back to splitting segment text on whitespace for word count.
+let wordCount: Int
+let words = segments.flatMap { $0.words }
+if !words.isEmpty {
+    wordCount = words.count
+} else {
+    wordCount = segments.flatMap { $0.text.split(separator: " ") }.count
+}
+guard wordCount > 0 else { return nil }
+
 let durationMinutes = (last.end - first.start) / 60.0
 let wpm = Double(wordCount) / durationMinutes
 ```
 
-Stored via `DataManager.updateVoiceRecordingWPM(uuid:wpm:)`.
+Stored via `DataManager.updateVoiceRecordingWordsPerMinute(uuid:wordsPerMinute:)`.
+
+**Note:** The `tiny` model variant may not produce word-level timestamps (`.words` can be empty). The whitespace-split fallback ensures WPM is always computable when text exists.
 
 **Prompt format:** Appended to each recording's header line:
 ```
@@ -241,9 +277,11 @@ Stored via `DataManager.updateVoiceRecordingWPM(uuid:wpm:)`.
 **Files modified:**
 - New: `Pilgrim/Models/Data/DataModels/Versions/PilgrimV3.swift`
 - Modified: `Pilgrim/Models/TranscriptionService.swift`
-- Modified: `Pilgrim/Models/Data/DataManager.swift` (migration chain + updateWPM method)
+- Modified: `Pilgrim/Models/Data/DataManager.swift` (migration chain, `updateVoiceRecordingWordsPerMinute(uuid:wordsPerMinute:)` method, default `dataModel` parameter → `PilgrimV3.self`, and `saveWalks`/`updateWalk` methods to copy `wordsPerMinute` field during persistence)
 - Modified: `Pilgrim/Models/Data/DataModels/VoiceRecording.swift` (type alias → PilgrimV3, interface property)
 - Modified: `Pilgrim/Protocols/DataInterfaces/VoiceRecordingInterface.swift` (add `wordsPerMinute`)
+- Modified: `Pilgrim/Models/Data/Temp/Versions/TempV4.swift` (add `wordsPerMinute` to `TempV4.VoiceRecording`)
+- Modified: `Pilgrim/Models/Data/Temp/Temp.swift` (add `wordsPerMinute` to `TempVoiceRecording` convenience init and interface conformance)
 - Modified: `Pilgrim/Models/PromptGenerator.swift` (format WPM in recording headers)
 
 ---


### PR DESCRIPTION
## Summary

- **PilgrimV3 schema**: New CoreStore version adding `wordsPerMinute` to VoiceRecording with migration from PilgrimV2
- **Speaking pace metadata**: Compute WPM from WhisperKit transcription segments, display qualitative labels (slow/thoughtful, measured, conversational, rapid) in prompt context
- **Reverse geocoding**: Convert walk route start/end GPS coordinates to place names via CLGeocoder
- **Walking pace context**: Include average pace and range (min/mi or min/km based on locale) in prompts
- **Walk-to-walk threading**: Include transcription snippets from up to 3 recent walks for continuity
- **Copy-to-clipboard with AI deep links**: Progressive disclosure of ChatGPT/Claude pills after copying prompt text
- **Custom prompt styles**: User-created styles (max 3) with title, icon picker, and custom instruction, persisted via UserDefaults
- **Meditation context**: Include meditation session times and durations in generated prompts

23 files changed, ~1300 lines added. 28 new tests (22 PromptGenerator + 6 CustomPromptStyleStore).

## Test plan

- [x] All 87 unit tests pass (`xcodebuild test`)
- [x] Build succeeds with no new lint errors
- [x] Migration from PilgrimV1 to PilgrimV3 verified on simulator
- [ ] Manual: Record walk with voice recordings, verify prompts include place names, pace, and WPM labels
- [ ] Manual: Create/edit/delete custom prompt styles, verify max-3 cap
- [ ] Manual: Copy prompt, verify AI pills appear and dismiss after 8 seconds
- [ ] Manual: Verify walk-to-walk threading shows snippets from previous walks

🤖 Generated with [Claude Code](https://claude.com/claude-code)