### PR TITLE
feat: checkpoint recovery and activity-aware power management

### DIFF
--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		764C2FC0EBC04F779B97EA92 /* WalkCheckpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74490DBCE024418B78E73B2 /* WalkCheckpoint.swift */; };
+		DAEA43ECD49D4467B169B413 /* WalkSessionGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8134F8A37D74FB3805684F1 /* WalkSessionGuard.swift */; };
 		0247093D7E5B019E36A98F9F /* AudioAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA2B0038D4875801C41DE26 /* AudioAsset.swift */; };
 		FA9B9D71DB2B3EA84CC73FEE /* AudioFileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90392F316E29A62DA1F0DE0E /* AudioFileStore.swift */; };
 		13F3292004EFCFD3572E44B9 /* AudioSessionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE6DC51742E035602E624F1 /* AudioSessionCoordinator.swift */; };
@@ -263,6 +265,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		A74490DBCE024418B78E73B2 /* WalkCheckpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkCheckpoint.swift; sourceTree = "<group>"; };
+		D8134F8A37D74FB3805684F1 /* WalkSessionGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkSessionGuard.swift; sourceTree = "<group>"; };
 		F0F0F00200000001AABBCC01 /* CormorantGaramond-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "CormorantGaramond-Light.otf"; sourceTree = "<group>"; };
 		F0F0F00200000002AABBCC02 /* CormorantGaramond-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "CormorantGaramond-Regular.otf"; sourceTree = "<group>"; };
 		F0F0F00200000003AABBCC03 /* CormorantGaramond-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "CormorantGaramond-SemiBold.otf"; sourceTree = "<group>"; };
@@ -988,6 +992,8 @@
 				22A0FAF224D8D4B7000292DF /* WalkCompletionActionHandler.swift */,
 				225BB02E2716E61000478E09 /* StatsHelper.swift */,
 				F1A2B3C4D5E6F7A8B9C0D1E2 /* WalkFavicon.swift */,
+				A74490DBCE024418B78E73B2 /* WalkCheckpoint.swift */,
+				D8134F8A37D74FB3805684F1 /* WalkSessionGuard.swift */,
 			);
 			path = Walk;
 			sourceTree = "<group>";
@@ -1363,6 +1369,8 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				764C2FC0EBC04F779B97EA92 /* WalkCheckpoint.swift in Sources */,
+				DAEA43ECD49D4467B169B413 /* WalkSessionGuard.swift in Sources */,
 				22C09B9426514BD8004AF34F /* DataInterface.swift in Sources */,
 				227C690725423294000458BC /* EventInterface.swift in Sources */,
 				22BF623D26E6B1D2008C904C /* WalkBuilderComponentStatus.swift in Sources */,

