### PR TITLE
feat: walk favicons — flame, leaf, star icons

### DIFF
--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -205,6 +205,9 @@
 		FE15922AE9DAD82F62BA4601 /* NewWalkComputationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E892B071C7BE6EBD74F3FC /* NewWalkComputationTests.swift */; };
 		3F8E37CD28D541C1838F01BD /* PilgrimV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2722224F049B455DB473E7C9 /* PilgrimV2.swift */; };
 		A1B2C3D4E5F601020304050B /* PilgrimV3.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F601020304050A /* PilgrimV3.swift */; };
+		F1A2B3C4D5E6F7A8B9C0D1E3 /* WalkFavicon.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7A8B9C0D1E2 /* WalkFavicon.swift */; };
+		F1A2B3C4D5E6F7A8B9C0D1E5 /* PilgrimV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7A8B9C0D1E4 /* PilgrimV4.swift */; };
+		F1A2B3C4D5E6F7A8B9C0D1E7 /* FaviconSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7A8B9C0D1E6 /* FaviconSelectorView.swift */; };
 		9726AFAB9F744FDA86EEC2CF /* ActivityInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA57CE96EE3401595264807 /* ActivityInterval.swift */; };
 		EF1533CDBBC5498EA3BFDFC6 /* ActivityIntervalInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964D4C7663494F3ABBEEF84F /* ActivityIntervalInterface.swift */; };
 		08508B6253B3427ABA939DED /* ActivityTimelineBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CBD6B08E4C437DA90FDDB0 /* ActivityTimelineBar.swift */; };
@@ -449,6 +452,9 @@
 		EC2D4ACA7F21BA80523DF98C /* DateFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DateFactory.swift; sourceTree = "<group>"; };
 		2722224F049B455DB473E7C9 /* PilgrimV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV2.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F601020304050A /* PilgrimV3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV3.swift; sourceTree = "<group>"; };
+		F1A2B3C4D5E6F7A8B9C0D1E2 /* WalkFavicon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkFavicon.swift; sourceTree = "<group>"; };
+		F1A2B3C4D5E6F7A8B9C0D1E4 /* PilgrimV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV4.swift; sourceTree = "<group>"; };
+		F1A2B3C4D5E6F7A8B9C0D1E6 /* FaviconSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconSelectorView.swift; sourceTree = "<group>"; };
 		1BA57CE96EE3401595264807 /* ActivityInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityInterval.swift; sourceTree = "<group>"; };
 		964D4C7663494F3ABBEEF84F /* ActivityIntervalInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIntervalInterface.swift; sourceTree = "<group>"; };
 		C9CBD6B08E4C437DA90FDDB0 /* ActivityTimelineBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityTimelineBar.swift; sourceTree = "<group>"; };
@@ -558,6 +564,7 @@
 				BB00AA010000000000000001 /* PilgrimV1.swift */,
 				2722224F049B455DB473E7C9 /* PilgrimV2.swift */,
 				A1B2C3D4E5F601020304050A /* PilgrimV3.swift */,
+				F1A2B3C4D5E6F7A8B9C0D1E4 /* PilgrimV4.swift */,
 			);
 			path = Versions;
 			sourceTree = "<group>";
@@ -972,6 +979,7 @@
 				CC00000100000000WKMODE01 /* WalkMode.swift */,
 				22A0FAF224D8D4B7000292DF /* WalkCompletionActionHandler.swift */,
 				225BB02E2716E61000478E09 /* StatsHelper.swift */,
+				F1A2B3C4D5E6F7A8B9C0D1E2 /* WalkFavicon.swift */,
 			);
 			path = Walk;
 			sourceTree = "<group>";
@@ -1092,6 +1100,7 @@
 				D2FDF0BD38D9467B99B2C4D7 /* ActivityListView.swift */,
 				C9CBD6B08E4C437DA90FDDB0 /* ActivityTimelineBar.swift */,
 				4B6BF30D6A9C48219D3C115C /* PaceSparklineView.swift */,
+				F1A2B3C4D5E6F7A8B9C0D1E6 /* FaviconSelectorView.swift */,
 			);
 			path = WalkSummary;
 			sourceTree = "<group>";
@@ -1547,6 +1556,9 @@
 				1B1EF52AF234570C6DDAE905 /* SoundscapePlayer.swift in Sources */,
 				2E59989F7B4496B95EBB0AB7 /* SoundManagement.swift in Sources */,
 				ACF07FD2C47613FD87D08EE7 /* SoundSettingsView.swift in Sources */,
+				F1A2B3C4D5E6F7A8B9C0D1E3 /* WalkFavicon.swift in Sources */,
+				F1A2B3C4D5E6F7A8B9C0D1E5 /* PilgrimV4.swift in Sources */,
+				F1A2B3C4D5E6F7A8B9C0D1E7 /* FaviconSelectorView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pilgrim/Models/Data/DataManager.swift
+++ b/Pilgrim/Models/Data/DataManager.swift
@@ -52,7 +52,7 @@ struct DataManager {
      - parameter migration: the closure being called on the event of a migration happening, including a `Progress` object indicating the progress of the migration
      - warning: If this method fails it does so in a fatal error, the app will crash as a result.
      */
-    public static func setup(dataModel: DataModelProtocol.Type = PilgrimV3.self, completion: @escaping (DataManager.SetupError?) -> Void, migration: @escaping (Progress) -> Void) {
+    public static func setup(dataModel: DataModelProtocol.Type = PilgrimV4.self, completion: @escaping (DataManager.SetupError?) -> Void, migration: @escaping (Progress) -> Void) {
         
         let completion = safeClosure(from: completion)
         
@@ -209,6 +209,8 @@ struct DataManager {
                 walk._talkDuration .= object.talkDuration
                 walk._meditateDuration .= object.meditateDuration
 
+                walk._favicon .= object.favicon
+
                 persistRelatedEntities(from: object, to: walk, in: transaction)
                 walks.append(walk)
 
@@ -353,6 +355,7 @@ struct DataManager {
                 walk._dayIdentifier .= object.dayIdentifier
                 walk._talkDuration .= object.talkDuration
                 walk._meditateDuration .= object.meditateDuration
+                walk._favicon .= object.favicon
 
                 for tempPause in object.pauses where tempPause.uuid == nil {
                     let pause = transaction.create(Into<WalkPause>())
@@ -488,6 +491,22 @@ struct DataManager {
         }) { result in
             if case .failure(let error) = result {
                 print("[DataManager] Failed to update WPM for \(uuid): \(error)")
+            }
+        }
+    }
+
+    // MARK: - Favicon
+
+    public static func setFavicon(walkID: UUID, favicon: WalkFavicon?) {
+        dataStack.perform(asynchronous: { transaction -> Void in
+            if let walk = transaction.edit(
+                queryObject(from: walkID, transaction: transaction) as Walk?
+            ) {
+                walk._favicon .= favicon?.rawValue
+            }
+        }) { result in
+            if case .failure(let error) = result {
+                print("[DataManager] Failed to set favicon: \(error)")
             }
         }
     }

--- a/Pilgrim/Models/Data/DataModels/ActivityInterval.swift
+++ b/Pilgrim/Models/Data/DataModels/ActivityInterval.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CoreStore
 
-public typealias ActivityInterval = PilgrimV3.ActivityInterval
+public typealias ActivityInterval = PilgrimV4.ActivityInterval
 
 extension PilgrimV2.ActivityInterval {
 

--- a/Pilgrim/Models/Data/DataModels/Event.swift
+++ b/Pilgrim/Models/Data/DataModels/Event.swift
@@ -21,7 +21,7 @@
 
 import Foundation
 
-public typealias Event = PilgrimV3.Event
+public typealias Event = PilgrimV4.Event
 
 // MARK: CustomStringConvertible
 

--- a/Pilgrim/Models/Data/DataModels/HeartRateDataSample.swift
+++ b/Pilgrim/Models/Data/DataModels/HeartRateDataSample.swift
@@ -21,7 +21,7 @@
 
 import Foundation
 
-public typealias HeartRateDataSample = PilgrimV3.WorkoutHeartRateDataSample
+public typealias HeartRateDataSample = PilgrimV4.WorkoutHeartRateDataSample
 
 // MARK: - CustomStringConvertible
 

--- a/Pilgrim/Models/Data/DataModels/RouteDataSample.swift
+++ b/Pilgrim/Models/Data/DataModels/RouteDataSample.swift
@@ -22,7 +22,7 @@
 import Foundation
 import CoreLocation
 
-public typealias RouteDataSample = PilgrimV3.WorkoutRouteDataSample
+public typealias RouteDataSample = PilgrimV4.WorkoutRouteDataSample
 
 // MARK: - CustomStringConvertible
 

--- a/Pilgrim/Models/Data/DataModels/Versions/PilgrimV4.swift
+++ b/Pilgrim/Models/Data/DataModels/Versions/PilgrimV4.swift
@@ -1,0 +1,248 @@
+import CoreStore
+
+public enum PilgrimV4: DataModelProtocol {
+
+    static let identifier = "PilgrimV4"
+    static let schema = CoreStoreSchema(
+        modelVersion: PilgrimV4.identifier,
+        entities: [
+            Entity<PilgrimV4.Workout>(PilgrimV4.Workout.identifier),
+            Entity<PilgrimV4.WorkoutPause>(PilgrimV4.WorkoutPause.identifier),
+            Entity<PilgrimV4.WorkoutEvent>(PilgrimV4.WorkoutEvent.identifier),
+            Entity<PilgrimV4.WorkoutRouteDataSample>(PilgrimV4.WorkoutRouteDataSample.identifier),
+            Entity<PilgrimV4.WorkoutHeartRateDataSample>(PilgrimV4.WorkoutHeartRateDataSample.identifier),
+            Entity<PilgrimV4.Event>(PilgrimV4.Event.identifier),
+            Entity<PilgrimV4.VoiceRecording>(PilgrimV4.VoiceRecording.identifier),
+            Entity<PilgrimV4.ActivityInterval>(PilgrimV4.ActivityInterval.identifier)
+        ]
+    )
+
+    static let mappingProvider: CustomSchemaMappingProvider? = CustomSchemaMappingProvider(
+        from: PilgrimV3.identifier,
+        to: PilgrimV4.identifier,
+        entityMappings: [
+            .transformEntity(
+                sourceEntity: PilgrimV3.Workout.identifier,
+                destinationEntity: PilgrimV4.Workout.identifier,
+                transformer: { (sourceObject: CustomSchemaMappingProvider.UnsafeSourceObject, createDestinationObject: () -> CustomSchemaMappingProvider.UnsafeDestinationObject) in
+                    let destinationObject = createDestinationObject()
+                    destinationObject.enumerateAttributes { (attribute, sourceAttribute) in
+                        if let sourceAttribute = sourceAttribute {
+                            destinationObject[attribute] = sourceObject[sourceAttribute]
+                        }
+                    }
+                }
+            ),
+            .transformEntity(
+                sourceEntity: PilgrimV3.WorkoutPause.identifier,
+                destinationEntity: PilgrimV4.WorkoutPause.identifier,
+                transformer: { (source: CustomSchemaMappingProvider.UnsafeSourceObject, create: () -> CustomSchemaMappingProvider.UnsafeDestinationObject) in
+                    let dest = create()
+                    dest.enumerateAttributes { (attr, srcAttr) in if let srcAttr { dest[attr] = source[srcAttr] } }
+                }
+            ),
+            .transformEntity(
+                sourceEntity: PilgrimV3.WorkoutEvent.identifier,
+                destinationEntity: PilgrimV4.WorkoutEvent.identifier,
+                transformer: { (source: CustomSchemaMappingProvider.UnsafeSourceObject, create: () -> CustomSchemaMappingProvider.UnsafeDestinationObject) in
+                    let dest = create()
+                    dest.enumerateAttributes { (attr, srcAttr) in if let srcAttr { dest[attr] = source[srcAttr] } }
+                }
+            ),
+            .transformEntity(
+                sourceEntity: PilgrimV3.WorkoutRouteDataSample.identifier,
+                destinationEntity: PilgrimV4.WorkoutRouteDataSample.identifier,
+                transformer: { (source: CustomSchemaMappingProvider.UnsafeSourceObject, create: () -> CustomSchemaMappingProvider.UnsafeDestinationObject) in
+                    let dest = create()
+                    dest.enumerateAttributes { (attr, srcAttr) in if let srcAttr { dest[attr] = source[srcAttr] } }
+                }
+            ),
+            .transformEntity(
+                sourceEntity: PilgrimV3.WorkoutHeartRateDataSample.identifier,
+                destinationEntity: PilgrimV4.WorkoutHeartRateDataSample.identifier,
+                transformer: { (source: CustomSchemaMappingProvider.UnsafeSourceObject, create: () -> CustomSchemaMappingProvider.UnsafeDestinationObject) in
+                    let dest = create()
+                    dest.enumerateAttributes { (attr, srcAttr) in if let srcAttr { dest[attr] = source[srcAttr] } }
+                }
+            ),
+            .transformEntity(
+                sourceEntity: PilgrimV3.Event.identifier,
+                destinationEntity: PilgrimV4.Event.identifier,
+                transformer: { (source: CustomSchemaMappingProvider.UnsafeSourceObject, create: () -> CustomSchemaMappingProvider.UnsafeDestinationObject) in
+                    let dest = create()
+                    dest.enumerateAttributes { (attr, srcAttr) in if let srcAttr { dest[attr] = source[srcAttr] } }
+                }
+            ),
+            .transformEntity(
+                sourceEntity: PilgrimV3.VoiceRecording.identifier,
+                destinationEntity: PilgrimV4.VoiceRecording.identifier,
+                transformer: { (source: CustomSchemaMappingProvider.UnsafeSourceObject, create: () -> CustomSchemaMappingProvider.UnsafeDestinationObject) in
+                    let dest = create()
+                    dest.enumerateAttributes { (attr, srcAttr) in if let srcAttr { dest[attr] = source[srcAttr] } }
+                }
+            ),
+            .transformEntity(
+                sourceEntity: PilgrimV3.ActivityInterval.identifier,
+                destinationEntity: PilgrimV4.ActivityInterval.identifier,
+                transformer: { (source: CustomSchemaMappingProvider.UnsafeSourceObject, create: () -> CustomSchemaMappingProvider.UnsafeDestinationObject) in
+                    let dest = create()
+                    dest.enumerateAttributes { (attr, srcAttr) in if let srcAttr { dest[attr] = source[srcAttr] } }
+                }
+            )
+        ]
+    )
+
+    static let migrationChain: [DataModelProtocol.Type] = [
+        OutRunV1.self, OutRunV2.self, OutRunV3.self, OutRunV3to4.self, OutRunV4.self, PilgrimV1.self, PilgrimV2.self, PilgrimV3.self, PilgrimV4.self
+    ]
+
+    // MARK: Workout
+    public final class Workout: CoreStoreObject, DataTypeProtocol {
+
+        static let identifier = "Workout"
+
+        let _uuid = Value.Optional<UUID>("id")
+        let _workoutType = Value.Required<PilgrimV2.Workout.WalkType>("workoutType", initial: .unknown)
+        let _distance = Value.Required<Double>("distance", initial: -1)
+        let _steps = Value.Optional<Int>("steps")
+        let _startDate = Value.Required<Date>("startDate", initial: .init(timeIntervalSince1970: 0))
+        let _endDate = Value.Required<Date>("endDate", initial: .init(timeIntervalSince1970: 0))
+        let _burnedEnergy = Value.Optional<Double>("burnedEnergy")
+        let _isRace = Value.Required<Bool>("isRace", initial: false)
+        let _comment = Value.Optional<String>("comment")
+        let _isUserModified = Value.Required<Bool>("isUserModified", initial: false)
+        let _healthKitUUID = Value.Optional<UUID>("healthKitID")
+        let _finishedRecording = Value.Required<Bool>("finishedRecording", initial: true)
+
+        let _ascend = Value.Required<Double>("ascendingAltitude", initial: 0)
+        let _descend = Value.Required<Double>("descendingAltitude", initial: 0)
+        let _activeDuration = Value.Required<Double>("activeDuration", initial: 0)
+        let _pauseDuration = Value.Required<Double>("pauseDuration", initial: 0)
+        let _dayIdentifier = Value.Required<String>("dayIdentifier", initial: "")
+
+        let _talkDuration = Value.Required<Double>("talkDuration", initial: 0)
+        let _meditateDuration = Value.Required<Double>("meditateDuration", initial: 0)
+
+        let _weatherTemperature = Value.Optional<Double>("weatherTemperature")
+        let _weatherCondition = Value.Optional<String>("weatherCondition")
+        let _weatherHumidity = Value.Optional<Double>("weatherHumidity")
+        let _weatherWindSpeed = Value.Optional<Double>("weatherWindSpeed")
+
+        let _favicon = Value.Optional<String>("favicon")
+
+        let _heartRates = Relationship.ToManyOrdered<PilgrimV4.WorkoutHeartRateDataSample>("heartRates", inverse: { $0._workout })
+        let _routeData = Relationship.ToManyOrdered<PilgrimV4.WorkoutRouteDataSample>("routeData", inverse: { $0._workout })
+        let _pauses = Relationship.ToManyOrdered<PilgrimV4.WorkoutPause>("pauses", inverse: { $0._workout })
+        let _workoutEvents = Relationship.ToManyOrdered<PilgrimV4.WorkoutEvent>("workoutEvents", inverse: { $0._workout })
+        let _events = Relationship.ToManyUnordered<PilgrimV4.Event>("events", inverse: { $0._workouts })
+        let _voiceRecordings = Relationship.ToManyOrdered<PilgrimV4.VoiceRecording>("voiceRecordings", inverse: { $0._workout })
+        let _activityIntervals = Relationship.ToManyOrdered<PilgrimV4.ActivityInterval>("activityIntervals", inverse: { $0._workout })
+
+    }
+
+    // MARK: WorkoutPause
+    public final class WorkoutPause: CoreStoreObject, DataTypeProtocol {
+
+        static let identifier = "WorkoutPause"
+
+        let _uuid = Value.Optional<UUID>("id")
+        let _startDate = Value.Required<Date>("startDate", initial: .init(timeIntervalSince1970: 0))
+        let _endDate = Value.Required<Date>("endDate", initial: .init(timeIntervalSince1970: 0))
+        let _pauseType = Value.Required<PilgrimV2.WorkoutPause.PauseType>("pauseType", initial: .manual)
+
+        let _workout = Relationship.ToOne<PilgrimV4.Workout>("workout")
+
+    }
+
+    // MARK: WorkoutEvent
+    public final class WorkoutEvent: CoreStoreObject, DataTypeProtocol {
+
+        static let identifier = "WorkoutEvent"
+
+        let _uuid = Value.Optional<UUID>("id")
+        let _eventType = Value.Required<PilgrimV2.WorkoutEvent.EventType>("eventType", initial: .unknown)
+        let _timestamp = Value.Required<Date>("timestamp", initial: .init(timeIntervalSince1970: 0), renamingIdentifier: "startDate")
+
+        let _workout = Relationship.ToOne<PilgrimV4.Workout>("workout")
+
+    }
+
+    // MARK: WorkoutRouteDataSample
+    public final class WorkoutRouteDataSample: CoreStoreObject, DataTypeProtocol {
+
+        static let identifier = "WorkoutRouteDataSample"
+
+        let _uuid = Value.Optional<UUID>("id")
+        let _timestamp = Value.Required<Date>("timestamp", initial: .init(timeIntervalSince1970: 0))
+        let _latitude = Value.Required<Double>("latitude", initial: -1)
+        let _longitude = Value.Required<Double>("longitude", initial: -1)
+        let _altitude = Value.Required<Double>("altitude", initial: -1)
+        let _horizontalAccuracy = Value.Required<Double>("horizontalAccuracy", initial: 0)
+        let _verticalAccuracy = Value.Required<Double>("verticalAccuracy", initial: 0)
+        let _speed = Value.Required<Double>("speed", initial: -1)
+        let _direction = Value.Required<Double>("direction", initial: -1)
+
+        let _workout = Relationship.ToOne<PilgrimV4.Workout>("workout")
+
+    }
+
+    // MARK: WorkoutHeartRateDataSample
+    public final class WorkoutHeartRateDataSample: CoreStoreObject, DataTypeProtocol {
+
+        static let identifier = "WorkoutHeartRateSample"
+
+        let _uuid = Value.Optional<UUID>("id")
+        let _heartRate = Value.Required<Int>("heartRate", initial: 0)
+        let _timestamp = Value.Required<Date>("timestamp", initial: .init(timeIntervalSince1970: 0))
+
+        let _workout = Relationship.ToOne<PilgrimV4.Workout>("workout")
+
+    }
+
+    // MARK: Event
+    public final class Event: CoreStoreObject, DataTypeProtocol {
+
+        static let identifier = "Event"
+
+        let _uuid = Value.Optional<UUID>("id")
+        let _title = Value.Required<String>("eventTitle", initial: "")
+        let _comment = Value.Optional<String>("comment")
+        let _startDate = Value.Optional<Date>("startDate")
+        let _endDate = Value.Optional<Date>("endDate")
+
+        let _workouts = Relationship.ToManyOrdered<PilgrimV4.Workout>("workouts")
+
+    }
+
+    // MARK: VoiceRecording
+    public final class VoiceRecording: CoreStoreObject, DataTypeProtocol {
+
+        static let identifier = "VoiceRecording"
+
+        let _uuid = Value.Optional<UUID>("id")
+        let _startDate = Value.Required<Date>("startDate", initial: .init(timeIntervalSince1970: 0))
+        let _endDate = Value.Required<Date>("endDate", initial: .init(timeIntervalSince1970: 0))
+        let _duration = Value.Required<Double>("duration", initial: 0)
+        let _fileRelativePath = Value.Required<String>("fileRelativePath", initial: "")
+        let _transcription = Value.Optional<String>("transcription")
+        let _wordsPerMinute = Value.Optional<Double>("wordsPerMinute")
+
+        let _workout = Relationship.ToOne<PilgrimV4.Workout>("workout")
+
+    }
+
+    // MARK: ActivityInterval
+    public final class ActivityInterval: CoreStoreObject, DataTypeProtocol {
+
+        static let identifier = "ActivityInterval"
+
+        let _uuid = Value.Optional<UUID>("id")
+        let _activityType = Value.Required<PilgrimV2.ActivityInterval.ActivityType>("activityType", initial: .unknown)
+        let _startDate = Value.Required<Date>("startDate", initial: .init(timeIntervalSince1970: 0))
+        let _endDate = Value.Required<Date>("endDate", initial: .init(timeIntervalSince1970: 0))
+
+        let _workout = Relationship.ToOne<PilgrimV4.Workout>("workout")
+
+    }
+
+}

--- a/Pilgrim/Models/Data/DataModels/VoiceRecording.swift
+++ b/Pilgrim/Models/Data/DataModels/VoiceRecording.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CoreStore
 
-public typealias VoiceRecording = PilgrimV3.VoiceRecording
+public typealias VoiceRecording = PilgrimV4.VoiceRecording
 
 extension VoiceRecording: VoiceRecordingInterface {
 

--- a/Pilgrim/Models/Data/DataModels/Walk.swift
+++ b/Pilgrim/Models/Data/DataModels/Walk.swift
@@ -23,7 +23,7 @@ import Foundation
 import CoreLocation
 import CoreStore
 
-public typealias Walk = PilgrimV3.Workout
+public typealias Walk = PilgrimV4.Workout
 
 extension PilgrimV2.Workout {
 
@@ -142,6 +142,7 @@ extension Walk: WalkInterface {
     public var voiceRecordings: [VoiceRecordingInterface] { threadSafeSyncReturn { self._voiceRecordings.value } }
     public var heartRates: [HeartRateDataSampleInterface] { threadSafeSyncReturn { self._heartRates.value } }
     public var activityIntervals: [ActivityIntervalInterface] { threadSafeSyncReturn { self._activityIntervals.value } }
+    public var favicon: String? { threadSafeSyncReturn { self._favicon.value } }
 
 }
 
@@ -176,7 +177,8 @@ extension Walk: TempValueConvertible {
                 pauses: self._pauses.value.map { $0.asTemp },
                 workoutEvents: self._workoutEvents.value.map { $0.asTemp },
                 voiceRecordings: self._voiceRecordings.value.map { $0.asTemp },
-                activityIntervals: self._activityIntervals.value.map { $0.asTemp }
+                activityIntervals: self._activityIntervals.value.map { $0.asTemp },
+                favicon: self._favicon.value
             )
         }
     }

--- a/Pilgrim/Models/Data/DataModels/WalkEvent.swift
+++ b/Pilgrim/Models/Data/DataModels/WalkEvent.swift
@@ -22,7 +22,7 @@
 import Foundation
 import CoreStore
 
-public typealias WalkEvent = PilgrimV3.WorkoutEvent
+public typealias WalkEvent = PilgrimV4.WorkoutEvent
 
 extension PilgrimV2.WorkoutEvent {
 

--- a/Pilgrim/Models/Data/DataModels/WalkPause.swift
+++ b/Pilgrim/Models/Data/DataModels/WalkPause.swift
@@ -22,7 +22,7 @@
 import Foundation
 import CoreStore
 
-public typealias WalkPause = PilgrimV3.WorkoutPause
+public typealias WalkPause = PilgrimV4.WorkoutPause
 
 extension PilgrimV2.WorkoutPause {
 

--- a/Pilgrim/Models/Data/Temp/Temp.swift
+++ b/Pilgrim/Models/Data/Temp/Temp.swift
@@ -54,7 +54,8 @@ extension TempWalk: WalkInterface, Identifiable {
             pauses: object.pauses.map { .init(from: $0) },
             workoutEvents: object.workoutEvents.map { .init(from: $0) },
             voiceRecordings: object.voiceRecordings.map { .init(from: $0) },
-            activityIntervals: object.activityIntervals.map { .init(from: $0) }
+            activityIntervals: object.activityIntervals.map { .init(from: $0) },
+            favicon: object.favicon
         )
     }
 }

--- a/Pilgrim/Models/Data/Temp/Versions/TempV4.swift
+++ b/Pilgrim/Models/Data/Temp/Versions/TempV4.swift
@@ -45,7 +45,8 @@ public enum TempV4 {
         public var dayIdentifier: String
         public var talkDuration: Double
         public var meditateDuration: Double
-        
+        public var favicon: String?
+
         var _heartRates: [TempV4.WorkoutHeartRateDataSample]
         var _routeData: [TempV4.WorkoutRouteDataSample]
         var _pauses: [TempV4.WorkoutPause]
@@ -61,7 +62,7 @@ public enum TempV4 {
         public var activityIntervals: [ActivityIntervalInterface] { _activityIntervals }
         public var events: [EventInterface] { throwOnAccess() }
         
-        public init(uuid: UUID?, workoutType: Walk.WalkType, distance: Double, steps: Int?, startDate: Date, endDate: Date, burnedEnergy: Double?, isRace: Bool, comment: String?, isUserModified: Bool, healthKitUUID: UUID?, finishedRecording: Bool, ascend: Double, descend: Double, activeDuration: Double, pauseDuration: Double, dayIdentifier: String, talkDuration: Double = 0, meditateDuration: Double = 0, heartRates: [TempV4.WorkoutHeartRateDataSample], routeData: [TempV4.WorkoutRouteDataSample], pauses: [TempV4.WorkoutPause], workoutEvents: [TempV4.WorkoutEvent], voiceRecordings: [TempV4.VoiceRecording] = [], activityIntervals: [TempV4.ActivityInterval] = []) {
+        public init(uuid: UUID?, workoutType: Walk.WalkType, distance: Double, steps: Int?, startDate: Date, endDate: Date, burnedEnergy: Double?, isRace: Bool, comment: String?, isUserModified: Bool, healthKitUUID: UUID?, finishedRecording: Bool, ascend: Double, descend: Double, activeDuration: Double, pauseDuration: Double, dayIdentifier: String, talkDuration: Double = 0, meditateDuration: Double = 0, heartRates: [TempV4.WorkoutHeartRateDataSample], routeData: [TempV4.WorkoutRouteDataSample], pauses: [TempV4.WorkoutPause], workoutEvents: [TempV4.WorkoutEvent], voiceRecordings: [TempV4.VoiceRecording] = [], activityIntervals: [TempV4.ActivityInterval] = [], favicon: String? = nil) {
             self.uuid = uuid
             self.workoutType = workoutType
             self.distance = distance
@@ -87,6 +88,7 @@ public enum TempV4 {
             self._workoutEvents = workoutEvents
             self._voiceRecordings = voiceRecordings
             self._activityIntervals = activityIntervals
+            self.favicon = favicon
         }
         
         public var asTemp: TempWalk {

--- a/Pilgrim/Models/DebugDataSeeder.swift
+++ b/Pilgrim/Models/DebugDataSeeder.swift
@@ -12,14 +12,17 @@ enum DebugDataSeeder {
         let longitude: Double
         let talkMinutes: Double
         let meditateMinutes: Double
+        let favicon: WalkFavicon?
 
         init(daysAgo: Int, hour: Int, distanceMeters: Double, durationMinutes: Double,
              latitude: Double, longitude: Double,
-             talkMinutes: Double = 0, meditateMinutes: Double = 0) {
+             talkMinutes: Double = 0, meditateMinutes: Double = 0,
+             favicon: WalkFavicon? = nil) {
             self.daysAgo = daysAgo; self.hour = hour
             self.distanceMeters = distanceMeters; self.durationMinutes = durationMinutes
             self.latitude = latitude; self.longitude = longitude
             self.talkMinutes = talkMinutes; self.meditateMinutes = meditateMinutes
+            self.favicon = favicon
         }
     }
 
@@ -33,7 +36,7 @@ enum DebugDataSeeder {
         // Spring — March/April
         WalkSpec(daysAgo: 370, hour: 7, distanceMeters: 4500, durationMinutes: 70, latitude: 35.0116, longitude: 135.7681, talkMinutes: 12, meditateMinutes: 8),
         WalkSpec(daysAgo: 355, hour: 9, distanceMeters: 5200, durationMinutes: 80, latitude: 35.0116, longitude: 135.7681),
-        WalkSpec(daysAgo: 345, hour: 6, distanceMeters: 8000, durationMinutes: 120, latitude: 35.0116, longitude: 135.7681, talkMinutes: 15, meditateMinutes: 10),
+        WalkSpec(daysAgo: 345, hour: 6, distanceMeters: 8000, durationMinutes: 120, latitude: 35.0116, longitude: 135.7681, talkMinutes: 15, meditateMinutes: 10, favicon: .star),
         WalkSpec(daysAgo: 335, hour: 8, distanceMeters: 3800, durationMinutes: 60, latitude: 35.0116, longitude: 135.7681, meditateMinutes: 15),
         WalkSpec(daysAgo: 320, hour: 7, distanceMeters: 6500, durationMinutes: 100, latitude: 34.6937, longitude: 135.5023, talkMinutes: 20),
 
@@ -42,7 +45,7 @@ enum DebugDataSeeder {
         WalkSpec(daysAgo: 275, hour: 6, distanceMeters: 15000, durationMinutes: 220, latitude: 34.6937, longitude: 135.5023, talkMinutes: 30),
         WalkSpec(daysAgo: 265, hour: 16, distanceMeters: 3500, durationMinutes: 50, latitude: 34.6937, longitude: 135.5023),
         WalkSpec(daysAgo: 255, hour: 7, distanceMeters: 9800, durationMinutes: 150, latitude: 34.6937, longitude: 135.5023, meditateMinutes: 20),
-        WalkSpec(daysAgo: 245, hour: 5, distanceMeters: 18000, durationMinutes: 280, latitude: 34.6937, longitude: 135.5023, talkMinutes: 35, meditateMinutes: 25),
+        WalkSpec(daysAgo: 245, hour: 5, distanceMeters: 18000, durationMinutes: 280, latitude: 34.6937, longitude: 135.5023, talkMinutes: 35, meditateMinutes: 25, favicon: .flame),
         WalkSpec(daysAgo: 235, hour: 8, distanceMeters: 7200, durationMinutes: 110, latitude: 43.0618, longitude: 141.3545, talkMinutes: 10),
 
         // Autumn — September/October
@@ -50,7 +53,7 @@ enum DebugDataSeeder {
         WalkSpec(daysAgo: 185, hour: 10, distanceMeters: 4200, durationMinutes: 75, latitude: 43.0618, longitude: 141.3545, talkMinutes: 8),
         WalkSpec(daysAgo: 170, hour: 14, distanceMeters: 2800, durationMinutes: 50, latitude: 43.0618, longitude: 141.3545),
         WalkSpec(daysAgo: 160, hour: 8, distanceMeters: 10500, durationMinutes: 165, latitude: 43.0618, longitude: 141.3545, talkMinutes: 18, meditateMinutes: 12),
-        WalkSpec(daysAgo: 150, hour: 7, distanceMeters: 5500, durationMinutes: 90, latitude: 35.6762, longitude: 139.6503, meditateMinutes: 15),
+        WalkSpec(daysAgo: 150, hour: 7, distanceMeters: 5500, durationMinutes: 90, latitude: 35.6762, longitude: 139.6503, meditateMinutes: 15, favicon: .leaf),
 
         // Late autumn/early winter
         WalkSpec(daysAgo: 130, hour: 11, distanceMeters: 3000, durationMinutes: 55, latitude: 35.6762, longitude: 139.6503, talkMinutes: 10),
@@ -62,9 +65,9 @@ enum DebugDataSeeder {
         WalkSpec(daysAgo: 65, hour: 8, distanceMeters: 5000, durationMinutes: 85, latitude: 35.0116, longitude: 135.7681, meditateMinutes: 12),
         WalkSpec(daysAgo: 50, hour: 7, distanceMeters: 7500, durationMinutes: 115, latitude: 35.0116, longitude: 135.7681, talkMinutes: 15),
         WalkSpec(daysAgo: 35, hour: 9, distanceMeters: 4000, durationMinutes: 65, latitude: 35.0116, longitude: 135.7681),
-        WalkSpec(daysAgo: 20, hour: 6, distanceMeters: 11000, durationMinutes: 170, latitude: 34.6937, longitude: 135.5023, talkMinutes: 22, meditateMinutes: 18),
+        WalkSpec(daysAgo: 20, hour: 6, distanceMeters: 11000, durationMinutes: 170, latitude: 34.6937, longitude: 135.5023, talkMinutes: 22, meditateMinutes: 18, favicon: .flame),
         WalkSpec(daysAgo: 10, hour: 8, distanceMeters: 6200, durationMinutes: 95, latitude: 34.6937, longitude: 135.5023, talkMinutes: 12),
-        WalkSpec(daysAgo: 5, hour: 7, distanceMeters: 8500, durationMinutes: 130, latitude: 34.6937, longitude: 135.5023, meditateMinutes: 20),
+        WalkSpec(daysAgo: 5, hour: 7, distanceMeters: 8500, durationMinutes: 130, latitude: 34.6937, longitude: 135.5023, meditateMinutes: 20, favicon: .star),
         WalkSpec(daysAgo: 2, hour: 9, distanceMeters: 3200, durationMinutes: 55, latitude: 34.6937, longitude: 135.5023, talkMinutes: 6),
         WalkSpec(daysAgo: 1, hour: 10, distanceMeters: 4500, durationMinutes: 70, latitude: 34.6937, longitude: 135.5023, talkMinutes: 10, meditateMinutes: 8),
     ]
@@ -140,6 +143,7 @@ enum DebugDataSeeder {
                 voiceRecordings: voiceRecordings,
                 activityIntervals: activityIntervals
             )
+            walk.favicon = spec.favicon?.rawValue
 
             DataManager.saveWalk(object: walk) { _, _, _ in
                 savedCount += 1

--- a/Pilgrim/Models/Walk/WalkFavicon.swift
+++ b/Pilgrim/Models/Walk/WalkFavicon.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum WalkFavicon: String, CaseIterable {
+    case flame, leaf, star
+
+    var icon: String {
+        switch self {
+        case .flame: return "flame.fill"
+        case .leaf: return "leaf.fill"
+        case .star: return "star.fill"
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .flame: return "Transformative"
+        case .leaf: return "Peaceful"
+        case .star: return "Extraordinary"
+        }
+    }
+}

--- a/Pilgrim/Protocols/DataInterfaces/WalkInterface.swift
+++ b/Pilgrim/Protocols/DataInterfaces/WalkInterface.swift
@@ -74,6 +74,8 @@ public protocol WalkInterface: DataInterface {
     var voiceRecordings: [VoiceRecordingInterface] { get }
     /// A reference to activity intervals associated with this walk.
     var activityIntervals: [ActivityIntervalInterface] { get }
+    /// An optional favicon rawValue identifying a special icon for this walk.
+    var favicon: String? { get }
 
 }
 
@@ -104,5 +106,6 @@ public extension WalkInterface {
     var events: [EventInterface] { throwOnAccess() }
     var voiceRecordings: [VoiceRecordingInterface] { throwOnAccess() }
     var activityIntervals: [ActivityIntervalInterface] { [] }
+    var favicon: String? { nil }
 
 }

--- a/Pilgrim/Scenes/Home/HomeView.swift
+++ b/Pilgrim/Scenes/Home/HomeView.swift
@@ -37,6 +37,11 @@ struct HomeView: View {
             .sheet(item: $selectedWalk) { walk in
                 WalkSummaryView(walk: walk)
             }
+            .onChange(of: selectedWalk) { old, new in
+                if old != nil && new == nil {
+                    viewModel.loadWalks()
+                }
+            }
         }
     }
 

--- a/Pilgrim/Scenes/Home/HomeViewModel.swift
+++ b/Pilgrim/Scenes/Home/HomeViewModel.swift
@@ -11,6 +11,7 @@ struct WalkSnapshot: Identifiable {
     let cumulativeDistance: Double
     let talkDuration: TimeInterval
     let meditateDuration: TimeInterval
+    let favicon: String?
 
     var walkOnlyDuration: TimeInterval {
         max(0, duration - talkDuration - meditateDuration)
@@ -84,7 +85,8 @@ class HomeViewModel: ObservableObject {
                 averagePace: pace,
                 cumulativeDistance: cumulative,
                 talkDuration: walk.talkDuration,
-                meditateDuration: walk.meditateDuration
+                meditateDuration: walk.meditateDuration,
+                favicon: walk.favicon
             ))
         }
 

--- a/Pilgrim/Scenes/Home/InkScrollView.swift
+++ b/Pilgrim/Scenes/Home/InkScrollView.swift
@@ -238,15 +238,8 @@ struct InkScrollView: View {
 
     private func breathingPulse(snapshot: WalkSnapshot, position: CGPoint) -> some View {
         let color = dotSeasonalColor(for: snapshot)
-        return Circle()
-            .fill(color.opacity(0.08))
-            .frame(width: 50, height: 50)
+        return BreathingPulseView(color: color)
             .position(position)
-            .phaseAnimator([false, true]) { content, phase in
-                content
-                    .scaleEffect(phase ? 1.3 : 0.9)
-                    .opacity(phase ? 0.0 : 0.15)
-            } animation: { _ in .easeInOut(duration: 2.5) }
     }
 
     private func dotSeasonalColor(for snapshot: WalkSnapshot) -> Color {
@@ -278,6 +271,12 @@ struct InkScrollView: View {
                         FootprintShape()
                             .fill(seasonColor.opacity(0.3))
                             .frame(width: 12, height: 18)
+
+                        if let raw = snapshot.favicon, let fav = WalkFavicon(rawValue: raw) {
+                            Image(systemName: fav.icon)
+                                .font(Constants.Typography.caption)
+                                .foregroundColor(seasonColor)
+                        }
 
                         Text(Self.expandDateFormatter.string(from: snapshot.startDate))
                             .font(Constants.Typography.annotation)
@@ -687,6 +686,21 @@ struct InkScrollView: View {
         hapticState.milestonePositions = milestonePositions.map { $0.yPosition }
     }
 
+}
+
+private struct BreathingPulseView: View {
+    let color: Color
+
+    var body: some View {
+        Circle()
+            .fill(color.opacity(0.08))
+            .frame(width: 50, height: 50)
+            .phaseAnimator([false, true]) { content, phase in
+                content
+                    .scaleEffect(phase ? 1.3 : 0.9)
+                    .opacity(phase ? 0.0 : 0.15)
+            } animation: { _ in .easeInOut(duration: 2.5) }
+    }
 }
 
 private struct SonarRingView: View {

--- a/Pilgrim/Scenes/Home/WalkDotView.swift
+++ b/Pilgrim/Scenes/Home/WalkDotView.swift
@@ -43,6 +43,8 @@ struct WalkDotView: View {
                 .opacity(opacity)
                 .shadow(color: .ink.opacity(0.15), radius: 2, x: 1, y: 2)
 
+            faviconOverlay(size: size)
+
             activityArcs(size: size)
 
             Circle()
@@ -63,6 +65,21 @@ struct WalkDotView: View {
         .position(position)
         .onTapGesture { onTap(snapshot.id) }
         .accessibilityLabel(accessibilityText)
+    }
+
+    // MARK: - Favicon overlay
+
+    @ViewBuilder
+    private func faviconOverlay(size: CGFloat) -> some View {
+        if size >= 14, let raw = snapshot.favicon, let fav = WalkFavicon(rawValue: raw) {
+            Image(systemName: fav.icon)
+                .font(size >= 18 ? Constants.Typography.caption : Constants.Typography.micro)
+                .bold()
+                .foregroundColor(.parchment)
+                .shadow(color: .ink.opacity(0.4), radius: 1, x: 0, y: 0.5)
+                .frame(width: size, height: size)
+                .opacity(opacity)
+        }
     }
 
     // MARK: - Activity arcs

--- a/Pilgrim/Scenes/Root/MainCoordinatorView.swift
+++ b/Pilgrim/Scenes/Root/MainCoordinatorView.swift
@@ -16,6 +16,7 @@ class MainCoordinator: ObservableObject {
             DataManager.saveWalk(object: snapshot) { success, error, walk in
                 guard let self else { return }
                 if success {
+                    snapshot.uuid = walk?.uuid
                     self.pendingSnapshot = snapshot
                     self.activeWalkViewModel = nil
                 } else {

--- a/Pilgrim/Scenes/WalkSummary/FaviconSelectorView.swift
+++ b/Pilgrim/Scenes/WalkSummary/FaviconSelectorView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct FaviconSelectorView: View {
+
+    @Binding var selection: WalkFavicon?
+
+    var body: some View {
+        VStack(spacing: Constants.UI.Padding.small) {
+            Text("Mark this walk")
+                .font(Constants.Typography.caption)
+                .foregroundColor(.fog)
+
+            HStack(spacing: Constants.UI.Padding.big) {
+                ForEach(WalkFavicon.allCases, id: \.self) { fav in
+                    faviconButton(fav)
+                }
+            }
+        }
+        .padding(Constants.UI.Padding.normal)
+        .background(Color.parchmentSecondary)
+        .cornerRadius(Constants.UI.CornerRadius.normal)
+    }
+
+    private func faviconButton(_ fav: WalkFavicon) -> some View {
+        let isSelected = selection == fav
+        return Button {
+            withAnimation(.easeInOut(duration: 0.2)) {
+                selection = isSelected ? nil : fav
+            }
+        } label: {
+            VStack(spacing: Constants.UI.Padding.xs) {
+                ZStack {
+                    Circle()
+                        .fill(isSelected ? Color.stone : Color.fog.opacity(0.15))
+                        .frame(width: 44, height: 44)
+
+                    Image(systemName: fav.icon)
+                        .font(Constants.Typography.statValue)
+                        .foregroundColor(isSelected ? .parchment : .fog)
+                }
+
+                Text(fav.label)
+                    .font(Constants.Typography.micro)
+                    .foregroundColor(isSelected ? .ink : .fog)
+            }
+        }
+        .accessibilityLabel(fav.label)
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+}

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
@@ -10,7 +10,13 @@ struct WalkSummaryView: View {
     @StateObject private var audioPlayer = AudioPlayerModel()
     @ObservedObject private var transcriptionService = TranscriptionService.shared
     @State private var transcriptions: [UUID: String] = [:]
+    @State private var selectedFavicon: WalkFavicon?
     @State private var showPrompts = false
+
+    init(walk: WalkInterface) {
+        self.walk = walk
+        _selectedFavicon = State(initialValue: walk.favicon.flatMap { WalkFavicon(rawValue: $0) })
+    }
     @State private var mapRegion: MKCoordinateRegion?
     @State private var recentWalkSnippets: [PromptGenerator.WalkSnippet] = []
 
@@ -20,6 +26,11 @@ struct WalkSummaryView: View {
                 VStack(spacing: Constants.UI.Padding.normal) {
                     mapSection
                     durationHero
+                    FaviconSelectorView(selection: $selectedFavicon)
+                        .onChange(of: selectedFavicon) { _, newValue in
+                            guard let uuid = walk.uuid else { return }
+                            DataManager.setFavicon(walkID: uuid, favicon: newValue)
+                        }
                     statsRow
                     timeBreakdown
                     activityTimelineBar

--- a/UnitTests/Helpers/WalkDataFactory.swift
+++ b/UnitTests/Helpers/WalkDataFactory.swift
@@ -28,7 +28,8 @@ enum WalkDataFactory {
         pauses: [TempV4.WorkoutPause] = [],
         workoutEvents: [TempV4.WorkoutEvent] = [],
         voiceRecordings: [TempV4.VoiceRecording] = [],
-        activityIntervals: [TempV4.ActivityInterval] = []
+        activityIntervals: [TempV4.ActivityInterval] = [],
+        favicon: String? = nil
     ) -> TempWalk {
         TempWalk(
             uuid: uuid, workoutType: workoutType, distance: distance, steps: steps,
@@ -40,7 +41,8 @@ enum WalkDataFactory {
             talkDuration: talkDuration, meditateDuration: meditateDuration,
             heartRates: heartRates, routeData: routeData, pauses: pauses,
             workoutEvents: workoutEvents, voiceRecordings: voiceRecordings,
-            activityIntervals: activityIntervals
+            activityIntervals: activityIntervals,
+            favicon: favicon
         )
     }
 


### PR DESCRIPTION
## Summary
- Adds optional favicon icons (flame/leaf/star) that users can assign to walks to mark them as transformative, peaceful, or extraordinary
- New CoreStore migration (PilgrimV4) adds nullable `favicon` field to Workout entity
- Favicon selector appears in post-walk summary and log detail views — tap to select, tap again to deselect
- Icons render inside the walk dot on the log page and in the expand card header
- Extracts `BreathingPulseView` to isolate infinite animation state, reducing idle CPU on the log page

## Test plan
- [x] Build succeeds (`xcodebuild build`)
- [x] All 103 tests pass (`xcodebuild test`)
- [ ] Fresh install → migration runs silently (no existing data to migrate)
- [ ] Upgrade from PilgrimV3 → PilgrimV4 migration completes without crash
- [ ] Complete a walk → summary shows favicon selector below duration
- [ ] Tap flame → icon appears selected → tap again → deselects (nil)
- [ ] Dismiss summary → return to log → dot shows favicon icon inside it
- [ ] Tap dot → expand card shows favicon icon next to date
- [ ] Tap "View details" → summary shows correct favicon selected
- [ ] Change favicon in detail view → dismiss → dot updates on log
- [ ] Walks without favicons display exactly as before (no visual change)
- [ ] Seed debug walks → 5 walks have favicons spread across the log

🤖 Generated with [Claude Code](https://claude.com/claude-code)