--- a/Pilgrim/AppDelegate.swift
+++ b/Pilgrim/AppDelegate.swift
@@ -35,7 +35,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ObservableObject {
         MapboxMapsOptions.tileStoreUsageMode = .readOnly
 
         DataManager.setup(
-            completion: { error in
+            completion: { _ in
                 
                 self.appLaunchState = .done
                 AudioManifestService.shared.syncIfNeeded()
@@ -61,7 +61,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ObservableObject {
                 //     }
                 // }
 
-            }, migration: { progress in
+            }, migration: { _ in
 
                 // show migration screen
                 self.appLaunchState = .migration

--- a/Pilgrim/AppDelegate.swift
+++ b/Pilgrim/AppDelegate.swift
@@ -73,6 +73,10 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ObservableObject {
     }
 
     func applicationDidEnterBackground(_ application: UIApplication) {
+        if WalkSessionGuard.active != nil {
+            print("[SessionGuard] BACKGROUND ENTRY — writing checkpoint")
+        }
+        WalkSessionGuard.active?.checkpointNow()
         WalkMapImageManager.suspendRenderProcess()
         ApplicationStateObservation.stateChanged(to: .background)
     }
@@ -82,7 +86,12 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ObservableObject {
         ApplicationStateObservation.stateChanged(to: .foreground)
     }
 
-    func applicationWillTerminate(_ application: UIApplication) {}
+    func applicationWillTerminate(_ application: UIApplication) {
+        if WalkSessionGuard.active != nil {
+            print("[SessionGuard] APP TERMINATING — writing final checkpoint")
+        }
+        WalkSessionGuard.active?.checkpointNow()
+    }
 
     enum AppLaunchState {
         case loading

--- a/Pilgrim/Models/Data/Temp/Versions/TempV4.swift
+++ b/Pilgrim/Models/Data/Temp/Versions/TempV4.swift
@@ -91,6 +91,14 @@ public enum TempV4 {
             self.favicon = favicon
         }
         
+        public func replaceActivityIntervals(_ intervals: [TempV4.ActivityInterval]) {
+            _activityIntervals = intervals
+        }
+
+        public func appendVoiceRecordings(_ recordings: [TempV4.VoiceRecording]) {
+            _voiceRecordings.append(contentsOf: recordings)
+        }
+
         public var asTemp: TempWalk {
             return self
         }

--- a/Pilgrim/Models/Walk/WalkBuilder/Components/LocationManagement.swift
+++ b/Pilgrim/Models/Walk/WalkBuilder/Components/LocationManagement.swift
@@ -128,8 +128,23 @@ public class LocationManagement: NSObject, WalkBuilderComponent, CLLocationManag
     }
     
     
+    // MARK: - Power Adjustment
+
+    private var baseAccuracy: CLLocationAccuracy = kCLLocationAccuracyBest
+    private var baseDistanceFilter: CLLocationDistance = kCLDistanceFilterNone
+
+    public func adjustPower(accuracy: CLLocationAccuracy, distanceFilter: CLLocationDistance) {
+        locationManager.desiredAccuracy = accuracy
+        locationManager.distanceFilter = distanceFilter
+    }
+
+    public func restoreDefaultPower() {
+        locationManager.desiredAccuracy = baseAccuracy
+        locationManager.distanceFilter = baseDistanceFilter
+    }
+
     // MARK: WalkBuilderComponent
-    
+
     public required init(builder: WalkBuilder) {
         super.init()
         self.builder = builder
@@ -192,6 +207,9 @@ public class LocationManagement: NSObject, WalkBuilderComponent, CLLocationManag
         self.locationManager.requestWhenInUseAuthorization()
         self.locationManager.pausesLocationUpdatesAutomatically = true
         self.locationManager.startUpdatingLocation()
+
+        self.baseAccuracy = self.locationManager.desiredAccuracy
+        self.baseDistanceFilter = self.locationManager.distanceFilter
     }
     
     // MARK: - CLLocationManagerDelegate

--- a/Pilgrim/Models/Walk/WalkBuilder/WalkBuilder.swift
+++ b/Pilgrim/Models/Walk/WalkBuilder/WalkBuilder.swift
@@ -351,19 +351,31 @@ public class WalkBuilder: ApplicationStateObserver {
     public func createCheckpointSnapshot() -> TempWalk? {
         guard let start = startDateRelay.value else { return nil }
 
+        let now = Date()
+        var pauses = pausesRelay.value
+        if let lastPause {
+            let pending = TempWalkPause(
+                uuid: nil,
+                startDate: lastPause.startingAt,
+                endDate: now,
+                pauseType: lastPause.type
+            )
+            pauses.append(pending)
+        }
+
         return NewWalk(
             workoutType: workoutTypeRelay.value,
             distance: distanceRelay.value,
             steps: stepsRelay.value,
             startDate: start,
-            endDate: Date(),
+            endDate: now,
             isRace: false,
             comment: nil,
             isUserModified: false,
             finishedRecording: false,
             heartRates: [],
             routeData: locationsRelay.value,
-            pauses: pausesRelay.value,
+            pauses: pauses,
             workoutEvents: [],
             voiceRecordings: voiceRecordingsRelay.value,
             activityIntervals: activityIntervalsRelay.value

--- a/Pilgrim/Models/Walk/WalkBuilder/WalkBuilder.swift
+++ b/Pilgrim/Models/Walk/WalkBuilder/WalkBuilder.swift
@@ -347,7 +347,29 @@ public class WalkBuilder: ApplicationStateObserver {
     }
     
     // MARK: - Create Snapshot
-    
+
+    public func createCheckpointSnapshot() -> TempWalk? {
+        guard let start = startDateRelay.value else { return nil }
+
+        return NewWalk(
+            workoutType: workoutTypeRelay.value,
+            distance: distanceRelay.value,
+            steps: stepsRelay.value,
+            startDate: start,
+            endDate: Date(),
+            isRace: false,
+            comment: nil,
+            isUserModified: false,
+            finishedRecording: false,
+            heartRates: [],
+            routeData: locationsRelay.value,
+            pauses: pausesRelay.value,
+            workoutEvents: [],
+            voiceRecordings: voiceRecordingsRelay.value,
+            activityIntervals: activityIntervalsRelay.value
+        )
+    }
+
     /**
      Creates a snapshot of the walk currently under construction.
      - returns: a `TempWalk` constructed from the recorded data; will be `nil` when start or end cannot be determined

--- a/Pilgrim/Models/Walk/WalkCheckpoint.swift
+++ b/Pilgrim/Models/Walk/WalkCheckpoint.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+struct WalkCheckpoint: Codable {
+    let schemaVersion: Int
+    let walkUUID: UUID
+    let checkpointDate: Date
+    let walk: TempWalk
+
+    init(walkUUID: UUID, walk: TempWalk) {
+        self.schemaVersion = 1
+        self.walkUUID = walkUUID
+        self.checkpointDate = Date()
+        self.walk = walk
+    }
+}

--- a/Pilgrim/Models/Walk/WalkSessionGuard.swift
+++ b/Pilgrim/Models/Walk/WalkSessionGuard.swift
@@ -1,0 +1,364 @@
+import Foundation
+import UIKit
+import CoreLocation
+import Combine
+import AVFoundation
+
+class WalkSessionGuard {
+
+    static weak var active: WalkSessionGuard?
+
+    weak var builder: WalkBuilder?
+    weak var locationManagement: LocationManagement?
+    weak var viewModel: ActiveWalkViewModel?
+
+    private var checkpointTimer: Timer?
+    private var currentTier: PowerTier = .normal
+    private var cancellables: [AnyCancellable] = []
+    private var walkUUID: UUID?
+    private var checkpointCount = 0
+
+    private static let tag = "[SessionGuard]"
+
+    // MARK: - Power Tiers
+
+    enum PowerTier: Equatable, CustomStringConvertible {
+        case normal
+        case meditation
+        case low
+        case critical
+
+        var checkpointInterval: TimeInterval {
+            switch self {
+            case .normal:     return 30
+            case .meditation: return 60
+            case .low:        return 15
+            case .critical:   return 10
+            }
+        }
+
+        var gpsAccuracy: CLLocationAccuracy {
+            switch self {
+            case .normal:     return kCLLocationAccuracyBest
+            case .meditation: return 100
+            case .low:        return kCLLocationAccuracyNearestTenMeters
+            case .critical:   return kCLLocationAccuracyNearestTenMeters
+            }
+        }
+
+        var distanceFilter: CLLocationDistance {
+            switch self {
+            case .normal:     return kCLDistanceFilterNone
+            case .meditation: return 50
+            case .low:        return 10
+            case .critical:   return 10
+            }
+        }
+
+        var description: String {
+            switch self {
+            case .normal:     return "normal"
+            case .meditation: return "meditation"
+            case .low:        return "low"
+            case .critical:   return "critical"
+            }
+        }
+    }
+
+    // MARK: - Lifecycle
+
+    func start() {
+        Self.active = self
+
+        let battery = UIDevice.current.batteryLevel
+        let thermal = ProcessInfo.processInfo.thermalState
+        print("\(Self.tag) START — battery: \(String(format: "%.0f%%", battery * 100)), thermal: \(Self.thermalName(thermal))")
+
+        UIDevice.current.isBatteryMonitoringEnabled = true
+
+        NotificationCenter.default.publisher(for: UIDevice.batteryLevelDidChangeNotification)
+            .sink { [weak self] _ in self?.recalculateTier() }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.publisher(for: ProcessInfo.thermalStateDidChangeNotification)
+            .sink { [weak self] _ in self?.recalculateTier() }
+            .store(in: &cancellables)
+
+        viewModel?.$isMeditating
+            .dropFirst()
+            .removeDuplicates()
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.recalculateTier() }
+            .store(in: &cancellables)
+
+        recalculateTier()
+        restartTimer()
+    }
+
+    func stopAndCleanup() {
+        print("\(Self.tag) STOP — wrote \(checkpointCount) checkpoints during session")
+        checkpointTimer?.invalidate()
+        checkpointTimer = nil
+        cancellables.removeAll()
+        locationManagement?.restoreDefaultPower()
+        UIDevice.current.isBatteryMonitoringEnabled = false
+        deleteCheckpointFile()
+        Self.active = nil
+    }
+
+    deinit {
+        checkpointTimer?.invalidate()
+        print("\(Self.tag) DEINIT")
+    }
+
+    // MARK: - Checkpointing
+
+    func checkpointNow() {
+        guard let builder, let snapshot = builder.createCheckpointSnapshot() else {
+            print("\(Self.tag) CHECKPOINT SKIPPED — no builder or no start date")
+            return
+        }
+
+        if let viewModel {
+            let intervals = viewModel.checkpointActivityIntervals()
+            snapshot.replaceActivityIntervals(intervals)
+        }
+
+        if walkUUID == nil {
+            walkUUID = Self.extractRecordingDirectoryUUID(from: snapshot) ?? UUID()
+        }
+
+        guard let resolvedUUID = walkUUID else { return }
+        let checkpoint = WalkCheckpoint(walkUUID: resolvedUUID, walk: snapshot)
+
+        do {
+            let data = try JSONEncoder().encode(checkpoint)
+            let url = Self.checkpointFileURL()
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try data.write(to: url, options: .atomic)
+            checkpointCount += 1
+            print("\(Self.tag) CHECKPOINT #\(checkpointCount) — tier: \(currentTier), routes: \(snapshot.routeData.count), pauses: \(snapshot.pauses.count), recordings: \(snapshot.voiceRecordings.count), intervals: \(snapshot.activityIntervals.count), size: \(ByteCountFormatter.string(fromByteCount: Int64(data.count), countStyle: .file))")
+        } catch {
+            print("\(Self.tag) CHECKPOINT WRITE FAILED: \(error)")
+        }
+    }
+
+    // MARK: - Tier Management
+
+    private func recalculateTier() {
+        let batteryLevel = UIDevice.current.batteryLevel
+        let thermalState = ProcessInfo.processInfo.thermalState
+        let isMeditating = viewModel?.isMeditating ?? false
+
+        let newTier: PowerTier
+        if (batteryLevel >= 0 && batteryLevel <= 0.05) || thermalState == .serious || thermalState == .critical {
+            newTier = .critical
+        } else if batteryLevel >= 0 && batteryLevel <= 0.20 {
+            newTier = .low
+        } else if isMeditating {
+            newTier = .meditation
+        } else {
+            newTier = .normal
+        }
+
+        guard newTier != currentTier else { return }
+        let oldTier = currentTier
+        currentTier = newTier
+        print("\(Self.tag) TIER \(oldTier) → \(newTier) — battery: \(String(format: "%.0f%%", batteryLevel * 100)), thermal: \(Self.thermalName(thermalState)), meditating: \(isMeditating), interval: \(newTier.checkpointInterval)s, gps: \(Self.accuracyName(newTier.gpsAccuracy))")
+        applyTier(newTier)
+    }
+
+    private func applyTier(_ tier: PowerTier) {
+        restartTimer()
+
+        guard let locationManagement else { return }
+        if tier == .normal {
+            locationManagement.restoreDefaultPower()
+        } else {
+            locationManagement.adjustPower(accuracy: tier.gpsAccuracy, distanceFilter: tier.distanceFilter)
+        }
+    }
+
+    private func restartTimer() {
+        checkpointTimer?.invalidate()
+        checkpointTimer = Timer.scheduledTimer(
+            withTimeInterval: currentTier.checkpointInterval,
+            repeats: true
+        ) { [weak self] _ in
+            self?.checkpointNow()
+        }
+    }
+
+    // MARK: - File I/O
+
+    static func checkpointFileURL() -> URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        return appSupport.appendingPathComponent("walk_checkpoint.json")
+    }
+
+    private func deleteCheckpointFile() {
+        let url = Self.checkpointFileURL()
+        guard FileManager.default.fileExists(atPath: url.path) else { return }
+        do {
+            try FileManager.default.removeItem(at: url)
+            print("\(Self.tag) CLEANUP — checkpoint file deleted")
+        } catch {
+            print("\(Self.tag) CLEANUP FAILED: \(error), retrying in 1s")
+            DispatchQueue.main.asyncAfter(deadline: .now() + 1) {
+                try? FileManager.default.removeItem(at: url)
+            }
+        }
+    }
+
+    // MARK: - Recovery
+
+    static func recoverIfNeeded(completion: @escaping (Date?) -> Void) {
+        guard DataManager.dataStack != nil else {
+            print("\(tag) RECOVERY SKIPPED — DataManager not ready")
+            completion(nil)
+            return
+        }
+
+        let url = checkpointFileURL()
+
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            print("\(tag) RECOVERY — no checkpoint file found")
+            completion(nil)
+            return
+        }
+
+        print("\(tag) RECOVERY — checkpoint file found, decoding...")
+
+        let checkpoint: WalkCheckpoint
+        do {
+            let data = try Data(contentsOf: url)
+            checkpoint = try JSONDecoder().decode(WalkCheckpoint.self, from: data)
+            print("\(tag) RECOVERY — decoded: schema=\(checkpoint.schemaVersion), walkUUID=\(checkpoint.walkUUID.uuidString.prefix(8))..., checkpointDate=\(checkpoint.checkpointDate)")
+        } catch {
+            print("\(tag) RECOVERY FAILED — decode error: \(error)")
+            try? FileManager.default.removeItem(at: url)
+            completion(nil)
+            return
+        }
+
+        if DataManager.objectHasDuplicate(uuid: checkpoint.walkUUID, objectType: Walk.self) {
+            print("\(tag) RECOVERY — stale checkpoint (walk already saved), deleting")
+            try? FileManager.default.removeItem(at: url)
+            completion(nil)
+            return
+        }
+
+        let walk = checkpoint.walk
+        let recordingDirUUID = extractRecordingDirectoryUUID(from: walk) ?? checkpoint.walkUUID
+        reconnectOrphanedRecordings(walk: walk, walkUUID: recordingDirUUID)
+
+        print("\(tag) RECOVERY — saving walk: start=\(walk.startDate), end=\(walk.endDate), routes=\(walk.routeData.count), pauses=\(walk.pauses.count), recordings=\(walk.voiceRecordings.count), intervals=\(walk.activityIntervals.count)")
+
+        let recovered = NewWalk(
+            workoutType: walk.workoutType,
+            distance: walk.distance,
+            steps: walk.steps,
+            startDate: walk.startDate,
+            endDate: walk.endDate,
+            isRace: walk.isRace,
+            comment: walk.comment,
+            isUserModified: walk.isUserModified,
+            finishedRecording: false,
+            heartRates: walk._heartRates,
+            routeData: walk._routeData,
+            pauses: walk._pauses,
+            workoutEvents: walk._workoutEvents,
+            voiceRecordings: walk._voiceRecordings,
+            activityIntervals: walk._activityIntervals
+        )
+        recovered.uuid = checkpoint.walkUUID
+
+        DataManager.saveWalk(object: recovered) { success, error, _ in
+            if success {
+                try? FileManager.default.removeItem(at: url)
+                print("\(tag) RECOVERY SUCCESS — walk from \(walk.startDate) saved, checkpoint deleted")
+                completion(walk.startDate)
+            } else {
+                print("\(tag) RECOVERY SAVE FAILED: \(String(describing: error)), keeping checkpoint for retry")
+                completion(nil)
+            }
+        }
+    }
+
+    private static func extractRecordingDirectoryUUID(from walk: TempWalk) -> UUID? {
+        for recording in walk._voiceRecordings {
+            let components = recording.fileRelativePath.split(separator: "/")
+            if components.count >= 2, let dirUUID = UUID(uuidString: String(components[1])) {
+                return dirUUID
+            }
+        }
+        return nil
+    }
+
+    private static func reconnectOrphanedRecordings(walk: TempWalk, walkUUID: UUID) {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let recordingsDir = docs.appendingPathComponent("Recordings/\(walkUUID.uuidString)")
+
+        guard FileManager.default.fileExists(atPath: recordingsDir.path) else {
+            print("\(tag) ORPHAN SCAN — no recordings directory for \(walkUUID.uuidString.prefix(8))...")
+            return
+        }
+
+        let existingPaths = Set(walk.voiceRecordings.map { $0.fileRelativePath })
+
+        guard let files = try? FileManager.default.contentsOfDirectory(
+            at: recordingsDir,
+            includingPropertiesForKeys: [.contentModificationDateKey]
+        ) else { return }
+
+        var orphans: [TempVoiceRecording] = []
+
+        for file in files where file.pathExtension == "m4a" {
+            let relativePath = "Recordings/\(walkUUID.uuidString)/\(file.lastPathComponent)"
+            guard !existingPaths.contains(relativePath) else { continue }
+
+            let asset = AVURLAsset(url: file)
+            let duration = CMTimeGetSeconds(asset.duration)
+            guard duration > 0 else { continue }
+
+            let modDate = (try? file.resourceValues(forKeys: [.contentModificationDateKey]))?.contentModificationDate ?? Date()
+            let startDate = modDate.addingTimeInterval(-duration)
+
+            let recording = TempVoiceRecording(
+                uuid: UUID(),
+                startDate: startDate,
+                endDate: modDate,
+                duration: duration,
+                fileRelativePath: relativePath
+            )
+            orphans.append(recording)
+            print("\(tag) ORPHAN FOUND — \(file.lastPathComponent), duration: \(String(format: "%.1f", duration))s")
+        }
+
+        if !orphans.isEmpty {
+            walk.appendVoiceRecordings(orphans)
+            print("\(tag) ORPHAN SCAN — reconnected \(orphans.count) recording(s)")
+        }
+    }
+
+    // MARK: - Formatting Helpers
+
+    private static func thermalName(_ state: ProcessInfo.ThermalState) -> String {
+        switch state {
+        case .nominal:  return "nominal"
+        case .fair:     return "fair"
+        case .serious:  return "serious"
+        case .critical: return "critical"
+        @unknown default: return "unknown"
+        }
+    }
+
+    private static func accuracyName(_ accuracy: CLLocationAccuracy) -> String {
+        if accuracy == kCLLocationAccuracyBest { return "best" }
+        if accuracy == kCLLocationAccuracyNearestTenMeters { return "10m" }
+        return "\(Int(accuracy))m"
+    }
+}

--- a/Pilgrim/Scenes/ActiveWalk/ActiveWalkViewModel.swift
+++ b/Pilgrim/Scenes/ActiveWalk/ActiveWalkViewModel.swift
@@ -7,12 +7,13 @@ class ActiveWalkViewModel: ObservableObject, Identifiable {
 
     let id = UUID()
     let builder: WalkBuilder
-    private let locationManagement: LocationManagement
+    let locationManagement: LocationManagement
     private let altitudeManagement: AltitudeManagement
     private let stepCounter: StepCounter
     private let liveStats: LiveStats
     let voiceRecordingManagement: VoiceRecordingManagement
     let soundManagement = SoundManagement()
+    private var sessionGuard: WalkSessionGuard?
 
     @Published var status: WalkBuilder.Status = .waiting
     @Published var duration: String = "0:00"
@@ -63,6 +64,13 @@ class ActiveWalkViewModel: ObservableObject, Identifiable {
         bindTimers()
         bindSoundscape()
         bindCompletedRecordings()
+
+        let guard_ = WalkSessionGuard()
+        guard_.builder = builder
+        guard_.locationManagement = locationManagement
+        guard_.viewModel = self
+        guard_.start()
+        self.sessionGuard = guard_
     }
 
     private func bindLiveStats() {
@@ -123,6 +131,7 @@ class ActiveWalkViewModel: ObservableObject, Identifiable {
     }
 
     func stop() {
+        sessionGuard?.stopAndCleanup()
         finalizeMeditation()
         soundManagement.onWalkEnd()
         builder.setStatus(.ready)
@@ -147,6 +156,20 @@ class ActiveWalkViewModel: ObservableObject, Identifiable {
     func endMeditationSilently() {
         finalizeMeditation()
         isMeditating = false
+    }
+
+    func checkpointActivityIntervals() -> [TempActivityInterval] {
+        var intervals = meditationIntervals
+        if let start = meditationStartDate {
+            let provisional = TempActivityInterval(
+                uuid: nil,
+                activityType: .meditation,
+                startDate: start,
+                endDate: Date()
+            )
+            intervals.append(provisional)
+        }
+        return intervals
     }
 
     private func finalizeMeditation() {

--- a/Pilgrim/Scenes/ActiveWalk/MeditationView.swift
+++ b/Pilgrim/Scenes/ActiveWalk/MeditationView.swift
@@ -295,7 +295,7 @@ struct MeditationView: View {
         "Stillness carries forward",
         "The path continues",
         "Return gently",
-        "Carry this calm with you",
+        "Carry this calm with you"
     ]
 
     private var closingSummary: some View {
@@ -641,7 +641,7 @@ struct BreathRhythm: Identifiable {
         BreathRhythm(id: 3, name: "Box", label: "4-4-4-4", description: "Four equal phases for focus", inhale: 4, holdIn: 4, exhale: 4, holdOut: 4),
         BreathRhythm(id: 4, name: "Coherent", label: "5 / 5", description: "Heart rate variability training", inhale: 5, holdIn: 0, exhale: 5, holdOut: 0),
         BreathRhythm(id: 5, name: "Deep calm", label: "3 / 6", description: "Short inhale, slow release", inhale: 3, holdIn: 0, exhale: 6, holdOut: 0),
-        BreathRhythm(id: 6, name: "None", label: "—", description: "Still focus point, open meditation", inhale: 0, holdIn: 0, exhale: 0, holdOut: 0),
+        BreathRhythm(id: 6, name: "None", label: "—", description: "Still focus point, open meditation", inhale: 0, holdIn: 0, exhale: 0, holdOut: 0)
     ]
 }
 

--- a/Pilgrim/Scenes/Root/MainCoordinatorView.swift
+++ b/Pilgrim/Scenes/Root/MainCoordinatorView.swift
@@ -6,8 +6,34 @@ class MainCoordinator: ObservableObject {
     @Published var activeWalkViewModel: ActiveWalkViewModel?
     @Published var completedSnapshot: TempWalk?
     @Published var showSaveError = false
+    @Published var recoveredWalkDate: Date?
 
     private var pendingSnapshot: TempWalk?
+    private var bannerDismissWork: DispatchWorkItem?
+
+    init() {
+        checkForRecovery()
+    }
+
+    private func checkForRecovery() {
+        WalkSessionGuard.recoverIfNeeded { [weak self] date in
+            DispatchQueue.main.async { [weak self] in
+                guard let self, let date else { return }
+                self.recoveredWalkDate = date
+                self.homeViewModel.loadWalks()
+                self.bannerDismissWork?.cancel()
+                let work = DispatchWorkItem { [weak self] in
+                    self?.recoveredWalkDate = nil
+                }
+                self.bannerDismissWork = work
+                DispatchQueue.main.asyncAfter(deadline: .now() + 4, execute: work)
+            }
+        }
+    }
+
+    deinit {
+        bannerDismissWork?.cancel()
+    }
 
     func startWalk(mode: WalkMode = .solo) {
         guard activeWalkViewModel == nil else { return }
@@ -45,5 +71,28 @@ struct MainCoordinatorView: View {
 
     var body: some View {
         HomeView(viewModel: coordinator.homeViewModel)
+    }
+}
+
+struct RecoveryBanner: View {
+
+    let date: Date
+
+    private static let formatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .medium
+        f.timeStyle = .short
+        return f
+    }()
+
+    var body: some View {
+        Text(String(format: LS["Recovery.WalkRecovered"], Self.formatter.string(from: date)))
+            .font(Constants.Typography.caption)
+            .foregroundColor(Color(.ink))
+            .padding(.horizontal, Constants.UI.Padding.normal)
+            .padding(.vertical, Constants.UI.Padding.small)
+            .background(Color(.parchmentSecondary).opacity(0.95))
+            .cornerRadius(8)
+            .padding(.top, Constants.UI.Padding.small)
     }
 }

--- a/Pilgrim/Scenes/Root/MainCoordinatorView.swift
+++ b/Pilgrim/Scenes/Root/MainCoordinatorView.swift
@@ -39,7 +39,7 @@ class MainCoordinator: ObservableObject {
         guard activeWalkViewModel == nil else { return }
         let vm = ActiveWalkViewModel()
         vm.onWalkCompleted = { [weak self] snapshot in
-            DataManager.saveWalk(object: snapshot) { success, error, walk in
+            DataManager.saveWalk(object: snapshot) { success, _, walk in
                 guard let self else { return }
                 if success {
                     snapshot.uuid = walk?.uuid

--- a/Pilgrim/Scenes/Root/MainTabView.swift
+++ b/Pilgrim/Scenes/Root/MainTabView.swift
@@ -43,5 +43,12 @@ struct MainTabView: View {
         } message: {
             Text("Your walk could not be saved. Please try again.")
         }
+        .overlay(alignment: .top) {
+            if let date = coordinator.recoveredWalkDate {
+                RecoveryBanner(date: date)
+                    .transition(.move(edge: .top).combined(with: .opacity))
+            }
+        }
+        .animation(.easeInOut, value: coordinator.recoveredWalkDate != nil)
     }
 }

--- a/Pilgrim/Scenes/Settings/SoundSettingsView.swift
+++ b/Pilgrim/Scenes/Settings/SoundSettingsView.swift
@@ -24,7 +24,7 @@ struct SoundSettingsView: View {
 
     var body: some View {
         List {
-            masterSection
+            mainToggleSection
             if soundsEnabled {
                 walkSection
                 meditationSection
@@ -54,7 +54,7 @@ struct SoundSettingsView: View {
 
     // MARK: - Sections
 
-    private var masterSection: some View {
+    private var mainToggleSection: some View {
         Section {
             Toggle(isOn: $soundsEnabled) {
                 Text("Sounds")

--- a/Pilgrim/Support Files/Base.lproj/Localizable.strings
+++ b/Pilgrim/Support Files/Base.lproj/Localizable.strings
@@ -186,3 +186,5 @@
 "Permissions.Skipped" = "Skipped";
 "Permissions.Next" = "Next";
 "Permissions.Required.Hint" = "Pilgrim needs this to walk with you";
+
+"Recovery.WalkRecovered" = "Walk from %@ recovered and saved";

--- a/Pilgrim/Views/Scenery/WinterTreeShape.swift
+++ b/Pilgrim/Views/Scenery/WinterTreeShape.swift
@@ -1,6 +1,24 @@
 import SwiftUI
 
 struct WinterTreeShape: Shape {
+
+    private struct Branch {
+        let y: CGFloat
+        let length: CGFloat
+        let angle: CGFloat
+        let side: CGFloat
+        let hasTwig: Bool
+    }
+
+    private static let branches = [
+        Branch(y: 0.32, length: 0.32, angle: -50, side: -1, hasTwig: true),
+        Branch(y: 0.42, length: 0.26, angle: -45, side: 1, hasTwig: true),
+        Branch(y: 0.50, length: 0.18, angle: -55, side: -1, hasTwig: false),
+        Branch(y: 0.58, length: 0.20, angle: -40, side: 1, hasTwig: true),
+        Branch(y: 0.68, length: 0.13, angle: -50, side: -1, hasTwig: false),
+        Branch(y: 0.75, length: 0.10, angle: -42, side: 1, hasTwig: false)
+    ]
+
     func path(in rect: CGRect) -> Path {
         var path = Path()
         let w = rect.width
@@ -8,12 +26,9 @@ struct WinterTreeShape: Shape {
         let cx = w * 0.48
 
         addTrunk(to: &path, cx: cx, w: w, h: h)
-        addBranch(to: &path, cx: cx, w: w, h: h, y: 0.32, length: 0.32, angle: -50, side: -1, hasTwig: true)
-        addBranch(to: &path, cx: cx, w: w, h: h, y: 0.42, length: 0.26, angle: -45, side: 1, hasTwig: true)
-        addBranch(to: &path, cx: cx, w: w, h: h, y: 0.50, length: 0.18, angle: -55, side: -1, hasTwig: false)
-        addBranch(to: &path, cx: cx, w: w, h: h, y: 0.58, length: 0.20, angle: -40, side: 1, hasTwig: true)
-        addBranch(to: &path, cx: cx, w: w, h: h, y: 0.68, length: 0.13, angle: -50, side: -1, hasTwig: false)
-        addBranch(to: &path, cx: cx, w: w, h: h, y: 0.75, length: 0.10, angle: -42, side: 1, hasTwig: false)
+        for branch in Self.branches {
+            addBranch(to: &path, cx: cx, w: w, h: h, branch: branch)
+        }
 
         return path
     }
@@ -36,19 +51,18 @@ struct WinterTreeShape: Shape {
         path.closeSubpath()
     }
 
-    private func addBranch(to path: inout Path, cx: CGFloat, w: CGFloat, h: CGFloat,
-                           y: CGFloat, length: CGFloat, angle: CGFloat, side: CGFloat, hasTwig: Bool) {
-        let startY = h * y
-        let startX = cx + side * w * 0.03
-        let rad = Double(angle) * .pi / 180
-        let len = w * length
+    private func addBranch(to path: inout Path, cx: CGFloat, w: CGFloat, h: CGFloat, branch: Branch) {
+        let startY = h * branch.y
+        let startX = cx + branch.side * w * 0.03
+        let rad = Double(branch.angle) * .pi / 180
+        let len = w * branch.length
         let thickness = w * 0.022
         let cosRad = CGFloat(Foundation.cos(rad))
         let sinRad = CGFloat(Foundation.sin(rad))
 
-        let midX = startX + side * len * 0.5
+        let midX = startX + branch.side * len * 0.5
         let curveY = startY + len * sinRad * 0.5 - w * 0.02
-        let endX = startX + side * len * cosRad
+        let endX = startX + branch.side * len * cosRad
         let endY = startY + len * sinRad
 
         path.move(to: CGPoint(x: startX, y: startY - thickness))
@@ -62,15 +76,13 @@ struct WinterTreeShape: Shape {
         )
         path.closeSubpath()
 
-        if hasTwig {
+        if branch.hasTwig {
             let twigStart: CGFloat = 0.55
-            let cosRad = CGFloat(Foundation.cos(Double(rad)))
-            let sinRad = CGFloat(Foundation.sin(Double(rad)))
-            let twigX = startX + side * len * twigStart * cosRad
+            let twigX = startX + branch.side * len * twigStart * cosRad
             let twigY = startY + len * twigStart * sinRad
             let twigLen = len * 0.35
-            let twigRad = Double(rad) + Double(side) * (-0.6)
-            let twigEndX = twigX + side * twigLen * CGFloat(Foundation.cos(twigRad))
+            let twigRad = Double(rad) + Double(branch.side) * (-0.6)
+            let twigEndX = twigX + branch.side * twigLen * CGFloat(Foundation.cos(twigRad))
             let twigEndY = twigY + twigLen * CGFloat(Foundation.sin(twigRad))
             let tw = thickness * 0.5
 


### PR DESCRIPTION
## Summary

- **Checkpoint recovery**: Periodically snapshots walk state to JSON in Application Support/. On crash or force-quit, the walk is recovered on next launch and saved to history with a banner notification.
- **Activity-aware power management**: Adjusts GPS accuracy and checkpoint frequency based on battery level, thermal state, and meditation activity. Four tiers: normal, meditation, low, critical.
- **Orphaned voice recording reconnection**: Scans for voice recording files on disk that weren't captured in the last checkpoint and reconnects them to the recovered walk.

### Power Tiers

| Tier | Trigger | Checkpoint | GPS |
|------|---------|-----------|-----|
| normal | >20% battery, walking | 30s | Best |
| meditation | user meditating | 60s | 100m / 50m filter |
| low | ≤20% battery | 15s | 10m |
| critical | ≤5% or thermal warning | 10s | 10m |

### Files

**New:**
- `WalkCheckpoint.swift` — Codable envelope with schema version
- `WalkSessionGuard.swift` — Unified checkpoint timer + power manager + recovery

**Modified:**
- `WalkBuilder.swift` — `createCheckpointSnapshot()` (non-destructive mid-walk snapshot)
- `LocationManagement.swift` — `adjustPower()` / `restoreDefaultPower()`
- `ActiveWalkViewModel.swift` — Owns guard, exposes meditation intervals
- `TempV4.swift` — Mutation methods for activity intervals and voice recordings
- `AppDelegate.swift` — Background + terminate checkpoint calls
- `MainCoordinatorView.swift` — Recovery check + banner
- `MainTabView.swift` — Banner overlay
- `Localizable.strings` — Recovery banner text

## Test plan

- [x] Start walk → checkpoints fire every ~30s → stop walk → file deleted
- [x] Start walk → force-quit → relaunch → walk recovered with route data → banner shown
- [x] Start meditation → tier changes to meditation (GPS 100m) → end → reverts to normal
- [x] Background app during walk → immediate checkpoint written
- [ ] Low battery simulation (Xcode) → tier changes to low/critical

🤖 Generated with [Claude Code](https://claude.com/claude-code)