### PR TITLE
feat: Share Your Walk

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,7 @@ Secrets.xcconfig
 # Superpowers
 .superpowers/
 
+
 # AppCode
 .idea/*
 !.idea/codeStyles/*

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -7,37 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		764C2FC0EBC04F779B97EA92 /* WalkCheckpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74490DBCE024418B78E73B2 /* WalkCheckpoint.swift */; };
-		DAEA43ECD49D4467B169B413 /* WalkSessionGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8134F8A37D74FB3805684F1 /* WalkSessionGuard.swift */; };
 		0247093D7E5B019E36A98F9F /* AudioAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA2B0038D4875801C41DE26 /* AudioAsset.swift */; };
-		FA9B9D71DB2B3EA84CC73FEE /* AudioFileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90392F316E29A62DA1F0DE0E /* AudioFileStore.swift */; };
-		13F3292004EFCFD3572E44B9 /* AudioSessionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE6DC51742E035602E624F1 /* AudioSessionCoordinator.swift */; };
-		45ECE5D78ADACF7F238277C4 /* AudioManifestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 390BFBA7B83028EA625B0CF9 /* AudioManifestService.swift */; };
-		9D37F522C28D84C1E1ECCDCC /* AudioDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1725921B51E95B8BB46C90E4 /* AudioDownloadManager.swift */; };
-		6EBC9E9BD642B03C2C67D8D2 /* BellPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5EFD54CACA590B1BE78B75 /* BellPlayer.swift */; };
-		1B1EF52AF234570C6DDAE905 /* SoundscapePlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F17456C4D1E2DAED49B9AC6 /* SoundscapePlayer.swift */; };
-		2E59989F7B4496B95EBB0AB7 /* SoundManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263D620E1DB30C5FCA0143CC /* SoundManagement.swift */; };
-		ACF07FD2C47613FD87D08EE7 /* SoundSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5581F46A4FFE9ED1D2DCEB /* SoundSettingsView.swift */; };
-		EE07C2075CD444E6833A365D /* VoiceEnhancer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37A4E244FA34A828856F814 /* VoiceEnhancer.swift */; };
-		5EB2EE597FAA4E288699FEF4 /* WaveformGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8019A1ED39BF4E889F5DF99C /* WaveformGenerator.swift */; };
-		A7A6E8BA14A8426581C2E09D /* WaveformCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE12D19DC32D4F8FB3A35965 /* WaveformCache.swift */; };
-		C8297CD567634F8E9D97738B /* TalkSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1EF72AE69CD4C1599071304 /* TalkSettingsView.swift */; };
-		B3D4E5F6A7B8C9D0E1F2A3B5 /* RecordingsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F6A7B8C9D0E1F2A3B4C6 /* RecordingsListView.swift */; };
-		F0F0F00100000001AABBCC01 /* CormorantGaramond-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = F0F0F00200000001AABBCC01 /* CormorantGaramond-Light.otf */; };
-		F0F0F00100000002AABBCC02 /* CormorantGaramond-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = F0F0F00200000002AABBCC02 /* CormorantGaramond-Regular.otf */; };
-		F0F0F00100000003AABBCC03 /* CormorantGaramond-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = F0F0F00200000003AABBCC03 /* CormorantGaramond-SemiBold.otf */; };
-		F0F0F00100000004AABBCC04 /* Lato-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F0F0F00200000004AABBCC04 /* Lato-Regular.ttf */; };
-		F0F0F00100000005AABBCC05 /* Lato-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F0F0F00200000005AABBCC05 /* Lato-Bold.ttf */; };
 		03A4AA6D8DD2B3AA6E9AF157 /* PromptGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD13E8087B26CC89725C3041 /* PromptGeneratorTests.swift */; };
-		CC00000200000000LUNRTST1 /* LunarPhaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000LUNRTST1 /* LunarPhaseTests.swift */; };
+		08508B6253B3427ABA939DED /* ActivityTimelineBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CBD6B08E4C437DA90FDDB0 /* ActivityTimelineBar.swift */; };
 		0900F4294F091546C199FA0A /* WalkDataFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4181215714A52E71449BC390 /* WalkDataFactory.swift */; };
 		0E29E944B6EEAD64EB33151E /* XCTestCase+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721BF267E7540B2B259806D1 /* XCTestCase+Combine.swift */; };
+		13F3292004EFCFD3572E44B9 /* AudioSessionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE6DC51742E035602E624F1 /* AudioSessionCoordinator.swift */; };
+		1B1EF52AF234570C6DDAE905 /* SoundscapePlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F17456C4D1E2DAED49B9AC6 /* SoundscapePlayer.swift */; };
 		2201BCA929423DF100F54277 /* View+Navigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2201BCA829423DF100F54277 /* View+Navigation.swift */; };
 		2201BCAB29423E1600F54277 /* NavigationLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2201BCAA29423E1600F54277 /* NavigationLink.swift */; };
-
 		2204A1DD255ACB1100906CFE /* DataTypeProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2204A1DC255ACB1100906CFE /* DataTypeProtocol.swift */; };
 		2204E428295DF28C00243FC3 /* SetupCoordinatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2204E427295DF28C00243FC3 /* SetupCoordinatorView.swift */; };
-
 		2207B75623128F8A00BA71B5 /* CLLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2207B75523128F8A00BA71B5 /* CLLocation.swift */; };
 		2209E53924DD4A8F00BBFC2F /* AltitudeManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2209E53824DD4A8F00BBFC2F /* AltitudeManagement.swift */; };
 		2213137D23B4110700881806 /* PermissionManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2213137C23B4110700881806 /* PermissionManager.swift */; };
@@ -101,7 +81,6 @@
 		22A5D02E25C1A57600C30786 /* TempV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A5D02D25C1A57600C30786 /* TempV2.swift */; };
 		22A5D03325C1AB2200C30786 /* TempV3.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A5D03225C1AB2200C30786 /* TempV3.swift */; };
 		22A5D03625C1ABDA00C30786 /* TempV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22A5D03525C1ABDA00C30786 /* TempV4.swift */; };
-
 		22B1DD82253F90700093822B /* DataStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B1DD80253F90700093822B /* DataStack.swift */; };
 		22B1DD83253F90700093822B /* SQLiteStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B1DD81253F90700093822B /* SQLiteStore.swift */; };
 		22B1DD8B253F90FD0093822B /* IntermediateDataModelProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22B1DD89253F90FD0093822B /* IntermediateDataModelProtocol.swift */; };
@@ -121,13 +100,6 @@
 		22BBDD3224D77C2B00225AE4 /* StepCounter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BBDD3124D77C2B00225AE4 /* StepCounter.swift */; };
 		22BC99162941D97600D9B1A5 /* WelcomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC99142941D97600D9B1A5 /* WelcomeViewModel.swift */; };
 		22BC99172941D97600D9B1A5 /* WelcomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC99152941D97600D9B1A5 /* WelcomeView.swift */; };
-		AABB000100000002 /* WelcomeAnimationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000100000001 /* WelcomeAnimationState.swift */; };
-		BREATH000000000000000002 /* BreathTransitionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BREATH000000000000000001 /* BreathTransitionView.swift */; };
-
-
-
-
-
 		22BC99392941D9A800D9B1A5 /* MetricViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC99272941D9A800D9B1A5 /* MetricViewModel.swift */; };
 		22BC993A2941D9A800D9B1A5 /* CloseButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC99292941D9A800D9B1A5 /* CloseButton.swift */; };
 		22BC993B2941D9A800D9B1A5 /* ActionButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC992A2941D9A800D9B1A5 /* ActionButton.swift */; };
@@ -136,8 +108,6 @@
 		22BC993E2941D9A800D9B1A5 /* CardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC992D2941D9A800D9B1A5 /* CardView.swift */; };
 		22BC993F2941D9A800D9B1A5 /* ProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC992E2941D9A800D9B1A5 /* ProgressView.swift */; };
 		22BC99402941D9A800D9B1A5 /* FeatureView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC992F2941D9A800D9B1A5 /* FeatureView.swift */; };
-
-
 		22BC99432941D9A800D9B1A5 /* CornerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC99322941D9A800D9B1A5 /* CornerView.swift */; };
 		22BC99442941D9A800D9B1A5 /* PermissionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC99332941D9A800D9B1A5 /* PermissionView.swift */; };
 		22BC99452941D9A800D9B1A5 /* MetricView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC99342941D9A800D9B1A5 /* MetricView.swift */; };
@@ -147,15 +117,12 @@
 		22BC99492941D9A800D9B1A5 /* WalkCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC99382941D9A800D9B1A5 /* WalkCard.swift */; };
 		22BC994B2941DA3400D9B1A5 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC994A2941DA3400D9B1A5 /* Constants.swift */; };
 		22BC994D2941DA6200D9B1A5 /* Binding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC994C2941DA6200D9B1A5 /* Binding.swift */; };
-
 		22BC99522941DC9900D9B1A5 /* Color.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BC99512941DC9900D9B1A5 /* Color.swift */; };
-
 		22BD1F3E247462FF00415A06 /* ApplicationStateObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BD1F3D247462FF00415A06 /* ApplicationStateObserver.swift */; };
 		22BD1F402474638200415A06 /* ApplicationStateObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BD1F3F2474638200415A06 /* ApplicationStateObservation.swift */; };
 		22BD1F42247463DF00415A06 /* ApplicationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BD1F41247463DF00415A06 /* ApplicationState.swift */; };
 		22BF623D26E6B1D2008C904C /* WalkBuilderComponentStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22BF623C26E6B1D2008C904C /* WalkBuilderComponentStatus.swift */; };
 		22C09B9426514BD8004AF34F /* DataInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C09B9326514BD8004AF34F /* DataInterface.swift */; };
-
 		22C1108024532C69009ACE81 /* WalkMapImageRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C1107F24532C69009ACE81 /* WalkMapImageRequest.swift */; };
 		22C1108224532DBA009ACE81 /* WalkMapImageSize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C1108124532DBA009ACE81 /* WalkMapImageSize.swift */; };
 		22C1108424532E36009ACE81 /* WalkMapImageQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22C1108324532E36009ACE81 /* WalkMapImageQueue.swift */; };
@@ -183,83 +150,108 @@
 		22FEA0AF24CDD7B50007CA9C /* DiskStorage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FEA0AE24CDD7B50007CA9C /* DiskStorage.swift */; };
 		22FEA0B124CDDFF80007CA9C /* CustomByteFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FEA0B024CDDFF80007CA9C /* CustomByteFormatting.swift */; };
 		2B6F4CE80AB1FB057688EAA1 /* ComputationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D23FF60A762C30296A69E6 /* ComputationTests.swift */; };
+		2E59989F7B4496B95EBB0AB7 /* SoundManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263D620E1DB30C5FCA0143CC /* SoundManagement.swift */; };
+		3F8E37CD28D541C1838F01BD /* PilgrimV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2722224F049B455DB473E7C9 /* PilgrimV2.swift */; };
+		45ECE5D78ADACF7F238277C4 /* AudioManifestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 390BFBA7B83028EA625B0CF9 /* AudioManifestService.swift */; };
 		487022E2F9AD1AE6D374FF39 /* Pods_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C56A574B3F5BFCBF50DB5368 /* Pods_UnitTests.framework */; };
+		4E9F3E9C7E3A4840ACD9DA73 /* ActivityIntervalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B789284BE2A474BA89993F2 /* ActivityIntervalTests.swift */; };
 		50A16B63C6F23E2D1E6210BA /* Pods_Pilgrim.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */; };
+		5EB2EE597FAA4E288699FEF4 /* WaveformGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8019A1ED39BF4E889F5DF99C /* WaveformGenerator.swift */; };
+		6AE85BCC627AF8321E753C1F /* ShareService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9D07CA4444A7B548B5CFA4 /* ShareService.swift */; };
+		6EBC9E9BD642B03C2C67D8D2 /* BellPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5EFD54CACA590B1BE78B75 /* BellPlayer.swift */; };
+		6F172421DF5C4B98BDFDA00E /* PaceSparklineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6BF30D6A9C48219D3C115C /* PaceSparklineView.swift */; };
+		6F242558E79A4653BAAAE3FB /* ActivityListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FDF0BD38D9467B99B2C4D7 /* ActivityListView.swift */; };
+		764C2FC0EBC04F779B97EA92 /* WalkCheckpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74490DBCE024418B78E73B2 /* WalkCheckpoint.swift */; };
 		76B622EBDD59AD9489586120 /* DateFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2D4ACA7F21BA80523DF98C /* DateFactory.swift */; };
-		AA000002PILGRIMLOGO00000 /* PilgrimLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000001PILGRIMLOGO00000 /* PilgrimLogoView.swift */; };
+		7C39E4160B0DA105D78F4C83 /* SharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EA6F12A77BD40C46E34D47 /* SharePayload.swift */; };
+		8A200FA63DDEC6D859F1C4EE /* WalkShareViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E0BF1B23139F428720EB2CF /* WalkShareViewModel.swift */; };
+		9726AFAB9F744FDA86EEC2CF /* ActivityInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA57CE96EE3401595264807 /* ActivityInterval.swift */; };
+		9A477336A61C4C38B9D4F13C /* RouteDownsampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E1B5A537C865F5416F6EF2 /* RouteDownsampler.swift */; };
+		9D37F522C28D84C1E1ECCDCC /* AudioDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1725921B51E95B8BB46C90E4 /* AudioDownloadManager.swift */; };
+		A1B2C3D4E5F601020304050B /* PilgrimV3.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F601020304050A /* PilgrimV3.swift */; };
+		A5B6C7D8E9F0A1B2C3D4E5F7 /* PilgrimV5.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B6C7D8E9F0A1B2C3D4E5F6 /* PilgrimV5.swift */; };
+		A7A6E8BA14A8426581C2E09D /* WaveformCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE12D19DC32D4F8FB3A35965 /* WaveformCache.swift */; };
 		AA000002FOOTPRINTSHAPE00 /* FootprintShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000001FOOTPRINTSHAPE00 /* FootprintShape.swift */; };
+		AA000002PILGRIMLOGO00000 /* PilgrimLogoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000001PILGRIMLOGO00000 /* PilgrimLogoView.swift */; };
 		AA0001010000000000000011 /* HomeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001010000000000000001 /* HomeView.swift */; };
 		AA0001010000000000000012 /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001010000000000000002 /* HomeViewModel.swift */; };
 		AA0001010000000000000013 /* WalkRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001010000000000000003 /* WalkRowView.swift */; };
 		AA0001010000000000000014 /* ActiveWalkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001010000000000000004 /* ActiveWalkView.swift */; };
 		AA0001010000000000000015 /* ActiveWalkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001010000000000000005 /* ActiveWalkViewModel.swift */; };
 		AA0001010000000000000016 /* WalkSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001010000000000000006 /* WalkSummaryView.swift */; };
-		AA00040100000000000002 /* VoiceRecordingRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00040100000000000001 /* VoiceRecordingRow.swift */; };
-		AA00040100000000000004 /* AudioPlayerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00040100000000000003 /* AudioPlayerModel.swift */; };
-		AAAA00000000000000000EL1 /* ElevationProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00000000000000000EL2 /* ElevationProfileView.swift */; };
 		AA0001010000000000000017 /* MainCoordinatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001010000000000000007 /* MainCoordinatorView.swift */; };
 		AA00020100000000000002 /* VoiceRecording.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00020100000000000001 /* VoiceRecording.swift */; };
 		AA00020100000000000004 /* VoiceRecordingManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00020100000000000003 /* VoiceRecordingManagement.swift */; };
 		AA00030100000000000002 /* MeditationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00030100000000000001 /* MeditationView.swift */; };
+		AA00040100000000000002 /* VoiceRecordingRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00040100000000000001 /* VoiceRecordingRow.swift */; };
+		AA00040100000000000004 /* AudioPlayerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00040100000000000003 /* AudioPlayerModel.swift */; };
 		AAAA000000000000000000A1 /* WhisperKit in Frameworks */ = {isa = PBXBuildFile; productRef = AAAA000000000000000000A3 /* WhisperKit */; };
-		AAAA00000000000000000MB1 /* MapboxMaps in Frameworks */ = {isa = PBXBuildFile; productRef = AAAA00000000000000000MB3 /* MapboxMaps */; };
-		AAAA00000000000000000MF1 /* RouteSegment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00000000000000000MF2 /* RouteSegment.swift */; };
-		AAAA00000000000000000MF3 /* PilgrimAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00000000000000000MF4 /* PilgrimAnnotation.swift */; };
-		AAAA00000000000000000MF5 /* PilgrimMapStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00000000000000000MF6 /* PilgrimMapStyle.swift */; };
-		AAAA00000000000000000MF7 /* PilgrimMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00000000000000000MF8 /* PilgrimMapView.swift */; };
 		AAAA000000000000000000B1 /* TranscriptionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000B2 /* TranscriptionService.swift */; };
 		AAAA000000000000000000C1 /* PromptGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000C2 /* PromptGenerator.swift */; };
 		AAAA000000000000000000C3 /* PromptListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000C4 /* PromptListView.swift */; };
 		AAAA000000000000000000C5 /* PromptDetailView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000C6 /* PromptDetailView.swift */; };
 		AAAA000000000000000000D1 /* CustomPromptStyleStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000D2 /* CustomPromptStyleStore.swift */; };
+		AAAA000000000000000000D3 /* CustomPromptStyleStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000D4 /* CustomPromptStyleStoreTests.swift */; };
+		AAAA000000000000000000E1 /* CustomPromptEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000E2 /* CustomPromptEditorView.swift */; };
+		AAAA00000000000000000EL1 /* ElevationProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00000000000000000EL2 /* ElevationProfileView.swift */; };
+		AAAA00000000000000000MB1 /* MapboxMaps in Frameworks */ = {isa = PBXBuildFile; productRef = AAAA00000000000000000MB3 /* MapboxMaps */; };
+		AAAA00000000000000000MF1 /* RouteSegment.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00000000000000000MF2 /* RouteSegment.swift */; };
+		AAAA00000000000000000MF3 /* PilgrimAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00000000000000000MF4 /* PilgrimAnnotation.swift */; };
+		AAAA00000000000000000MF5 /* PilgrimMapStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00000000000000000MF6 /* PilgrimMapStyle.swift */; };
+		AAAA00000000000000000MF7 /* PilgrimMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00000000000000000MF8 /* PilgrimMapView.swift */; };
+		AABB000100000002 /* WelcomeAnimationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000100000001 /* WelcomeAnimationState.swift */; };
+		ACF07FD2C47613FD87D08EE7 /* SoundSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5581F46A4FFE9ED1D2DCEB /* SoundSettingsView.swift */; };
+		B3D4E5F6A7B8C9D0E1F2A3B5 /* RecordingsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F6A7B8C9D0E1F2A3B4C6 /* RecordingsListView.swift */; };
+		B9C538ECD15D4CE3B5B4186E /* ActivityInsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D6AFD9DABC41629606A762 /* ActivityInsightsView.swift */; };
 		BB00AA010000000000000002 /* PilgrimV1.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00AA010000000000000001 /* PilgrimV1.swift */; };
+		BB00CC010000000000000001 /* WelcomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00CC010000000000000002 /* WelcomeViewModelTests.swift */; };
+		BREATH000000000000000002 /* BreathTransitionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BREATH000000000000000001 /* BreathTransitionView.swift */; };
+		C8297CD567634F8E9D97738B /* TalkSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1EF72AE69CD4C1599071304 /* TalkSettingsView.swift */; };
+		CC00000200000000BTRFLY01 /* ButterflyShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000BTRFLY01 /* ButterflyShape.swift */; };
+		CC00000200000000CALLIG01 /* CalligraphyPathRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000CALLIG01 /* CalligraphyPathRenderer.swift */; };
+		CC00000200000000DEBUGS01 /* DebugDataSeeder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000DEBUGS01 /* DebugDataSeeder.swift */; };
+		CC00000200000000GRASSH01 /* GrassShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000GRASSH01 /* GrassShape.swift */; };
+		CC00000200000000HAPTIC01 /* ScrollHapticEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000HAPTIC01 /* ScrollHapticEngine.swift */; };
+		CC00000200000000INKSCR01 /* InkScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000INKSCR01 /* InkScrollView.swift */; };
+		CC00000200000000LANTRN01 /* LanternShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000LANTRN01 /* LanternShape.swift */; };
+		CC00000200000000LUNRPH01 /* LunarPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000LUNRPH01 /* LunarPhase.swift */; };
+		CC00000200000000LUNRTST1 /* LunarPhaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000LUNRTST1 /* LunarPhaseTests.swift */; };
+		CC00000200000000MAINTB01 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000MAINTB01 /* MainTabView.swift */; };
+		CC00000200000000MILEST01 /* MilestoneMarkerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000MILEST01 /* MilestoneMarkerView.swift */; };
+		CC00000200000000MOONPV01 /* MoonPhaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000MOONPV01 /* MoonPhaseView.swift */; };
+		CC00000200000000MOONSH01 /* MoonShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000MOONSH01 /* MoonShape.swift */; };
+		CC00000200000000MOUNTN01 /* MountainShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000MOUNTN01 /* MountainShape.swift */; };
+		CC00000200000000SCENER01 /* SceneryGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000SCENER01 /* SceneryGenerator.swift */; };
+		CC00000200000000SCENIV01 /* SceneryItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000SCENIV01 /* SceneryItemView.swift */; };
+		CC00000200000000SEASON01 /* SeasonalColorEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000SEASON01 /* SeasonalColorEngine.swift */; };
+		CC00000200000000SETTVW01 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000SETTVW01 /* SettingsView.swift */; };
+		CC00000200000000TORIIG01 /* ToriiGateShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000TORIIG01 /* ToriiGateShape.swift */; };
+		CC00000200000000TREESH01 /* TreeShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000TREESH01 /* TreeShape.swift */; };
+		CC00000200000000WINTRT01 /* WinterTreeShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000WINTRT01 /* WinterTreeShape.swift */; };
+		CC00000200000000WKDOTV01 /* WalkDotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000WKDOTV01 /* WalkDotView.swift */; };
+		CC00000200000000WKMODE01 /* WalkMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000WKMODE01 /* WalkMode.swift */; };
+		CC00000200000000WKSTRT01 /* WalkStartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000WKSTRT01 /* WalkStartView.swift */; };
 		CC00BB010000000000000002 /* VoiceRecordingInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00BB010000000000000001 /* VoiceRecordingInterface.swift */; };
 		CDB0F563A56A46B5981279A2 /* WalkBuilderStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4102471AC572B099189FB03 /* WalkBuilderStatusTests.swift */; };
+		DAEA43ECD49D4467B169B413 /* WalkSessionGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8134F8A37D74FB3805684F1 /* WalkSessionGuard.swift */; };
+		DBC54AC76144B10493D3E481 /* WalkShareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BE9557700152F043C359DC /* WalkShareView.swift */; };
 		DD00CC0100000000000002 /* MeditateDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00CC0100000000000001 /* MeditateDetection.swift */; };
-		F28633E25671B876232C0F34 /* BackupSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB8B7996545B4CEF51D686E /* BackupSerializationTests.swift */; };
-		FE15922AE9DAD82F62BA4601 /* NewWalkComputationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E892B071C7BE6EBD74F3FC /* NewWalkComputationTests.swift */; };
-		3F8E37CD28D541C1838F01BD /* PilgrimV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2722224F049B455DB473E7C9 /* PilgrimV2.swift */; };
-		A1B2C3D4E5F601020304050B /* PilgrimV3.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F601020304050A /* PilgrimV3.swift */; };
+		EE07C2075CD444E6833A365D /* VoiceEnhancer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37A4E244FA34A828856F814 /* VoiceEnhancer.swift */; };
+		EF1533CDBBC5498EA3BFDFC6 /* ActivityIntervalInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964D4C7663494F3ABBEEF84F /* ActivityIntervalInterface.swift */; };
+		F0F0F00100000001AABBCC01 /* CormorantGaramond-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = F0F0F00200000001AABBCC01 /* CormorantGaramond-Light.otf */; };
+		F0F0F00100000002AABBCC02 /* CormorantGaramond-Regular.otf in Resources */ = {isa = PBXBuildFile; fileRef = F0F0F00200000002AABBCC02 /* CormorantGaramond-Regular.otf */; };
+		F0F0F00100000003AABBCC03 /* CormorantGaramond-SemiBold.otf in Resources */ = {isa = PBXBuildFile; fileRef = F0F0F00200000003AABBCC03 /* CormorantGaramond-SemiBold.otf */; };
+		F0F0F00100000004AABBCC04 /* Lato-Regular.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F0F0F00200000004AABBCC04 /* Lato-Regular.ttf */; };
+		F0F0F00100000005AABBCC05 /* Lato-Bold.ttf in Resources */ = {isa = PBXBuildFile; fileRef = F0F0F00200000005AABBCC05 /* Lato-Bold.ttf */; };
 		F1A2B3C4D5E6F7A8B9C0D1E3 /* WalkFavicon.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7A8B9C0D1E2 /* WalkFavicon.swift */; };
 		F1A2B3C4D5E6F7A8B9C0D1E5 /* PilgrimV4.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7A8B9C0D1E4 /* PilgrimV4.swift */; };
-		A5B6C7D8E9F0A1B2C3D4E5F7 /* PilgrimV5.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B6C7D8E9F0A1B2C3D4E5F6 /* PilgrimV5.swift */; };
 		F1A2B3C4D5E6F7A8B9C0D1E7 /* FaviconSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7A8B9C0D1E6 /* FaviconSelectorView.swift */; };
-		9726AFAB9F744FDA86EEC2CF /* ActivityInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA57CE96EE3401595264807 /* ActivityInterval.swift */; };
-		EF1533CDBBC5498EA3BFDFC6 /* ActivityIntervalInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964D4C7663494F3ABBEEF84F /* ActivityIntervalInterface.swift */; };
-		08508B6253B3427ABA939DED /* ActivityTimelineBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CBD6B08E4C437DA90FDDB0 /* ActivityTimelineBar.swift */; };
-		6F172421DF5C4B98BDFDA00E /* PaceSparklineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6BF30D6A9C48219D3C115C /* PaceSparklineView.swift */; };
-		6F242558E79A4653BAAAE3FB /* ActivityListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FDF0BD38D9467B99B2C4D7 /* ActivityListView.swift */; };
-		B9C538ECD15D4CE3B5B4186E /* ActivityInsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D6AFD9DABC41629606A762 /* ActivityInsightsView.swift */; };
-		4E9F3E9C7E3A4840ACD9DA73 /* ActivityIntervalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B789284BE2A474BA89993F2 /* ActivityIntervalTests.swift */; };
-		AAAA000000000000000000D3 /* CustomPromptStyleStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000D4 /* CustomPromptStyleStoreTests.swift */; };
-		BB00CC010000000000000001 /* WelcomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00CC010000000000000002 /* WelcomeViewModelTests.swift */; };
-		AAAA000000000000000000E1 /* CustomPromptEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000E2 /* CustomPromptEditorView.swift */; };
+		F28633E25671B876232C0F34 /* BackupSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB8B7996545B4CEF51D686E /* BackupSerializationTests.swift */; };
+		FA9B9D71DB2B3EA84CC73FEE /* AudioFileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90392F316E29A62DA1F0DE0E /* AudioFileStore.swift */; };
+		FE15922AE9DAD82F62BA4601 /* NewWalkComputationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E892B071C7BE6EBD74F3FC /* NewWalkComputationTests.swift */; };
 		PERM000100000003 /* PermissionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = PERM000100000002 /* PermissionsViewModel.swift */; };
 		PERM000100000005 /* PermissionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PERM000100000004 /* PermissionsViewModelTests.swift */; };
 		PERM000100000007 /* PermissionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = PERM000100000006 /* PermissionsView.swift */; };
-		CC00000200000000SEASON01 /* SeasonalColorEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000SEASON01 /* SeasonalColorEngine.swift */; };
-		CC00000200000000SCENER01 /* SceneryGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000SCENER01 /* SceneryGenerator.swift */; };
-		CC00000200000000CALLIG01 /* CalligraphyPathRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000CALLIG01 /* CalligraphyPathRenderer.swift */; };
-		CC00000200000000WKDOTV01 /* WalkDotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000WKDOTV01 /* WalkDotView.swift */; };
-		CC00000200000000INKSCR01 /* InkScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000INKSCR01 /* InkScrollView.swift */; };
-		CC00000200000000HAPTIC01 /* ScrollHapticEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000HAPTIC01 /* ScrollHapticEngine.swift */; };
-		CC00000200000000MILEST01 /* MilestoneMarkerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000MILEST01 /* MilestoneMarkerView.swift */; };
-		CC00000200000000TREESH01 /* TreeShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000TREESH01 /* TreeShape.swift */; };
-		CC00000200000000WINTRT01 /* WinterTreeShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000WINTRT01 /* WinterTreeShape.swift */; };
-		CC00000200000000MOUNTN01 /* MountainShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000MOUNTN01 /* MountainShape.swift */; };
-		CC00000200000000GRASSH01 /* GrassShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000GRASSH01 /* GrassShape.swift */; };
-		CC00000200000000TORIIG01 /* ToriiGateShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000TORIIG01 /* ToriiGateShape.swift */; };
-		CC00000200000000MOONSH01 /* MoonShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000MOONSH01 /* MoonShape.swift */; };
-		CC00000200000000DEBUGS01 /* DebugDataSeeder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000DEBUGS01 /* DebugDataSeeder.swift */; };
-		CC00000200000000MAINTB01 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000MAINTB01 /* MainTabView.swift */; };
-		CC00000200000000WKSTRT01 /* WalkStartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000WKSTRT01 /* WalkStartView.swift */; };
-		CC00000200000000WKMODE01 /* WalkMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000WKMODE01 /* WalkMode.swift */; };
-		CC00000200000000LUNRPH01 /* LunarPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000LUNRPH01 /* LunarPhase.swift */; };
-		CC00000200000000MOONPV01 /* MoonPhaseView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000MOONPV01 /* MoonPhaseView.swift */; };
-		CC00000200000000SETTVW01 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000SETTVW01 /* SettingsView.swift */; };
-		CC00000200000000SCENIV01 /* SceneryItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000SCENIV01 /* SceneryItemView.swift */; };
-		CC00000200000000LANTRN01 /* LanternShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000LANTRN01 /* LanternShape.swift */; };
-		CC00000200000000BTRFLY01 /* ButterflyShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000BTRFLY01 /* ButterflyShape.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -273,20 +265,16 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
-		A74490DBCE024418B78E73B2 /* WalkCheckpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkCheckpoint.swift; sourceTree = "<group>"; };
-		D8134F8A37D74FB3805684F1 /* WalkSessionGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkSessionGuard.swift; sourceTree = "<group>"; };
-		F0F0F00200000001AABBCC01 /* CormorantGaramond-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "CormorantGaramond-Light.otf"; sourceTree = "<group>"; };
-		F0F0F00200000002AABBCC02 /* CormorantGaramond-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "CormorantGaramond-Regular.otf"; sourceTree = "<group>"; };
-		F0F0F00200000003AABBCC03 /* CormorantGaramond-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "CormorantGaramond-SemiBold.otf"; sourceTree = "<group>"; };
-		F0F0F00200000004AABBCC04 /* Lato-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Regular.ttf"; sourceTree = "<group>"; };
-		F0F0F00200000005AABBCC05 /* Lato-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Bold.ttf"; sourceTree = "<group>"; };
+		04D6AFD9DABC41629606A762 /* ActivityInsightsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityInsightsView.swift; sourceTree = "<group>"; };
+		0F5581F46A4FFE9ED1D2DCEB /* SoundSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundSettingsView.swift; sourceTree = "<group>"; };
+		16BE9557700152F043C359DC /* WalkShareView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkShareView.swift; sourceTree = "<group>"; };
+		1725921B51E95B8BB46C90E4 /* AudioDownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDownloadManager.swift; sourceTree = "<group>"; };
 		1AB8B7996545B4CEF51D686E /* BackupSerializationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BackupSerializationTests.swift; sourceTree = "<group>"; };
+		1BA57CE96EE3401595264807 /* ActivityInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityInterval.swift; sourceTree = "<group>"; };
 		2201BCA829423DF100F54277 /* View+Navigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+Navigation.swift"; sourceTree = "<group>"; };
 		2201BCAA29423E1600F54277 /* NavigationLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationLink.swift; sourceTree = "<group>"; };
-
 		2204A1DC255ACB1100906CFE /* DataTypeProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataTypeProtocol.swift; sourceTree = "<group>"; };
 		2204E427295DF28C00243FC3 /* SetupCoordinatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupCoordinatorView.swift; sourceTree = "<group>"; };
-
 		2207B75523128F8A00BA71B5 /* CLLocation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLLocation.swift; sourceTree = "<group>"; };
 		2209E53824DD4A8F00BBFC2F /* AltitudeManagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AltitudeManagement.swift; sourceTree = "<group>"; };
 		2213137C23B4110700881806 /* PermissionManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionManager.swift; sourceTree = "<group>"; };
@@ -352,7 +340,6 @@
 		22A5D02D25C1A57600C30786 /* TempV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempV2.swift; sourceTree = "<group>"; };
 		22A5D03225C1AB2200C30786 /* TempV3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempV3.swift; sourceTree = "<group>"; };
 		22A5D03525C1ABDA00C30786 /* TempV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempV4.swift; sourceTree = "<group>"; };
-
 		22B1DD80253F90700093822B /* DataStack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DataStack.swift; sourceTree = "<group>"; };
 		22B1DD81253F90700093822B /* SQLiteStore.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SQLiteStore.swift; sourceTree = "<group>"; };
 		22B1DD89253F90FD0093822B /* IntermediateDataModelProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = IntermediateDataModelProtocol.swift; sourceTree = "<group>"; };
@@ -372,13 +359,6 @@
 		22BBDD3124D77C2B00225AE4 /* StepCounter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StepCounter.swift; sourceTree = "<group>"; };
 		22BC99142941D97600D9B1A5 /* WelcomeViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeViewModel.swift; sourceTree = "<group>"; };
 		22BC99152941D97600D9B1A5 /* WelcomeView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeView.swift; sourceTree = "<group>"; };
-		AABB000100000001 /* WelcomeAnimationState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeAnimationState.swift; sourceTree = "<group>"; };
-		BREATH000000000000000001 /* BreathTransitionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BreathTransitionView.swift; sourceTree = "<group>"; };
-
-
-
-
-
 		22BC99272941D9A800D9B1A5 /* MetricViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetricViewModel.swift; sourceTree = "<group>"; };
 		22BC99292941D9A800D9B1A5 /* CloseButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CloseButton.swift; sourceTree = "<group>"; };
 		22BC992A2941D9A800D9B1A5 /* ActionButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionButton.swift; sourceTree = "<group>"; };
@@ -387,8 +367,6 @@
 		22BC992D2941D9A800D9B1A5 /* CardView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardView.swift; sourceTree = "<group>"; };
 		22BC992E2941D9A800D9B1A5 /* ProgressView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProgressView.swift; sourceTree = "<group>"; };
 		22BC992F2941D9A800D9B1A5 /* FeatureView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FeatureView.swift; sourceTree = "<group>"; };
-
-
 		22BC99322941D9A800D9B1A5 /* CornerView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CornerView.swift; sourceTree = "<group>"; };
 		22BC99332941D9A800D9B1A5 /* PermissionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PermissionView.swift; sourceTree = "<group>"; };
 		22BC99342941D9A800D9B1A5 /* MetricView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MetricView.swift; sourceTree = "<group>"; };
@@ -398,15 +376,12 @@
 		22BC99382941D9A800D9B1A5 /* WalkCard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WalkCard.swift; sourceTree = "<group>"; };
 		22BC994A2941DA3400D9B1A5 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
 		22BC994C2941DA6200D9B1A5 /* Binding.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Binding.swift; sourceTree = "<group>"; };
-
 		22BC99512941DC9900D9B1A5 /* Color.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Color.swift; sourceTree = "<group>"; };
-
 		22BD1F3D247462FF00415A06 /* ApplicationStateObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationStateObserver.swift; sourceTree = "<group>"; };
 		22BD1F3F2474638200415A06 /* ApplicationStateObservation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationStateObservation.swift; sourceTree = "<group>"; };
 		22BD1F41247463DF00415A06 /* ApplicationState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApplicationState.swift; sourceTree = "<group>"; };
 		22BF623C26E6B1D2008C904C /* WalkBuilderComponentStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkBuilderComponentStatus.swift; sourceTree = "<group>"; };
 		22C09B9326514BD8004AF34F /* DataInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataInterface.swift; sourceTree = "<group>"; };
-
 		22C1107F24532C69009ACE81 /* WalkMapImageRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkMapImageRequest.swift; sourceTree = "<group>"; };
 		22C1108124532DBA009ACE81 /* WalkMapImageSize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkMapImageSize.swift; sourceTree = "<group>"; };
 		22C1108324532E36009ACE81 /* WalkMapImageQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkMapImageQueue.swift; sourceTree = "<group>"; };
@@ -435,103 +410,112 @@
 		22FEA0AC24CDD4CA0007CA9C /* FileManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileManager.swift; sourceTree = "<group>"; };
 		22FEA0AE24CDD7B50007CA9C /* DiskStorage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DiskStorage.swift; sourceTree = "<group>"; };
 		22FEA0B024CDDFF80007CA9C /* CustomByteFormatting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomByteFormatting.swift; sourceTree = "<group>"; };
+		263D620E1DB30C5FCA0143CC /* SoundManagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundManagement.swift; sourceTree = "<group>"; };
+		2722224F049B455DB473E7C9 /* PilgrimV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV2.swift; sourceTree = "<group>"; };
+		2CA2B0038D4875801C41DE26 /* AudioAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioAsset.swift; sourceTree = "<group>"; };
+		390BFBA7B83028EA625B0CF9 /* AudioManifestService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioManifestService.swift; sourceTree = "<group>"; };
+		3B789284BE2A474BA89993F2 /* ActivityIntervalTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActivityIntervalTests.swift; sourceTree = "<group>"; };
+		3E5EFD54CACA590B1BE78B75 /* BellPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BellPlayer.swift; sourceTree = "<group>"; };
 		4181215714A52E71449BC390 /* WalkDataFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkDataFactory.swift; sourceTree = "<group>"; };
+		4AE6DC51742E035602E624F1 /* AudioSessionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionCoordinator.swift; sourceTree = "<group>"; };
+		4B6BF30D6A9C48219D3C115C /* PaceSparklineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaceSparklineView.swift; sourceTree = "<group>"; };
+		5D9D07CA4444A7B548B5CFA4 /* ShareService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShareService.swift; sourceTree = "<group>"; };
+		6F17456C4D1E2DAED49B9AC6 /* SoundscapePlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundscapePlayer.swift; sourceTree = "<group>"; };
 		721BF267E7540B2B259806D1 /* XCTestCase+Combine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Combine.swift"; sourceTree = "<group>"; };
+		8019A1ED39BF4E889F5DF99C /* WaveformGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaveformGenerator.swift; sourceTree = "<group>"; };
 		8C0699EE439FF3DC5E16B8E0 /* Pods-Pilgrim.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pilgrim.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Pilgrim/Pods-Pilgrim.debug.xcconfig"; sourceTree = "<group>"; };
+		8E0BF1B23139F428720EB2CF /* WalkShareViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkShareViewModel.swift; sourceTree = "<group>"; };
+		90392F316E29A62DA1F0DE0E /* AudioFileStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioFileStore.swift; sourceTree = "<group>"; };
+		964D4C7663494F3ABBEEF84F /* ActivityIntervalInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIntervalInterface.swift; sourceTree = "<group>"; };
 		980407DB8189D982A61A73F9 /* Pods-UnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.release.xcconfig"; sourceTree = "<group>"; };
-		AA000001PILGRIMLOGO00000 /* PilgrimLogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimLogoView.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F601020304050A /* PilgrimV3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV3.swift; sourceTree = "<group>"; };
+		A5B6C7D8E9F0A1B2C3D4E5F6 /* PilgrimV5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV5.swift; sourceTree = "<group>"; };
+		A74490DBCE024418B78E73B2 /* WalkCheckpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkCheckpoint.swift; sourceTree = "<group>"; };
 		AA000001FOOTPRINTSHAPE00 /* FootprintShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FootprintShape.swift; sourceTree = "<group>"; };
+		AA000001PILGRIMLOGO00000 /* PilgrimLogoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimLogoView.swift; sourceTree = "<group>"; };
 		AA0001010000000000000001 /* HomeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeView.swift; sourceTree = "<group>"; };
 		AA0001010000000000000002 /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		AA0001010000000000000003 /* WalkRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkRowView.swift; sourceTree = "<group>"; };
 		AA0001010000000000000004 /* ActiveWalkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveWalkView.swift; sourceTree = "<group>"; };
 		AA0001010000000000000005 /* ActiveWalkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveWalkViewModel.swift; sourceTree = "<group>"; };
 		AA0001010000000000000006 /* WalkSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkSummaryView.swift; sourceTree = "<group>"; };
-		AA00040100000000000001 /* VoiceRecordingRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecordingRow.swift; sourceTree = "<group>"; };
-		AA00040100000000000003 /* AudioPlayerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayerModel.swift; sourceTree = "<group>"; };
 		AA0001010000000000000007 /* MainCoordinatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCoordinatorView.swift; sourceTree = "<group>"; };
 		AA00020100000000000001 /* VoiceRecording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecording.swift; sourceTree = "<group>"; };
 		AA00020100000000000003 /* VoiceRecordingManagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecordingManagement.swift; sourceTree = "<group>"; };
 		AA00030100000000000001 /* MeditationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeditationView.swift; sourceTree = "<group>"; };
+		AA00040100000000000001 /* VoiceRecordingRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecordingRow.swift; sourceTree = "<group>"; };
+		AA00040100000000000003 /* AudioPlayerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioPlayerModel.swift; sourceTree = "<group>"; };
 		AAAA000000000000000000B2 /* TranscriptionService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptionService.swift; sourceTree = "<group>"; };
 		AAAA000000000000000000C2 /* PromptGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptGenerator.swift; sourceTree = "<group>"; };
 		AAAA000000000000000000C4 /* PromptListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptListView.swift; sourceTree = "<group>"; };
 		AAAA000000000000000000C6 /* PromptDetailView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PromptDetailView.swift; sourceTree = "<group>"; };
 		AAAA000000000000000000D2 /* CustomPromptStyleStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPromptStyleStore.swift; sourceTree = "<group>"; };
-		B3E892B071C7BE6EBD74F3FC /* NewWalkComputationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NewWalkComputationTests.swift; sourceTree = "<group>"; };
-		BB00AA010000000000000001 /* PilgrimV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV1.swift; sourceTree = "<group>"; };
-		C1B583B563EC4764AEDC9E50 /* Pods-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
-		C1C8D965F1351F85D4E4F35D /* Pods-Pilgrim.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pilgrim.release.xcconfig"; path = "Pods/Target Support Files/Pods-Pilgrim/Pods-Pilgrim.release.xcconfig"; sourceTree = "<group>"; };
-		C2D23FF60A762C30296A69E6 /* ComputationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ComputationTests.swift; sourceTree = "<group>"; };
-		C56A574B3F5BFCBF50DB5368 /* Pods_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		CC00BB010000000000000001 /* VoiceRecordingInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecordingInterface.swift; sourceTree = "<group>"; };
-		D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Pilgrim.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		DD00CC0100000000000001 /* MeditateDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeditateDetection.swift; sourceTree = "<group>"; };
-		DD13E8087B26CC89725C3041 /* PromptGeneratorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptGeneratorTests.swift; sourceTree = "<group>"; };
-		CC00000100000000LUNRTST1 /* LunarPhaseTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LunarPhaseTests.swift; sourceTree = "<group>"; };
-		E4102471AC572B099189FB03 /* WalkBuilderStatusTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkBuilderStatusTests.swift; sourceTree = "<group>"; };
-		EC2D4ACA7F21BA80523DF98C /* DateFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DateFactory.swift; sourceTree = "<group>"; };
-		2722224F049B455DB473E7C9 /* PilgrimV2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV2.swift; sourceTree = "<group>"; };
-		A1B2C3D4E5F601020304050A /* PilgrimV3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV3.swift; sourceTree = "<group>"; };
-		F1A2B3C4D5E6F7A8B9C0D1E2 /* WalkFavicon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkFavicon.swift; sourceTree = "<group>"; };
-		F1A2B3C4D5E6F7A8B9C0D1E4 /* PilgrimV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV4.swift; sourceTree = "<group>"; };
-		A5B6C7D8E9F0A1B2C3D4E5F6 /* PilgrimV5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV5.swift; sourceTree = "<group>"; };
-		F1A2B3C4D5E6F7A8B9C0D1E6 /* FaviconSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconSelectorView.swift; sourceTree = "<group>"; };
-		1BA57CE96EE3401595264807 /* ActivityInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityInterval.swift; sourceTree = "<group>"; };
-		964D4C7663494F3ABBEEF84F /* ActivityIntervalInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIntervalInterface.swift; sourceTree = "<group>"; };
-		C9CBD6B08E4C437DA90FDDB0 /* ActivityTimelineBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityTimelineBar.swift; sourceTree = "<group>"; };
-		4B6BF30D6A9C48219D3C115C /* PaceSparklineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaceSparklineView.swift; sourceTree = "<group>"; };
-		D2FDF0BD38D9467B99B2C4D7 /* ActivityListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityListView.swift; sourceTree = "<group>"; };
-		04D6AFD9DABC41629606A762 /* ActivityInsightsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityInsightsView.swift; sourceTree = "<group>"; };
-		3B789284BE2A474BA89993F2 /* ActivityIntervalTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActivityIntervalTests.swift; sourceTree = "<group>"; };
 		AAAA000000000000000000D4 /* CustomPromptStyleStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CustomPromptStyleStoreTests.swift; sourceTree = "<group>"; };
-		BB00CC010000000000000002 /* WelcomeViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WelcomeViewModelTests.swift; sourceTree = "<group>"; };
-		PERM000100000002 /* PermissionsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PermissionsViewModel.swift; sourceTree = "<group>"; };
-		PERM000100000004 /* PermissionsViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PermissionsViewModelTests.swift; sourceTree = "<group>"; };
-		PERM000100000006 /* PermissionsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PermissionsView.swift; sourceTree = "<group>"; };
 		AAAA000000000000000000E2 /* CustomPromptEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPromptEditorView.swift; sourceTree = "<group>"; };
-		CC00000100000000SEASON01 /* SeasonalColorEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonalColorEngine.swift; sourceTree = "<group>"; };
-		CC00000100000000SCENER01 /* SceneryGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneryGenerator.swift; sourceTree = "<group>"; };
-		CC00000100000000CALLIG01 /* CalligraphyPathRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalligraphyPathRenderer.swift; sourceTree = "<group>"; };
-		CC00000100000000WKDOTV01 /* WalkDotView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkDotView.swift; sourceTree = "<group>"; };
-		CC00000100000000INKSCR01 /* InkScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InkScrollView.swift; sourceTree = "<group>"; };
-		CC00000100000000HAPTIC01 /* ScrollHapticEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollHapticEngine.swift; sourceTree = "<group>"; };
-		CC00000100000000MILEST01 /* MilestoneMarkerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneMarkerView.swift; sourceTree = "<group>"; };
-		CC00000100000000TREESH01 /* TreeShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeShape.swift; sourceTree = "<group>"; };
-		CC00000100000000WINTRT01 /* WinterTreeShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinterTreeShape.swift; sourceTree = "<group>"; };
-		CC00000100000000MOUNTN01 /* MountainShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MountainShape.swift; sourceTree = "<group>"; };
-		CC00000100000000GRASSH01 /* GrassShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrassShape.swift; sourceTree = "<group>"; };
-		CC00000100000000TORIIG01 /* ToriiGateShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToriiGateShape.swift; sourceTree = "<group>"; };
-		CC00000100000000MOONSH01 /* MoonShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoonShape.swift; sourceTree = "<group>"; };
-		CC00000100000000DEBUGS01 /* DebugDataSeeder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugDataSeeder.swift; sourceTree = "<group>"; };
-		CC00000100000000MAINTB01 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
-		CC00000100000000WKSTRT01 /* WalkStartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkStartView.swift; sourceTree = "<group>"; };
-		CC00000100000000WKMODE01 /* WalkMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkMode.swift; sourceTree = "<group>"; };
-		CC00000100000000LUNRPH01 /* LunarPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LunarPhase.swift; sourceTree = "<group>"; };
-		CC00000100000000MOONPV01 /* MoonPhaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoonPhaseView.swift; sourceTree = "<group>"; };
-		CC00000100000000SETTVW01 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
-		CC00000100000000SCENIV01 /* SceneryItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneryItemView.swift; sourceTree = "<group>"; };
-		CC00000100000000LANTRN01 /* LanternShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanternShape.swift; sourceTree = "<group>"; };
-		CC00000100000000BTRFLY01 /* ButterflyShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButterflyShape.swift; sourceTree = "<group>"; };
-		2CA2B0038D4875801C41DE26 /* AudioAsset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioAsset.swift; sourceTree = "<group>"; };
-		90392F316E29A62DA1F0DE0E /* AudioFileStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioFileStore.swift; sourceTree = "<group>"; };
-		4AE6DC51742E035602E624F1 /* AudioSessionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionCoordinator.swift; sourceTree = "<group>"; };
-		390BFBA7B83028EA625B0CF9 /* AudioManifestService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioManifestService.swift; sourceTree = "<group>"; };
-		1725921B51E95B8BB46C90E4 /* AudioDownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDownloadManager.swift; sourceTree = "<group>"; };
-		3E5EFD54CACA590B1BE78B75 /* BellPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BellPlayer.swift; sourceTree = "<group>"; };
-		6F17456C4D1E2DAED49B9AC6 /* SoundscapePlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundscapePlayer.swift; sourceTree = "<group>"; };
-		263D620E1DB30C5FCA0143CC /* SoundManagement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundManagement.swift; sourceTree = "<group>"; };
-		0F5581F46A4FFE9ED1D2DCEB /* SoundSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundSettingsView.swift; sourceTree = "<group>"; };
-		C37A4E244FA34A828856F814 /* VoiceEnhancer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceEnhancer.swift; sourceTree = "<group>"; };
-		8019A1ED39BF4E889F5DF99C /* WaveformGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaveformGenerator.swift; sourceTree = "<group>"; };
-		EE12D19DC32D4F8FB3A35965 /* WaveformCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaveformCache.swift; sourceTree = "<group>"; };
-		F1EF72AE69CD4C1599071304 /* TalkSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkSettingsView.swift; sourceTree = "<group>"; };
-		D4E5F6A7B8C9D0E1F2A3B4C6 /* RecordingsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingsListView.swift; sourceTree = "<group>"; };
+		AAAA00000000000000000EL2 /* ElevationProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElevationProfileView.swift; sourceTree = "<group>"; };
 		AAAA00000000000000000MF2 /* RouteSegment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteSegment.swift; sourceTree = "<group>"; };
 		AAAA00000000000000000MF4 /* PilgrimAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimAnnotation.swift; sourceTree = "<group>"; };
 		AAAA00000000000000000MF6 /* PilgrimMapStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimMapStyle.swift; sourceTree = "<group>"; };
 		AAAA00000000000000000MF8 /* PilgrimMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimMapView.swift; sourceTree = "<group>"; };
-		AAAA00000000000000000EL2 /* ElevationProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElevationProfileView.swift; sourceTree = "<group>"; };
+		AABB000100000001 /* WelcomeAnimationState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeAnimationState.swift; sourceTree = "<group>"; };
+		B3E892B071C7BE6EBD74F3FC /* NewWalkComputationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NewWalkComputationTests.swift; sourceTree = "<group>"; };
+		BB00AA010000000000000001 /* PilgrimV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV1.swift; sourceTree = "<group>"; };
+		BB00CC010000000000000002 /* WelcomeViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WelcomeViewModelTests.swift; sourceTree = "<group>"; };
+		BREATH000000000000000001 /* BreathTransitionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BreathTransitionView.swift; sourceTree = "<group>"; };
+		C1B583B563EC4764AEDC9E50 /* Pods-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
+		C1C8D965F1351F85D4E4F35D /* Pods-Pilgrim.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pilgrim.release.xcconfig"; path = "Pods/Target Support Files/Pods-Pilgrim/Pods-Pilgrim.release.xcconfig"; sourceTree = "<group>"; };
+		C2D23FF60A762C30296A69E6 /* ComputationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ComputationTests.swift; sourceTree = "<group>"; };
+		C37A4E244FA34A828856F814 /* VoiceEnhancer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceEnhancer.swift; sourceTree = "<group>"; };
+		C56A574B3F5BFCBF50DB5368 /* Pods_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		C9CBD6B08E4C437DA90FDDB0 /* ActivityTimelineBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityTimelineBar.swift; sourceTree = "<group>"; };
+		CC00000100000000BTRFLY01 /* ButterflyShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButterflyShape.swift; sourceTree = "<group>"; };
+		CC00000100000000CALLIG01 /* CalligraphyPathRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalligraphyPathRenderer.swift; sourceTree = "<group>"; };
+		CC00000100000000DEBUGS01 /* DebugDataSeeder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugDataSeeder.swift; sourceTree = "<group>"; };
+		CC00000100000000GRASSH01 /* GrassShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GrassShape.swift; sourceTree = "<group>"; };
+		CC00000100000000HAPTIC01 /* ScrollHapticEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollHapticEngine.swift; sourceTree = "<group>"; };
+		CC00000100000000INKSCR01 /* InkScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InkScrollView.swift; sourceTree = "<group>"; };
+		CC00000100000000LANTRN01 /* LanternShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanternShape.swift; sourceTree = "<group>"; };
+		CC00000100000000LUNRPH01 /* LunarPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LunarPhase.swift; sourceTree = "<group>"; };
+		CC00000100000000LUNRTST1 /* LunarPhaseTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LunarPhaseTests.swift; sourceTree = "<group>"; };
+		CC00000100000000MAINTB01 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
+		CC00000100000000MILEST01 /* MilestoneMarkerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneMarkerView.swift; sourceTree = "<group>"; };
+		CC00000100000000MOONPV01 /* MoonPhaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoonPhaseView.swift; sourceTree = "<group>"; };
+		CC00000100000000MOONSH01 /* MoonShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoonShape.swift; sourceTree = "<group>"; };
+		CC00000100000000MOUNTN01 /* MountainShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MountainShape.swift; sourceTree = "<group>"; };
+		CC00000100000000SCENER01 /* SceneryGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneryGenerator.swift; sourceTree = "<group>"; };
+		CC00000100000000SCENIV01 /* SceneryItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneryItemView.swift; sourceTree = "<group>"; };
+		CC00000100000000SEASON01 /* SeasonalColorEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonalColorEngine.swift; sourceTree = "<group>"; };
+		CC00000100000000SETTVW01 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		CC00000100000000TORIIG01 /* ToriiGateShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToriiGateShape.swift; sourceTree = "<group>"; };
+		CC00000100000000TREESH01 /* TreeShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeShape.swift; sourceTree = "<group>"; };
+		CC00000100000000WINTRT01 /* WinterTreeShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinterTreeShape.swift; sourceTree = "<group>"; };
+		CC00000100000000WKDOTV01 /* WalkDotView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkDotView.swift; sourceTree = "<group>"; };
+		CC00000100000000WKMODE01 /* WalkMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkMode.swift; sourceTree = "<group>"; };
+		CC00000100000000WKSTRT01 /* WalkStartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkStartView.swift; sourceTree = "<group>"; };
+		CC00BB010000000000000001 /* VoiceRecordingInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecordingInterface.swift; sourceTree = "<group>"; };
+		D0EA6F12A77BD40C46E34D47 /* SharePayload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SharePayload.swift; sourceTree = "<group>"; };
+		D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Pilgrim.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D2FDF0BD38D9467B99B2C4D7 /* ActivityListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityListView.swift; sourceTree = "<group>"; };
+		D4E5F6A7B8C9D0E1F2A3B4C6 /* RecordingsListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecordingsListView.swift; sourceTree = "<group>"; };
+		D8134F8A37D74FB3805684F1 /* WalkSessionGuard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkSessionGuard.swift; sourceTree = "<group>"; };
+		DD00CC0100000000000001 /* MeditateDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeditateDetection.swift; sourceTree = "<group>"; };
+		DD13E8087B26CC89725C3041 /* PromptGeneratorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PromptGeneratorTests.swift; sourceTree = "<group>"; };
+		E4102471AC572B099189FB03 /* WalkBuilderStatusTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkBuilderStatusTests.swift; sourceTree = "<group>"; };
+		E6E1B5A537C865F5416F6EF2 /* RouteDownsampler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RouteDownsampler.swift; sourceTree = "<group>"; };
+		EC2D4ACA7F21BA80523DF98C /* DateFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DateFactory.swift; sourceTree = "<group>"; };
+		EE12D19DC32D4F8FB3A35965 /* WaveformCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaveformCache.swift; sourceTree = "<group>"; };
+		F0F0F00200000001AABBCC01 /* CormorantGaramond-Light.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "CormorantGaramond-Light.otf"; sourceTree = "<group>"; };
+		F0F0F00200000002AABBCC02 /* CormorantGaramond-Regular.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "CormorantGaramond-Regular.otf"; sourceTree = "<group>"; };
+		F0F0F00200000003AABBCC03 /* CormorantGaramond-SemiBold.otf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "CormorantGaramond-SemiBold.otf"; sourceTree = "<group>"; };
+		F0F0F00200000004AABBCC04 /* Lato-Regular.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Regular.ttf"; sourceTree = "<group>"; };
+		F0F0F00200000005AABBCC05 /* Lato-Bold.ttf */ = {isa = PBXFileReference; lastKnownFileType = file; path = "Lato-Bold.ttf"; sourceTree = "<group>"; };
+		F1A2B3C4D5E6F7A8B9C0D1E2 /* WalkFavicon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkFavicon.swift; sourceTree = "<group>"; };
+		F1A2B3C4D5E6F7A8B9C0D1E4 /* PilgrimV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV4.swift; sourceTree = "<group>"; };
+		F1A2B3C4D5E6F7A8B9C0D1E6 /* FaviconSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconSelectorView.swift; sourceTree = "<group>"; };
+		F1EF72AE69CD4C1599071304 /* TalkSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkSettingsView.swift; sourceTree = "<group>"; };
+		PERM000100000002 /* PermissionsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PermissionsViewModel.swift; sourceTree = "<group>"; };
+		PERM000100000004 /* PermissionsViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PermissionsViewModelTests.swift; sourceTree = "<group>"; };
+		PERM000100000006 /* PermissionsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PermissionsView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -609,11 +593,12 @@
 			children = (
 				225C0F772931D26600B9B45F /* Root */,
 				AA0001010000000000000021 /* Home */,
-				CC00000100000000SETGRP01 /* Settings_Scene */,
+				CC00000100000000SETGRP01 /* Settings */,
 				AA0001010000000000000022 /* ActiveWalk */,
 				AA0001010000000000000023 /* WalkSummary */,
 				22BC99182941D97F00D9B1A5 /* Setup */,
 				AAAA000000000000000000C7 /* Prompts */,
+				5F0241D04FDB88FFB08D690B /* WalkShare */,
 			);
 			path = Scenes;
 			sourceTree = "<group>";
@@ -772,18 +757,6 @@
 			path = "Support Files";
 			sourceTree = "<group>";
 		};
-		F0F0F00300000000AABBCC00 /* Fonts */ = {
-			isa = PBXGroup;
-			children = (
-				F0F0F00200000001AABBCC01 /* CormorantGaramond-Light.otf */,
-				F0F0F00200000002AABBCC02 /* CormorantGaramond-Regular.otf */,
-				F0F0F00200000003AABBCC03 /* CormorantGaramond-SemiBold.otf */,
-				F0F0F00200000004AABBCC04 /* Lato-Regular.ttf */,
-				F0F0F00200000005AABBCC05 /* Lato-Bold.ttf */,
-			);
-			path = Fonts;
-			sourceTree = "<group>";
-		};
 		22B6CF4A22CA0814002D2FB0 = {
 			isa = PBXGroup;
 			children = (
@@ -853,6 +826,7 @@
 				AAAA000000000000000000C2 /* PromptGenerator.swift */,
 				AAAA000000000000000000D2 /* CustomPromptStyleStore.swift */,
 				CC00000100000000LUNRPH01 /* LunarPhase.swift */,
+				8534424C43418F78E8F15520 /* Share */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -867,12 +841,10 @@
 				22E5057025C96B3600DC9AC1 /* UIKit */,
 				221436BA244356A90010D82B /* Array.swift */,
 				2207B75523128F8A00BA71B5 /* CLLocation.swift */,
-
 				22FEA0A624CDA3FF0007CA9C /* ClosedRange.swift */,
 				226E9A4A23F01E6E00992815 /* Date.swift */,
 				2230926224D7573C00A3F636 /* Double.swift */,
 				22FEA0AC24CDD4CA0007CA9C /* FileManager.swift */,
-
 				22623C0022DFBB71004065C6 /* Sequence.swift */,
 				221436C02443960A0010D82B /* UnitCount.swift */,
 				22877543234A75A10078CE12 /* Units.swift */,
@@ -889,15 +861,6 @@
 				AABB000100000001 /* WelcomeAnimationState.swift */,
 			);
 			path = Welcome;
-			sourceTree = "<group>";
-		};
-		PERM000100000001 /* Permissions */ = {
-			isa = PBXGroup;
-			children = (
-				PERM000100000002 /* PermissionsViewModel.swift */,
-				PERM000100000006 /* PermissionsView.swift */,
-			);
-			path = Permissions;
 			sourceTree = "<group>";
 		};
 		22BC99182941D97F00D9B1A5 /* Setup */ = {
@@ -917,12 +880,10 @@
 				22BC99282941D9A800D9B1A5 /* Buttons */,
 				CC00000100000000SCGRP001 /* Scenery */,
 				22BC99352941D9A800D9B1A5 /* AxisGeometryReader.swift */,
-
 				22BC992D2941D9A800D9B1A5 /* CardView.swift */,
 				22BC99322941D9A800D9B1A5 /* CornerView.swift */,
 				22BC992F2941D9A800D9B1A5 /* FeatureView.swift */,
 				22BC99372941D9A800D9B1A5 /* FeatureViewModel.swift */,
-
 				AAAA00000000000000000MF8 /* PilgrimMapView.swift */,
 				22BC99342941D9A800D9B1A5 /* MetricView.swift */,
 				22BC99272941D9A800D9B1A5 /* MetricViewModel.swift */,
@@ -1086,6 +1047,24 @@
 			path = WalkBuilder;
 			sourceTree = "<group>";
 		};
+		3A2B6107FC73A26AFA4F2434 /* Audio */ = {
+			isa = PBXGroup;
+			children = (
+				2CA2B0038D4875801C41DE26 /* AudioAsset.swift */,
+				90392F316E29A62DA1F0DE0E /* AudioFileStore.swift */,
+				4AE6DC51742E035602E624F1 /* AudioSessionCoordinator.swift */,
+				390BFBA7B83028EA625B0CF9 /* AudioManifestService.swift */,
+				1725921B51E95B8BB46C90E4 /* AudioDownloadManager.swift */,
+				3E5EFD54CACA590B1BE78B75 /* BellPlayer.swift */,
+				6F17456C4D1E2DAED49B9AC6 /* SoundscapePlayer.swift */,
+				263D620E1DB30C5FCA0143CC /* SoundManagement.swift */,
+				C37A4E244FA34A828856F814 /* VoiceEnhancer.swift */,
+				8019A1ED39BF4E889F5DF99C /* WaveformGenerator.swift */,
+				EE12D19DC32D4F8FB3A35965 /* WaveformCache.swift */,
+			);
+			path = Audio;
+			sourceTree = "<group>";
+		};
 		4C304343458BA5DB0C7E2372 /* Helpers */ = {
 			isa = PBXGroup;
 			children = (
@@ -1095,6 +1074,27 @@
 			);
 			name = Helpers;
 			path = Helpers;
+			sourceTree = "<group>";
+		};
+		5F0241D04FDB88FFB08D690B /* WalkShare */ = {
+			isa = PBXGroup;
+			children = (
+				16BE9557700152F043C359DC /* WalkShareView.swift */,
+				8E0BF1B23139F428720EB2CF /* WalkShareViewModel.swift */,
+			);
+			name = WalkShare;
+			path = WalkShare;
+			sourceTree = "<group>";
+		};
+		8534424C43418F78E8F15520 /* Share */ = {
+			isa = PBXGroup;
+			children = (
+				D0EA6F12A77BD40C46E34D47 /* SharePayload.swift */,
+				E6E1B5A537C865F5416F6EF2 /* RouteDownsampler.swift */,
+				5D9D07CA4444A7B548B5CFA4 /* ShareService.swift */,
+			);
+			name = Share;
+			path = Share;
 			sourceTree = "<group>";
 		};
 		AA0001010000000000000021 /* Home */ = {
@@ -1176,25 +1176,7 @@
 			path = Scenery;
 			sourceTree = "<group>";
 		};
-		3A2B6107FC73A26AFA4F2434 /* Audio */ = {
-			isa = PBXGroup;
-			children = (
-				2CA2B0038D4875801C41DE26 /* AudioAsset.swift */,
-				90392F316E29A62DA1F0DE0E /* AudioFileStore.swift */,
-				4AE6DC51742E035602E624F1 /* AudioSessionCoordinator.swift */,
-				390BFBA7B83028EA625B0CF9 /* AudioManifestService.swift */,
-				1725921B51E95B8BB46C90E4 /* AudioDownloadManager.swift */,
-				3E5EFD54CACA590B1BE78B75 /* BellPlayer.swift */,
-				6F17456C4D1E2DAED49B9AC6 /* SoundscapePlayer.swift */,
-				263D620E1DB30C5FCA0143CC /* SoundManagement.swift */,
-				C37A4E244FA34A828856F814 /* VoiceEnhancer.swift */,
-				8019A1ED39BF4E889F5DF99C /* WaveformGenerator.swift */,
-				EE12D19DC32D4F8FB3A35965 /* WaveformCache.swift */,
-			);
-			path = Audio;
-			sourceTree = "<group>";
-		};
-		CC00000100000000SETGRP01 /* Settings_Scene */ = {
+		CC00000100000000SETGRP01 /* Settings */ = {
 			isa = PBXGroup;
 			children = (
 				CC00000100000000SETTVW01 /* SettingsView.swift */,
@@ -1203,6 +1185,27 @@
 				D4E5F6A7B8C9D0E1F2A3B4C6 /* RecordingsListView.swift */,
 			);
 			path = Settings;
+			sourceTree = "<group>";
+		};
+		F0F0F00300000000AABBCC00 /* Fonts */ = {
+			isa = PBXGroup;
+			children = (
+				F0F0F00200000001AABBCC01 /* CormorantGaramond-Light.otf */,
+				F0F0F00200000002AABBCC02 /* CormorantGaramond-Regular.otf */,
+				F0F0F00200000003AABBCC03 /* CormorantGaramond-SemiBold.otf */,
+				F0F0F00200000004AABBCC04 /* Lato-Regular.ttf */,
+				F0F0F00200000005AABBCC05 /* Lato-Bold.ttf */,
+			);
+			path = Fonts;
+			sourceTree = "<group>";
+		};
+		PERM000100000001 /* Permissions */ = {
+			isa = PBXGroup;
+			children = (
+				PERM000100000002 /* PermissionsViewModel.swift */,
+				PERM000100000006 /* PermissionsView.swift */,
+			);
+			path = Permissions;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1398,7 +1401,6 @@
 				22C09B9426514BD8004AF34F /* DataInterface.swift in Sources */,
 				227C690725423294000458BC /* EventInterface.swift in Sources */,
 				22BF623D26E6B1D2008C904C /* WalkBuilderComponentStatus.swift in Sources */,
-
 				229790F628F365B50072DC86 /* Publisher.swift in Sources */,
 				2273943C233BF6EA00176A07 /* WalkMapImageManager.swift in Sources */,
 				22A5D02625C1A45100C30786 /* TempValueConvertible.swift in Sources */,
@@ -1428,11 +1430,9 @@
 				22834F772542236000057FEB /* WalkEventInterface.swift in Sources */,
 				22F0000B234A1DF8008CFAD2 /* SwitchSetting.swift in Sources */,
 				221436B924432B390010D82B /* DataManager+Query.swift in Sources */,
-
 				224AF62A237624E80047CBDE /* CustomDateFormatting.swift in Sources */,
 				22C1108024532C69009ACE81 /* WalkMapImageRequest.swift in Sources */,
 				22BC99452941D9A800D9B1A5 /* MetricView.swift in Sources */,
-
 				2288F6B422E0FB5C0014471C /* UIColor.swift in Sources */,
 				221436C12443960A0010D82B /* UnitCount.swift in Sources */,
 				22BC993C2941D9A800D9B1A5 /* RoundedButton.swift in Sources */,
@@ -1440,23 +1440,18 @@
 				22DBFBE12349362900DE6E92 /* UserPreferences.swift in Sources */,
 				2287753E234A3DF60078CE12 /* TextInputSetting.swift in Sources */,
 				22BD1F402474638200415A06 /* ApplicationStateObservation.swift in Sources */,
-
 				2273943E233BF81800176A07 /* CustomImageCache.swift in Sources */,
-
 				22834F8225422D8200057FEB /* HeartRateDataSampleInterface.swift in Sources */,
 				22BC993E2941D9A800D9B1A5 /* CardView.swift in Sources */,
 				AA000002PILGRIMLOGO00000 /* PilgrimLogoView.swift in Sources */,
 				AA000002FOOTPRINTSHAPE00 /* FootprintShape.swift in Sources */,
-
 				2226A3BF240C441700FF7A94 /* TextViewSetting.swift in Sources */,
 				22F0000D234A2055008CFAD2 /* Setting.swift in Sources */,
 				2230926324D7573C00A3F636 /* Double.swift in Sources */,
 				22B1DD92253F91380093822B /* OutRunV3to4.swift in Sources */,
 				22BD1F3E247462FF00415A06 /* ApplicationStateObserver.swift in Sources */,
 				22B1DD9A253F91F20093822B /* OutRunV2.swift in Sources */,
-
 				22BC994B2941DA3400D9B1A5 /* Constants.swift in Sources */,
-
 				22BC99402941D9A800D9B1A5 /* FeatureView.swift in Sources */,
 				225BB02F2716E61000478E09 /* StatsHelper.swift in Sources */,
 				22B1DD82253F90700093822B /* DataStack.swift in Sources */,
@@ -1465,12 +1460,10 @@
 				22BC99482941D9A800D9B1A5 /* FeatureViewModel.swift in Sources */,
 				2221997F2439F6FF00ADAE24 /* CustomNumberFormatting.swift in Sources */,
 				22D299372402BDE400F3F6B8 /* TimeIntervalPickerSetting.swift in Sources */,
-
 				AAAA00000000000000000MF1 /* RouteSegment.swift in Sources */,
 				AAAA00000000000000000MF3 /* PilgrimAnnotation.swift in Sources */,
 				AAAA00000000000000000MF5 /* PilgrimMapStyle.swift in Sources */,
 				AAAA00000000000000000MF7 /* PilgrimMapView.swift in Sources */,
-
 				22834F73254220FC00057FEB /* WalkPauseInterface.swift in Sources */,
 				22A5D03625C1ABDA00C30786 /* TempV4.swift in Sources */,
 				221436BF2443746B0010D82B /* Event.swift in Sources */,
@@ -1497,7 +1490,6 @@
 				22D299332402B1AC00F3F6B8 /* InputViewSetting.swift in Sources */,
 				22B1DD93253F91380093822B /* OutRunV4.swift in Sources */,
 				22FEA0B124CDDFF80007CA9C /* CustomByteFormatting.swift in Sources */,
-
 				22BC994D2941DA6200D9B1A5 /* Binding.swift in Sources */,
 				22B6CF7022CA08C9002D2FB0 /* WalkBuilder.swift in Sources */,
 				221436BB244356A90010D82B /* Array.swift in Sources */,
@@ -1541,10 +1533,8 @@
 				2227C642234B66BC00CFE31A /* ButtonSetting.swift in Sources */,
 				221E47D123ECB837004EAB1D /* Backup.swift in Sources */,
 				225C0F762931D22300B9B45F /* RootCoordinatorView.swift in Sources */,
-
 				22BC99172941D97600D9B1A5 /* WelcomeView.swift in Sources */,
 				225AC6A4243F2710008D493D /* HeartRateDataSample.swift in Sources */,
-
 				22585C22240AE1BC0052E2CA /* RouteDataSample.swift in Sources */,
 				22585C20240AE0C70052E2CA /* Walk.swift in Sources */,
 				9726AFAB9F744FDA86EEC2CF /* ActivityInterval.swift in Sources */,
@@ -1617,6 +1607,11 @@
 				F1A2B3C4D5E6F7A8B9C0D1E5 /* PilgrimV4.swift in Sources */,
 				A5B6C7D8E9F0A1B2C3D4E5F7 /* PilgrimV5.swift in Sources */,
 				F1A2B3C4D5E6F7A8B9C0D1E7 /* FaviconSelectorView.swift in Sources */,
+				DBC54AC76144B10493D3E481 /* WalkShareView.swift in Sources */,
+				8A200FA63DDEC6D859F1C4EE /* WalkShareViewModel.swift in Sources */,
+				7C39E4160B0DA105D78F4C83 /* SharePayload.swift in Sources */,
+				9A477336A61C4C38B9D4F13C /* RouteDownsampler.swift in Sources */,
+				6AE85BCC627AF8321E753C1F /* ShareService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -206,6 +206,7 @@
 		BB00AA010000000000000002 /* PilgrimV1.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00AA010000000000000001 /* PilgrimV1.swift */; };
 		BB00CC010000000000000001 /* WelcomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00CC010000000000000002 /* WelcomeViewModelTests.swift */; };
 		BREATH000000000000000002 /* BreathTransitionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BREATH000000000000000001 /* BreathTransitionView.swift */; };
+		C34D17383682ACAD912B2387 /* RouteShapeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B95E4FB1DF743CEF3AC77C2 /* RouteShapeView.swift */; };
 		C8297CD567634F8E9D97738B /* TalkSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1EF72AE69CD4C1599071304 /* TalkSettingsView.swift */; };
 		CC00000200000000BTRFLY01 /* ButterflyShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000BTRFLY01 /* ButterflyShape.swift */; };
 		CC00000200000000CALLIG01 /* CalligraphyPathRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000CALLIG01 /* CalligraphyPathRenderer.swift */; };
@@ -419,6 +420,7 @@
 		4181215714A52E71449BC390 /* WalkDataFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkDataFactory.swift; sourceTree = "<group>"; };
 		4AE6DC51742E035602E624F1 /* AudioSessionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionCoordinator.swift; sourceTree = "<group>"; };
 		4B6BF30D6A9C48219D3C115C /* PaceSparklineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaceSparklineView.swift; sourceTree = "<group>"; };
+		4B95E4FB1DF743CEF3AC77C2 /* RouteShapeView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RouteShapeView.swift; sourceTree = "<group>"; };
 		5D9D07CA4444A7B548B5CFA4 /* ShareService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShareService.swift; sourceTree = "<group>"; };
 		6F17456C4D1E2DAED49B9AC6 /* SoundscapePlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundscapePlayer.swift; sourceTree = "<group>"; };
 		721BF267E7540B2B259806D1 /* XCTestCase+Combine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Combine.swift"; sourceTree = "<group>"; };
@@ -1081,6 +1083,7 @@
 			children = (
 				16BE9557700152F043C359DC /* WalkShareView.swift */,
 				8E0BF1B23139F428720EB2CF /* WalkShareViewModel.swift */,
+				4B95E4FB1DF743CEF3AC77C2 /* RouteShapeView.swift */,
 			);
 			name = WalkShare;
 			path = WalkShare;
@@ -1612,6 +1615,7 @@
 				7C39E4160B0DA105D78F4C83 /* SharePayload.swift in Sources */,
 				9A477336A61C4C38B9D4F13C /* RouteDownsampler.swift in Sources */,
 				6AE85BCC627AF8321E753C1F /* ShareService.swift in Sources */,
+				C34D17383682ACAD912B2387 /* RouteShapeView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pilgrim/Models/Share/RouteDownsampler.swift
+++ b/Pilgrim/Models/Share/RouteDownsampler.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+enum RouteDownsampler {
+
+    static func downsample(
+        _ points: [SharePayload.RoutePoint],
+        maxPoints: Int = 200
+    ) -> [SharePayload.RoutePoint] {
+        guard points.count > maxPoints else { return points }
+        return ramerDouglasPeucker(points, epsilon: findEpsilon(points, target: maxPoints))
+    }
+
+    private static func ramerDouglasPeucker(
+        _ points: [SharePayload.RoutePoint],
+        epsilon: Double
+    ) -> [SharePayload.RoutePoint] {
+        guard points.count > 2 else { return points }
+
+        var maxDist = 0.0
+        var maxIndex = 0
+
+        let first = points[0]
+        let last = points[points.count - 1]
+
+        for i in 1..<(points.count - 1) {
+            let dist = perpendicularDistance(points[i], lineStart: first, lineEnd: last)
+            if dist > maxDist {
+                maxDist = dist
+                maxIndex = i
+            }
+        }
+
+        if maxDist > epsilon {
+            let left = ramerDouglasPeucker(Array(points[...maxIndex]), epsilon: epsilon)
+            let right = ramerDouglasPeucker(Array(points[maxIndex...]), epsilon: epsilon)
+            return Array(left.dropLast()) + right
+        }
+
+        return [first, last]
+    }
+
+    private static func perpendicularDistance(
+        _ point: SharePayload.RoutePoint,
+        lineStart: SharePayload.RoutePoint,
+        lineEnd: SharePayload.RoutePoint
+    ) -> Double {
+        let dx = lineEnd.lon - lineStart.lon
+        let dy = lineEnd.lat - lineStart.lat
+        let lengthSq = dx * dx + dy * dy
+
+        guard lengthSq > 0 else {
+            let px = point.lon - lineStart.lon
+            let py = point.lat - lineStart.lat
+            return sqrt(px * px + py * py)
+        }
+
+        let t = max(0, min(1,
+            ((point.lon - lineStart.lon) * dx + (point.lat - lineStart.lat) * dy) / lengthSq
+        ))
+
+        let projLon = lineStart.lon + t * dx
+        let projLat = lineStart.lat + t * dy
+        let px = point.lon - projLon
+        let py = point.lat - projLat
+
+        return sqrt(px * px + py * py)
+    }
+
+    private static func findEpsilon(
+        _ points: [SharePayload.RoutePoint],
+        target: Int
+    ) -> Double {
+        var low = 0.0
+        var high = 0.01
+
+        for _ in 0..<20 {
+            let mid = (low + high) / 2
+            let result = ramerDouglasPeucker(points, epsilon: mid)
+            if result.count > target {
+                low = mid
+            } else {
+                high = mid
+            }
+        }
+
+        return high
+    }
+}

--- a/Pilgrim/Models/Share/RouteDownsampler.swift
+++ b/Pilgrim/Models/Share/RouteDownsampler.swift
@@ -7,7 +7,24 @@ enum RouteDownsampler {
         maxPoints: Int = 200
     ) -> [SharePayload.RoutePoint] {
         guard points.count > maxPoints else { return points }
-        return ramerDouglasPeucker(points, epsilon: findEpsilon(points, target: maxPoints))
+        let result = ramerDouglasPeucker(points, epsilon: findEpsilon(points, target: maxPoints))
+        guard result.count <= maxPoints else {
+            return strideSample(result, target: maxPoints)
+        }
+        return result
+    }
+
+    private static func strideSample(
+        _ points: [SharePayload.RoutePoint],
+        target: Int
+    ) -> [SharePayload.RoutePoint] {
+        let step = Double(points.count - 1) / Double(target - 1)
+        var result: [SharePayload.RoutePoint] = []
+        for i in 0..<(target - 1) {
+            result.append(points[Int((Double(i) * step).rounded())])
+        }
+        result.append(points[points.count - 1])
+        return result
     }
 
     private static func ramerDouglasPeucker(

--- a/Pilgrim/Models/Share/SharePayload.swift
+++ b/Pilgrim/Models/Share/SharePayload.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+struct SharePayload: Encodable {
+
+    let stats: Stats
+    let route: [RoutePoint]
+    let activityIntervals: [ActivityIntervalPayload]
+    let journal: String?
+    let expiryDays: Int
+    let units: String
+    let startDate: String
+    let toggledStats: [String]
+
+    struct Stats: Encodable {
+        let distance: Double?
+        let activeDuration: Double?
+        let elevationAscent: Double?
+        let elevationDescent: Double?
+        let steps: Int?
+        let meditateDuration: Double?
+        let talkDuration: Double?
+
+        enum CodingKeys: String, CodingKey {
+            case distance
+            case activeDuration = "active_duration"
+            case elevationAscent = "elevation_ascent"
+            case elevationDescent = "elevation_descent"
+            case steps
+            case meditateDuration = "meditate_duration"
+            case talkDuration = "talk_duration"
+        }
+    }
+
+    struct RoutePoint: Encodable {
+        let lat: Double
+        let lon: Double
+        let alt: Double
+        let ts: Int
+    }
+
+    struct ActivityIntervalPayload: Encodable {
+        let type: String
+        let startTs: Int
+        let endTs: Int
+
+        enum CodingKeys: String, CodingKey {
+            case type
+            case startTs = "start_ts"
+            case endTs = "end_ts"
+        }
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case stats, route, journal, units
+        case activityIntervals = "activity_intervals"
+        case expiryDays = "expiry_days"
+        case startDate = "start_date"
+        case toggledStats = "toggled_stats"
+    }
+}

--- a/Pilgrim/Models/Share/SharePayload.swift
+++ b/Pilgrim/Models/Share/SharePayload.swift
@@ -10,6 +10,8 @@ struct SharePayload: Encodable {
     let units: String
     let startDate: String
     let toggledStats: [String]
+    let placeStart: String?
+    let placeEnd: String?
 
     struct Stats: Encodable {
         let distance: Double?
@@ -56,5 +58,7 @@ struct SharePayload: Encodable {
         case expiryDays = "expiry_days"
         case startDate = "start_date"
         case toggledStats = "toggled_stats"
+        case placeStart = "place_start"
+        case placeEnd = "place_end"
     }
 }

--- a/Pilgrim/Models/Share/ShareService.swift
+++ b/Pilgrim/Models/Share/ShareService.swift
@@ -97,18 +97,21 @@ enum ShareService {
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrAccount as String: keychainKey,
-            kSecValueData as String: data
+            kSecValueData as String: data,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
         ]
         SecItemDelete(query as CFDictionary)
         SecItemAdd(query as CFDictionary, nil)
     }
+
+    private static let isoFormatter = ISO8601DateFormatter()
 
     static func cachedShare(for walkID: UUID) -> ShareResult? {
         guard let dict = UserDefaults.standard.dictionary(forKey: "share:\(walkID.uuidString)"),
               let url = dict["url"] as? String,
               let id = dict["id"] as? String,
               let expiryStr = dict["expiry"] as? String,
-              let expiry = ISO8601DateFormatter().date(from: expiryStr),
+              let expiry = isoFormatter.date(from: expiryStr),
               expiry > Date() else {
             return nil
         }
@@ -120,7 +123,7 @@ enum ShareService {
         let dict: [String: String] = [
             "url": result.url,
             "id": result.id,
-            "expiry": ISO8601DateFormatter().string(from: expiry)
+            "expiry": isoFormatter.string(from: expiry)
         ]
         UserDefaults.standard.set(dict, forKey: "share:\(walkID.uuidString)")
     }

--- a/Pilgrim/Models/Share/ShareService.swift
+++ b/Pilgrim/Models/Share/ShareService.swift
@@ -1,0 +1,136 @@
+import Foundation
+import Security
+
+enum ShareService {
+
+    private static let baseURL = "https://walk.pilgrimapp.org"
+    private static let keychainKey = "pilgrim.share.device-token"
+
+    enum ShareError: LocalizedError {
+        case encodingFailed
+        case networkError(String)
+        case serverError(Int, String)
+        case rateLimited
+
+        var errorDescription: String? {
+            switch self {
+            case .encodingFailed:
+                return "Failed to prepare walk data."
+            case .networkError(let message):
+                return "Network error: \(message)"
+            case .serverError(let code, let message):
+                return "Server error (\(code)): \(message)"
+            case .rateLimited:
+                return "You've shared too many walks today. Try again tomorrow."
+            }
+        }
+    }
+
+    struct ShareResult {
+        let url: String
+        let id: String
+    }
+
+    static func share(payload: SharePayload) async throws -> ShareResult {
+        let url = URL(string: "\(baseURL)/api/share")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.setValue(deviceToken(), forHTTPHeaderField: "X-Device-Token")
+        request.timeoutInterval = 30
+
+        let encoder = JSONEncoder()
+        guard let body = try? encoder.encode(payload) else {
+            throw ShareError.encodingFailed
+        }
+        request.httpBody = body
+
+        let (data, response): (Data, URLResponse)
+        do {
+            (data, response) = try await URLSession.shared.data(for: request)
+        } catch {
+            throw ShareError.networkError(error.localizedDescription)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw ShareError.networkError("Invalid response")
+        }
+
+        if httpResponse.statusCode == 429 {
+            throw ShareError.rateLimited
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            let message = (try? JSONDecoder().decode(ErrorResponse.self, from: data))?.error
+                ?? "Unknown error"
+            throw ShareError.serverError(httpResponse.statusCode, message)
+        }
+
+        let result = try JSONDecoder().decode(SuccessResponse.self, from: data)
+        return ShareResult(url: result.url, id: result.id)
+    }
+
+    private static func deviceToken() -> String {
+        if let existing = readKeychainToken() {
+            return existing
+        }
+        let token = UUID().uuidString
+        saveKeychainToken(token)
+        return token
+    }
+
+    private static func readKeychainToken() -> String? {
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: keychainKey,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        guard status == errSecSuccess, let data = result as? Data else { return nil }
+        return String(data: data, encoding: .utf8)
+    }
+
+    private static func saveKeychainToken(_ token: String) {
+        let data = Data(token.utf8)
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrAccount as String: keychainKey,
+            kSecValueData as String: data
+        ]
+        SecItemDelete(query as CFDictionary)
+        SecItemAdd(query as CFDictionary, nil)
+    }
+
+    static func cachedShare(for walkID: UUID) -> ShareResult? {
+        guard let dict = UserDefaults.standard.dictionary(forKey: "share:\(walkID.uuidString)"),
+              let url = dict["url"] as? String,
+              let id = dict["id"] as? String,
+              let expiryStr = dict["expiry"] as? String,
+              let expiry = ISO8601DateFormatter().date(from: expiryStr),
+              expiry > Date() else {
+            return nil
+        }
+        return ShareResult(url: url, id: id)
+    }
+
+    static func cacheShare(_ result: ShareResult, walkID: UUID, expiryDays: Int) {
+        let expiry = Calendar.current.date(byAdding: .day, value: expiryDays, to: Date()) ?? Date()
+        let dict: [String: String] = [
+            "url": result.url,
+            "id": result.id,
+            "expiry": ISO8601DateFormatter().string(from: expiry)
+        ]
+        UserDefaults.standard.set(dict, forKey: "share:\(walkID.uuidString)")
+    }
+}
+
+private struct SuccessResponse: Decodable {
+    let url: String
+    let id: String
+}
+
+private struct ErrorResponse: Decodable {
+    let error: String
+}

--- a/Pilgrim/Scenes/Home/HomeViewModel.swift
+++ b/Pilgrim/Scenes/Home/HomeViewModel.swift
@@ -12,6 +12,7 @@ struct WalkSnapshot: Identifiable {
     let talkDuration: TimeInterval
     let meditateDuration: TimeInterval
     let favicon: String?
+    let isShared: Bool
 
     var walkOnlyDuration: TimeInterval {
         max(0, duration - talkDuration - meditateDuration)
@@ -86,7 +87,8 @@ class HomeViewModel: ObservableObject {
                 cumulativeDistance: cumulative,
                 talkDuration: walk.talkDuration,
                 meditateDuration: walk.meditateDuration,
-                favicon: walk.favicon
+                favicon: walk.favicon,
+                isShared: ShareService.cachedShare(for: walk.id) != nil
             ))
         }
 

--- a/Pilgrim/Scenes/Home/InkScrollView.swift
+++ b/Pilgrim/Scenes/Home/InkScrollView.swift
@@ -283,6 +283,13 @@ struct InkScrollView: View {
                             .foregroundColor(.ink)
 
                         Spacer()
+
+                        if snapshot.isShared {
+                            Image(systemName: "link")
+                                .font(.system(size: 10))
+                                .foregroundColor(.stone)
+                                .opacity(0.5)
+                        }
                     }
 
                     Rectangle()

--- a/Pilgrim/Scenes/Home/WalkDotView.swift
+++ b/Pilgrim/Scenes/Home/WalkDotView.swift
@@ -60,6 +60,13 @@ struct WalkDotView: View {
                 .opacity(opacity * 0.5)
                 .offset(x: -size * 0.08, y: -size * 0.08)
 
+            if snapshot.isShared {
+                Circle()
+                    .stroke(Color.stone.opacity(0.5), lineWidth: 1)
+                    .frame(width: size + 12, height: size + 12)
+                    .opacity(opacity)
+            }
+
         }
         .position(position)
         .onTapGesture { onTap(snapshot.id) }

--- a/Pilgrim/Scenes/WalkShare/RouteShapeView.swift
+++ b/Pilgrim/Scenes/WalkShare/RouteShapeView.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+struct RouteShapeView: View {
+    let routeData: [RouteDataSampleInterface]
+
+    var body: some View {
+        GeometryReader { geo in
+            let points = projectRoute(in: geo.size)
+            if points.count >= 2 {
+                Path { path in
+                    path.move(to: points[0])
+                    for i in 1..<points.count {
+                        path.addLine(to: points[i])
+                    }
+                }
+                .stroke(Color.stone, style: StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round))
+
+                Circle()
+                    .fill(Color.moss)
+                    .frame(width: 8, height: 8)
+                    .position(points[0])
+
+                Circle()
+                    .stroke(Color.moss, lineWidth: 1.5)
+                    .frame(width: 8, height: 8)
+                    .position(points[points.count - 1])
+            }
+        }
+        .padding(Constants.UI.Padding.big)
+    }
+
+    private func projectRoute(in size: CGSize) -> [CGPoint] {
+        guard routeData.count >= 2 else { return [] }
+
+        var minLat = Double.infinity
+        var maxLat = -Double.infinity
+        var minLon = Double.infinity
+        var maxLon = -Double.infinity
+
+        for sample in routeData {
+            if sample.latitude < minLat { minLat = sample.latitude }
+            if sample.latitude > maxLat { maxLat = sample.latitude }
+            if sample.longitude < minLon { minLon = sample.longitude }
+            if sample.longitude > maxLon { maxLon = sample.longitude }
+        }
+
+        let latRange = maxLat - minLat
+        let lonRange = maxLon - minLon
+        guard latRange > 0 || lonRange > 0 else { return [] }
+
+        let padding: CGFloat = 0
+        let w = size.width - padding * 2
+        let h = size.height - padding * 2
+
+        let scale = min(
+            lonRange > 0 ? w / lonRange : .infinity,
+            latRange > 0 ? h / latRange : .infinity
+        )
+
+        let routeW = lonRange * scale
+        let routeH = latRange * scale
+        let offsetX = padding + (w - routeW) / 2
+        let offsetY = padding + (h - routeH) / 2
+
+        let step = max(1, routeData.count / 200)
+        var points: [CGPoint] = []
+        for i in stride(from: 0, to: routeData.count, by: step) {
+            let s = routeData[i]
+            let x = offsetX + (s.longitude - minLon) * scale
+            let y = offsetY + (maxLat - s.latitude) * scale
+            points.append(CGPoint(x: x, y: y))
+        }
+
+        let last = routeData[routeData.count - 1]
+        let lastPoint = CGPoint(
+            x: offsetX + (last.longitude - minLon) * scale,
+            y: offsetY + (maxLat - last.latitude) * scale
+        )
+        if points.last != lastPoint {
+            points.append(lastPoint)
+        }
+
+        return points
+    }
+}

--- a/Pilgrim/Scenes/WalkShare/WalkShareView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareView.swift
@@ -11,15 +11,24 @@ struct WalkShareView: View {
         _viewModel = StateObject(wrappedValue: WalkShareViewModel(walk: walk))
     }
 
+    private var isShared: Bool {
+        if case .success = viewModel.shareState { return true }
+        return false
+    }
+
     var body: some View {
         NavigationView {
             ScrollView {
                 VStack(spacing: Constants.UI.Padding.big) {
-                    mapPreview
-                    statToggles
-                    journalSection
-                    expiryPicker
-                    shareButton
+                    if isShared {
+                        shareButton
+                    } else {
+                        routePreview
+                        statToggles
+                        journalSection
+                        expiryPicker
+                        shareButton
+                    }
                 }
                 .padding(Constants.UI.Padding.normal)
             }
@@ -27,29 +36,34 @@ struct WalkShareView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .principal) {
-                    Text("Share Walk")
+                    Text(isShared ? "Walk Shared" : "Share Walk")
                         .font(Constants.Typography.heading)
                         .foregroundColor(.ink)
                 }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    if isShared {
+                        Button("Done") { dismiss() }
+                            .foregroundColor(.stone)
+                    }
+                }
                 ToolbarItem(placement: .navigationBarLeading) {
-                    Button("Cancel") { dismiss() }
-                        .foregroundColor(.stone)
+                    if !isShared {
+                        Button("Cancel") { dismiss() }
+                            .foregroundColor(.stone)
+                    }
                 }
             }
         }
     }
 
-    // MARK: - Map Preview
+    // MARK: - Route Preview
 
-    private var mapPreview: some View {
-        RoundedRectangle(cornerRadius: Constants.UI.CornerRadius.normal)
-            .fill(Color.parchmentSecondary)
+    private var routePreview: some View {
+        let points = viewModel.walk.routeData
+        return RouteShapeView(routeData: points)
             .frame(height: 200)
-            .overlay(
-                Text("Route Preview")
-                    .font(Constants.Typography.caption)
-                    .foregroundColor(.fog)
-            )
+            .background(Color.parchmentSecondary)
+            .cornerRadius(Constants.UI.CornerRadius.normal)
     }
 
     // MARK: - Stat Toggles
@@ -58,11 +72,31 @@ struct WalkShareView: View {
         VStack(alignment: .leading, spacing: Constants.UI.Padding.small) {
             sectionLabel("Share these details")
 
-            StatToggleRow(title: "Distance", isOn: $viewModel.toggleDistance)
-            StatToggleRow(title: "Duration", isOn: $viewModel.toggleDuration)
-            StatToggleRow(title: "Elevation", isOn: $viewModel.toggleElevation)
-            StatToggleRow(title: "Walk / Meditation / Talk", isOn: $viewModel.toggleActivityBreakdown)
-            StatToggleRow(title: "Steps", isOn: $viewModel.toggleSteps)
+            StatToggleRow(
+                title: "Distance",
+                value: viewModel.formattedDistance,
+                isOn: $viewModel.toggleDistance
+            )
+            StatToggleRow(
+                title: "Duration",
+                value: viewModel.formattedDuration,
+                isOn: $viewModel.toggleDuration
+            )
+            StatToggleRow(
+                title: "Elevation",
+                value: viewModel.formattedElevation,
+                isOn: $viewModel.toggleElevation
+            )
+            StatToggleRow(
+                title: "Walk / Meditation / Talk",
+                value: viewModel.formattedActivityBreakdown,
+                isOn: $viewModel.toggleActivityBreakdown
+            )
+            StatToggleRow(
+                title: "Steps",
+                value: viewModel.formattedSteps,
+                isOn: $viewModel.toggleSteps
+            )
         }
     }
 
@@ -75,7 +109,7 @@ struct WalkShareView: View {
             ZStack(alignment: .topLeading) {
                 TextEditor(text: $viewModel.journal)
                     .font(Constants.Typography.body)
-                    .frame(minHeight: 60)
+                    .frame(minHeight: 80)
                     .padding(Constants.UI.Padding.small)
                     .scrollContentBackground(.hidden)
                     .background(Color.parchmentSecondary)
@@ -87,7 +121,7 @@ struct WalkShareView: View {
                     }
 
                 if viewModel.journal.isEmpty {
-                    Text("A few words about this walk...")
+                    Text("\u{201C}A few words about this walk...")
                         .font(Constants.Typography.body)
                         .foregroundColor(.fog)
                         .padding(.horizontal, Constants.UI.Padding.normal)
@@ -177,17 +211,18 @@ struct WalkShareView: View {
 
         case .success(let url):
             VStack(spacing: Constants.UI.Padding.normal) {
-                VStack(spacing: Constants.UI.Padding.small) {
-                    Text("Walk shared")
-                        .font(Constants.Typography.heading)
-                        .foregroundColor(.ink)
+                routePreview
 
-                    Text(url)
-                        .font(Constants.Typography.caption)
-                        .foregroundColor(.stone)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                }
+                Text(url)
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.stone)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+
+                Text("Returns to the trail on \(expiryDateFormatted)")
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog)
+                    .italic()
 
                 HStack(spacing: Constants.UI.Padding.small) {
                     Button {
@@ -272,13 +307,21 @@ struct WalkShareView: View {
 
 private struct StatToggleRow: View {
     let title: String
+    let value: String?
     @Binding var isOn: Bool
 
     var body: some View {
         HStack {
-            Text(title)
-                .font(Constants.Typography.body)
-                .foregroundColor(.ink)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(Constants.Typography.body)
+                    .foregroundColor(.ink)
+                if let value {
+                    Text(value)
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.fog)
+                }
+            }
             Spacer()
             Toggle("", isOn: $isOn)
                 .labelsHidden()

--- a/Pilgrim/Scenes/WalkShare/WalkShareView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareView.swift
@@ -5,6 +5,7 @@ struct WalkShareView: View {
     @StateObject private var viewModel: WalkShareViewModel
     @Environment(\.dismiss) private var dismiss
     @State private var showCopiedToast = false
+    @State private var toastGeneration = 0
 
     init(walk: WalkInterface) {
         _viewModel = StateObject(wrappedValue: WalkShareViewModel(walk: walk))
@@ -191,9 +192,12 @@ struct WalkShareView: View {
                 HStack(spacing: Constants.UI.Padding.small) {
                     Button {
                         UIPasteboard.general.string = url
+                        toastGeneration += 1
+                        let gen = toastGeneration
                         showCopiedToast = true
-                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-                            showCopiedToast = false
+                        Task {
+                            try? await Task.sleep(for: .seconds(2))
+                            if toastGeneration == gen { showCopiedToast = false }
                         }
                     } label: {
                         HStack(spacing: 4) {
@@ -208,17 +212,19 @@ struct WalkShareView: View {
                         .cornerRadius(Constants.UI.CornerRadius.small)
                     }
 
-                    ShareLink(item: URL(string: url)!) {
-                        HStack(spacing: 4) {
-                            Image(systemName: "square.and.arrow.up")
-                            Text("Share")
-                                .font(Constants.Typography.button)
+                    if let shareURL = URL(string: url) {
+                        ShareLink(item: shareURL) {
+                            HStack(spacing: 4) {
+                                Image(systemName: "square.and.arrow.up")
+                                Text("Share")
+                                    .font(Constants.Typography.button)
+                            }
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                            .background(Color.stone)
+                            .foregroundColor(.parchment)
+                            .cornerRadius(Constants.UI.CornerRadius.small)
                         }
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 12)
-                        .background(Color.stone)
-                        .foregroundColor(.parchment)
-                        .cornerRadius(Constants.UI.CornerRadius.small)
                     }
                 }
             }

--- a/Pilgrim/Scenes/WalkShare/WalkShareView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareView.swift
@@ -1,0 +1,286 @@
+import SwiftUI
+
+struct WalkShareView: View {
+
+    @StateObject private var viewModel: WalkShareViewModel
+    @Environment(\.dismiss) private var dismiss
+    @State private var showCopiedToast = false
+
+    init(walk: WalkInterface) {
+        _viewModel = StateObject(wrappedValue: WalkShareViewModel(walk: walk))
+    }
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                VStack(spacing: Constants.UI.Padding.big) {
+                    mapPreview
+                    statToggles
+                    journalSection
+                    expiryPicker
+                    shareButton
+                }
+                .padding(Constants.UI.Padding.normal)
+            }
+            .background(Color.parchment)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Text("Share Walk")
+                        .font(Constants.Typography.heading)
+                        .foregroundColor(.ink)
+                }
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Cancel") { dismiss() }
+                        .foregroundColor(.stone)
+                }
+            }
+        }
+    }
+
+    // MARK: - Map Preview
+
+    private var mapPreview: some View {
+        RoundedRectangle(cornerRadius: Constants.UI.CornerRadius.normal)
+            .fill(Color.parchmentSecondary)
+            .frame(height: 200)
+            .overlay(
+                Text("Route Preview")
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog)
+            )
+    }
+
+    // MARK: - Stat Toggles
+
+    private var statToggles: some View {
+        VStack(alignment: .leading, spacing: Constants.UI.Padding.small) {
+            sectionLabel("Share these details")
+
+            StatToggleRow(title: "Distance", isOn: $viewModel.toggleDistance)
+            StatToggleRow(title: "Duration", isOn: $viewModel.toggleDuration)
+            StatToggleRow(title: "Elevation", isOn: $viewModel.toggleElevation)
+            StatToggleRow(title: "Walk / Meditation / Talk", isOn: $viewModel.toggleActivityBreakdown)
+            StatToggleRow(title: "Steps", isOn: $viewModel.toggleSteps)
+        }
+    }
+
+    // MARK: - Journal
+
+    private var journalSection: some View {
+        VStack(alignment: .leading, spacing: Constants.UI.Padding.small) {
+            sectionLabel("Reflection")
+
+            ZStack(alignment: .topLeading) {
+                TextEditor(text: $viewModel.journal)
+                    .font(Constants.Typography.body)
+                    .frame(minHeight: 60)
+                    .padding(Constants.UI.Padding.small)
+                    .scrollContentBackground(.hidden)
+                    .background(Color.parchmentSecondary)
+                    .cornerRadius(Constants.UI.CornerRadius.small)
+                    .onChange(of: viewModel.journal) { _, newValue in
+                        if newValue.count > 140 {
+                            viewModel.journal = String(newValue.prefix(140))
+                        }
+                    }
+
+                if viewModel.journal.isEmpty {
+                    Text("A few words about this walk...")
+                        .font(Constants.Typography.body)
+                        .foregroundColor(.fog)
+                        .padding(.horizontal, Constants.UI.Padding.normal)
+                        .padding(.vertical, Constants.UI.Padding.normal)
+                        .allowsHitTesting(false)
+                }
+            }
+
+            HStack {
+                Spacer()
+                Text("\(viewModel.journal.count) / 140")
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog)
+            }
+        }
+    }
+
+    // MARK: - Expiry Picker
+
+    private var expiryPicker: some View {
+        VStack(alignment: .leading, spacing: Constants.UI.Padding.small) {
+            sectionLabel("This walk lives for")
+
+            HStack(spacing: Constants.UI.Padding.small) {
+                ForEach(WalkShareViewModel.ExpiryOption.allCases, id: \.rawValue) { option in
+                    expiryButton(option)
+                }
+            }
+
+            HStack {
+                Spacer()
+                Text("Expires \(expiryDateFormatted)")
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog)
+                Spacer()
+            }
+        }
+    }
+
+    private func expiryButton(_ option: WalkShareViewModel.ExpiryOption) -> some View {
+        let isSelected = viewModel.selectedExpiry == option
+        return Button {
+            viewModel.selectedExpiry = option
+        } label: {
+            Text(option.label)
+                .font(Constants.Typography.caption)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 10)
+                .background(isSelected ? Color.stone : Color.parchmentSecondary)
+                .foregroundColor(isSelected ? .parchment : .fog)
+                .cornerRadius(Constants.UI.CornerRadius.small)
+        }
+    }
+
+    private var expiryDateFormatted: String {
+        Self.expiryFormatter.string(from: viewModel.expiryDate)
+    }
+
+    private static let expiryFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .long
+        return f
+    }()
+
+    // MARK: - Share Button
+
+    @ViewBuilder
+    private var shareButton: some View {
+        switch viewModel.shareState {
+        case .idle:
+            primaryButton("Share Walk") {
+                Task { await viewModel.share() }
+            }
+
+        case .uploading:
+            HStack(spacing: Constants.UI.Padding.small) {
+                SwiftUI.ProgressView()
+                    .tint(.parchment)
+                Text("Sharing...")
+                    .font(Constants.Typography.button)
+                    .foregroundColor(.parchment)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .background(Color.stone.opacity(0.6))
+            .cornerRadius(Constants.UI.CornerRadius.normal)
+
+        case .success(let url):
+            VStack(spacing: Constants.UI.Padding.normal) {
+                VStack(spacing: Constants.UI.Padding.small) {
+                    Text("Walk shared")
+                        .font(Constants.Typography.heading)
+                        .foregroundColor(.ink)
+
+                    Text(url)
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.stone)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+
+                HStack(spacing: Constants.UI.Padding.small) {
+                    Button {
+                        UIPasteboard.general.string = url
+                        showCopiedToast = true
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
+                            showCopiedToast = false
+                        }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: showCopiedToast ? "checkmark" : "doc.on.doc")
+                            Text(showCopiedToast ? "Copied" : "Copy")
+                                .font(Constants.Typography.button)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(Color.parchmentSecondary)
+                        .foregroundColor(.stone)
+                        .cornerRadius(Constants.UI.CornerRadius.small)
+                    }
+
+                    ShareLink(item: URL(string: url)!) {
+                        HStack(spacing: 4) {
+                            Image(systemName: "square.and.arrow.up")
+                            Text("Share")
+                                .font(Constants.Typography.button)
+                        }
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 12)
+                        .background(Color.stone)
+                        .foregroundColor(.parchment)
+                        .cornerRadius(Constants.UI.CornerRadius.small)
+                    }
+                }
+            }
+            .padding(Constants.UI.Padding.normal)
+            .background(Color.parchmentSecondary)
+            .cornerRadius(Constants.UI.CornerRadius.normal)
+
+        case .error(let message):
+            VStack(spacing: Constants.UI.Padding.small) {
+                Text(message)
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.rust)
+                    .multilineTextAlignment(.center)
+
+                primaryButton("Try Again") {
+                    Task { await viewModel.share() }
+                }
+            }
+        }
+    }
+
+    private func primaryButton(_ title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(Constants.Typography.button)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .background(Color.stone)
+                .foregroundColor(.parchment)
+                .cornerRadius(Constants.UI.CornerRadius.normal)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func sectionLabel(_ text: String) -> some View {
+        Text(text.uppercased())
+            .font(Constants.Typography.micro)
+            .foregroundColor(.fog)
+            .tracking(1.5)
+    }
+}
+
+// MARK: - Stat Toggle Row
+
+private struct StatToggleRow: View {
+    let title: String
+    @Binding var isOn: Bool
+
+    var body: some View {
+        HStack {
+            Text(title)
+                .font(Constants.Typography.body)
+                .foregroundColor(.ink)
+            Spacer()
+            Toggle("", isOn: $isOn)
+                .labelsHidden()
+                .tint(.moss)
+        }
+        .padding(.horizontal, Constants.UI.Padding.normal)
+        .padding(.vertical, 10)
+        .background(Color.parchmentSecondary)
+        .cornerRadius(Constants.UI.CornerRadius.small)
+    }
+}

--- a/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import CoreLocation
 
 @MainActor
 final class WalkShareViewModel: ObservableObject {
@@ -60,7 +61,8 @@ final class WalkShareViewModel: ObservableObject {
     func share() async {
         shareState = .uploading
 
-        let payload = buildPayload()
+        let placeNames = await geocodeEndpoints()
+        let payload = buildPayload(placeStart: placeNames.start, placeEnd: placeNames.end)
 
         do {
             let result = try await ShareService.share(payload: payload)
@@ -73,7 +75,34 @@ final class WalkShareViewModel: ObservableObject {
         }
     }
 
-    private func buildPayload() -> SharePayload {
+    private func geocodeEndpoints() async -> (start: String?, end: String?) {
+        let routeData = walk.routeData
+        guard let first = routeData.first, let last = routeData.last else {
+            return (nil, nil)
+        }
+
+        let geocoder = CLGeocoder()
+        let startLoc = CLLocation(latitude: first.latitude, longitude: first.longitude)
+        let endLoc = CLLocation(latitude: last.latitude, longitude: last.longitude)
+
+        async let startName = geocodeSingle(geocoder: CLGeocoder(), location: startLoc)
+        async let endName = geocodeSingle(geocoder: CLGeocoder(), location: endLoc)
+
+        let (s, e) = await (startName, endName)
+        if s != nil && e != nil && s == e { return (s, nil) }
+        return (s, e)
+    }
+
+    private func geocodeSingle(geocoder: CLGeocoder, location: CLLocation) async -> String? {
+        do {
+            let placemarks = try await geocoder.reverseGeocodeLocation(location)
+            return placemarks.first?.locality ?? placemarks.first?.subLocality ?? placemarks.first?.name
+        } catch {
+            return nil
+        }
+    }
+
+    private func buildPayload(placeStart: String?, placeEnd: String?) -> SharePayload {
         let isMetric = UserPreferences.distanceMeasurementType.safeValue == .kilometers
 
         let routePoints = walk.routeData.map { sample in
@@ -132,7 +161,9 @@ final class WalkShareViewModel: ObservableObject {
             expiryDays: selectedExpiry.rawValue,
             units: isMetric ? "metric" : "imperial",
             startDate: formatter.string(from: walk.startDate),
-            toggledStats: toggledStats
+            toggledStats: toggledStats,
+            placeStart: placeStart,
+            placeEnd: placeEnd
         )
     }
 }

--- a/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
@@ -51,6 +51,45 @@ final class WalkShareViewModel: ObservableObject {
         return ShareService.cachedShare(for: uuid) != nil
     }
 
+    var formattedDistance: String? {
+        guard walk.distance > 0 else { return nil }
+        let isMetric = UserPreferences.distanceMeasurementType.safeValue == .kilometers
+        if isMetric {
+            return String(format: "%.1f km", walk.distance / 1000)
+        }
+        return String(format: "%.1f mi", walk.distance / 1609.344)
+    }
+
+    var formattedDuration: String? {
+        guard walk.activeDuration > 0 else { return nil }
+        let h = Int(walk.activeDuration) / 3600
+        let m = (Int(walk.activeDuration) % 3600) / 60
+        if h > 0 { return "\(h)h \(m)m" }
+        return "\(m)m"
+    }
+
+    var formattedElevation: String? {
+        guard walk.ascend > 1 else { return nil }
+        let isMetric = UserPreferences.altitudeMeasurementType.safeValue == .meters
+        if isMetric {
+            return "\(Int(walk.ascend)) m"
+        }
+        return "\(Int(walk.ascend * 3.28084)) ft"
+    }
+
+    var formattedActivityBreakdown: String? {
+        let parts = [
+            walk.meditateDuration > 0 ? "\(Int(walk.meditateDuration / 60))m meditation" : nil,
+            walk.talkDuration > 0 ? "\(Int(walk.talkDuration / 60))m reflection" : nil,
+        ].compactMap { $0 }
+        return parts.isEmpty ? nil : parts.joined(separator: ", ")
+    }
+
+    var formattedSteps: String? {
+        guard let steps = walk.steps, steps > 0 else { return nil }
+        return "\(steps.formatted())"
+    }
+
     init(walk: WalkInterface) {
         self.walk = walk
         if let uuid = walk.uuid, let cached = ShareService.cachedShare(for: uuid) {

--- a/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
@@ -81,7 +81,6 @@ final class WalkShareViewModel: ObservableObject {
             return (nil, nil)
         }
 
-        let geocoder = CLGeocoder()
         let startLoc = CLLocation(latitude: first.latitude, longitude: first.longitude)
         let endLoc = CLLocation(latitude: last.latitude, longitude: last.longitude)
 

--- a/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
@@ -1,0 +1,138 @@
+import Foundation
+
+@MainActor
+final class WalkShareViewModel: ObservableObject {
+
+    let walk: WalkInterface
+
+    @Published var toggleDistance = true
+    @Published var toggleDuration = true
+    @Published var toggleElevation = true
+    @Published var toggleActivityBreakdown = true
+    @Published var toggleSteps = false
+
+    @Published var journal = ""
+    @Published var selectedExpiry: ExpiryOption = .season
+
+    @Published var shareState: ShareState = .idle
+
+    enum ExpiryOption: Int, CaseIterable {
+        case moon = 30
+        case season = 90
+        case cycle = 365
+
+        var label: String {
+            switch self {
+            case .moon: return "1 moon"
+            case .season: return "1 season"
+            case .cycle: return "1 cycle"
+            }
+        }
+    }
+
+    enum ShareState: Equatable {
+        case idle
+        case uploading
+        case success(url: String)
+        case error(message: String)
+    }
+
+    var expiryDate: Date {
+        Calendar.current.date(
+            byAdding: .day,
+            value: selectedExpiry.rawValue,
+            to: Date()
+        ) ?? Date()
+    }
+
+    var hasExistingShare: Bool {
+        guard let uuid = walk.uuid else { return false }
+        return ShareService.cachedShare(for: uuid) != nil
+    }
+
+    init(walk: WalkInterface) {
+        self.walk = walk
+        if let uuid = walk.uuid, let cached = ShareService.cachedShare(for: uuid) {
+            shareState = .success(url: cached.url)
+        }
+    }
+
+    func share() async {
+        shareState = .uploading
+
+        let payload = buildPayload()
+
+        do {
+            let result = try await ShareService.share(payload: payload)
+            if let uuid = walk.uuid {
+                ShareService.cacheShare(result, walkID: uuid, expiryDays: selectedExpiry.rawValue)
+            }
+            shareState = .success(url: result.url)
+        } catch {
+            shareState = .error(message: error.localizedDescription)
+        }
+    }
+
+    private func buildPayload() -> SharePayload {
+        let isMetric = UserPreferences.distanceMeasurementType.safeValue == .kilometers
+
+        let routePoints = walk.routeData.map { sample in
+            SharePayload.RoutePoint(
+                lat: sample.latitude,
+                lon: sample.longitude,
+                alt: sample.altitude,
+                ts: Int(sample.timestamp.timeIntervalSince1970)
+            )
+        }
+
+        let downsampled = RouteDownsampler.downsample(routePoints)
+
+        var intervals: [SharePayload.ActivityIntervalPayload] = []
+
+        for interval in walk.activityIntervals {
+            intervals.append(SharePayload.ActivityIntervalPayload(
+                type: "meditation",
+                startTs: Int(interval.startDate.timeIntervalSince1970),
+                endTs: Int(interval.endDate.timeIntervalSince1970)
+            ))
+        }
+
+        for recording in walk.voiceRecordings {
+            intervals.append(SharePayload.ActivityIntervalPayload(
+                type: "talk",
+                startTs: Int(recording.startDate.timeIntervalSince1970),
+                endTs: Int(recording.endDate.timeIntervalSince1970)
+            ))
+        }
+
+        var toggledStats: [String] = []
+        if toggleDistance { toggledStats.append("distance") }
+        if toggleDuration { toggledStats.append("duration") }
+        if toggleElevation { toggledStats.append("elevation") }
+        if toggleActivityBreakdown { toggledStats.append("activity_breakdown") }
+        if toggleSteps { toggledStats.append("steps") }
+
+        let stats = SharePayload.Stats(
+            distance: toggleDistance ? walk.distance : nil,
+            activeDuration: toggleDuration ? walk.activeDuration : nil,
+            elevationAscent: toggleElevation ? walk.ascend : nil,
+            elevationDescent: toggleElevation ? walk.descend : nil,
+            steps: toggleSteps ? walk.steps : nil,
+            meditateDuration: toggleActivityBreakdown ? walk.meditateDuration : nil,
+            talkDuration: toggleActivityBreakdown ? walk.talkDuration : nil
+        )
+
+        let formatter = ISO8601DateFormatter()
+
+        return SharePayload(
+            stats: stats,
+            route: downsampled,
+            activityIntervals: intervals,
+            journal: journal.isEmpty ? nil : journal,
+            expiryDays: selectedExpiry.rawValue,
+            units: isMetric ? "metric" : "imperial",
+            startDate: formatter.string(from: walk.startDate),
+            toggledStats: toggledStats
+        )
+    }
+}

--- a/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
@@ -89,7 +89,7 @@ final class WalkShareViewModel: ObservableObject {
 
         var intervals: [SharePayload.ActivityIntervalPayload] = []
 
-        for interval in walk.activityIntervals {
+        for interval in walk.activityIntervals where interval.activityType == .meditation {
             intervals.append(SharePayload.ActivityIntervalPayload(
                 type: "meditation",
                 startTs: Int(interval.startDate.timeIntervalSince1970),

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
@@ -66,6 +66,7 @@ struct WalkSummaryView: View {
                         promptsButton
                     }
                     detailsSection
+                    shareCard
                 }
                 .padding(Constants.UI.Padding.normal)
             }
@@ -78,17 +79,8 @@ struct WalkSummaryView: View {
                         .foregroundColor(.ink)
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    HStack(spacing: Constants.UI.Padding.normal) {
-                        Button {
-                            showShareSheet = true
-                        } label: {
-                            Image(systemName: "square.and.arrow.up")
-                        }
+                    Button("Done") { dismiss() }
                         .foregroundColor(.stone)
-
-                        Button("Done") { dismiss() }
-                            .foregroundColor(.stone)
-                    }
                 }
             }
             .onAppear {
@@ -652,6 +644,33 @@ struct WalkSummaryView: View {
             .padding(Constants.UI.Padding.normal)
             .background(Color.parchmentSecondary)
             .cornerRadius(Constants.UI.CornerRadius.normal)
+        }
+    }
+
+    @ViewBuilder
+    private var shareCard: some View {
+        if walk.routeData.count >= 2 {
+            Button {
+                showShareSheet = true
+            } label: {
+                VStack(spacing: Constants.UI.Padding.small) {
+                    Image(systemName: "square.and.arrow.up")
+                        .font(.system(size: 20))
+                        .foregroundColor(.stone)
+                    Text("Share this walk")
+                        .font(Constants.Typography.heading)
+                        .foregroundColor(.ink)
+                    Text("Create a beautiful page to share with others")
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.fog)
+                        .multilineTextAlignment(.center)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, Constants.UI.Padding.big)
+                .padding(.horizontal, Constants.UI.Padding.normal)
+                .background(Color.parchmentSecondary)
+                .cornerRadius(Constants.UI.CornerRadius.normal)
+            }
         }
     }
 

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
@@ -16,6 +16,7 @@ struct WalkSummaryView: View {
     @State private var pathToDelete: String?
     @State private var showDeleteConfirmation = false
     @State private var waveforms: [UUID: [Float]] = [:]
+    @State private var showShareSheet = false
 
     init(walk: WalkInterface) {
         self.walk = walk
@@ -77,8 +78,17 @@ struct WalkSummaryView: View {
                         .foregroundColor(.ink)
                 }
                 ToolbarItem(placement: .navigationBarTrailing) {
-                    Button("Done") { dismiss() }
+                    HStack(spacing: Constants.UI.Padding.normal) {
+                        Button {
+                            showShareSheet = true
+                        } label: {
+                            Image(systemName: "square.and.arrow.up")
+                        }
                         .foregroundColor(.stone)
+
+                        Button("Done") { dismiss() }
+                            .foregroundColor(.stone)
+                    }
                 }
             }
             .onAppear {
@@ -93,6 +103,9 @@ struct WalkSummaryView: View {
                 NavigationView {
                     PromptListView(walk: walk, transcriptions: transcriptions, recentWalkSnippets: recentWalkSnippets)
                 }
+            }
+            .sheet(isPresented: $showShareSheet) {
+                WalkShareView(walk: walk)
             }
         }
     }

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
@@ -674,9 +674,13 @@ struct WalkSummaryView: View {
         }
     }
 
-    // MARK: - Activity-Colored Route Segments
+}
 
-    private var activityColoredSegments: [RouteSegment] {
+// MARK: - Route Segments & Annotations
+
+extension WalkSummaryView {
+
+    var activityColoredSegments: [RouteSegment] {
         let samples = walk.routeData
         guard samples.count > 1 else { return [] }
 
@@ -705,7 +709,7 @@ struct WalkSummaryView: View {
         }
     }
 
-    private func activityTypeForSample(_ sample: RouteDataSampleInterface) -> String {
+    func activityTypeForSample(_ sample: RouteDataSampleInterface) -> String {
         let timestamp = sample.timestamp
 
         for interval in walk.activityIntervals where interval.activityType == .meditation {
@@ -723,13 +727,11 @@ struct WalkSummaryView: View {
         return "walking"
     }
 
-    // MARK: - Pin Annotations
-
-    private var allPinAnnotations: [PilgrimAnnotation] {
+    var allPinAnnotations: [PilgrimAnnotation] {
         startEndAnnotations + meditationPinAnnotations + voicePinAnnotations
     }
 
-    private var startEndAnnotations: [PilgrimAnnotation] {
+    var startEndAnnotations: [PilgrimAnnotation] {
         var pins: [PilgrimAnnotation] = []
         if let first = walk.routeData.first {
             pins.append(PilgrimAnnotation(
@@ -746,7 +748,7 @@ struct WalkSummaryView: View {
         return pins
     }
 
-    private var meditationPinAnnotations: [PilgrimAnnotation] {
+    var meditationPinAnnotations: [PilgrimAnnotation] {
         let routeSamples = walk.routeData
         return walk.activityIntervals
             .filter { $0.activityType == .meditation }
@@ -763,7 +765,7 @@ struct WalkSummaryView: View {
             }
     }
 
-    private var voicePinAnnotations: [PilgrimAnnotation] {
+    var voicePinAnnotations: [PilgrimAnnotation] {
         let routeSamples = walk.routeData
         return walk.voiceRecordings.compactMap { recording in
             guard let closest = routeSamples.min(by: {
@@ -778,22 +780,20 @@ struct WalkSummaryView: View {
         }
     }
 
-    // MARK: - Helpers
-
-    private var routeCoordinates: [CLLocationCoordinate2D] {
+    var routeCoordinates: [CLLocationCoordinate2D] {
         walk.routeData.map {
             CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude)
         }
     }
 
-    private func boundsForTimeRange(start: Date, end: Date) -> MapCameraBounds? {
+    func boundsForTimeRange(start: Date, end: Date) -> MapCameraBounds? {
         let samples = walk.routeData.filter { $0.timestamp >= start && $0.timestamp <= end }
         let coords = samples.map { CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude) }
         guard !coords.isEmpty else { return nil }
         return boundsForRoute(coords)
     }
 
-    private func boundsForRoute(_ coords: [CLLocationCoordinate2D]) -> MapCameraBounds {
+    func boundsForRoute(_ coords: [CLLocationCoordinate2D]) -> MapCameraBounds {
         let lats = coords.map { $0.latitude }
         let lons = coords.map { $0.longitude }
         let minLat = lats.min() ?? 0
@@ -808,7 +808,7 @@ struct WalkSummaryView: View {
         )
     }
 
-    private func formatDuration(_ seconds: Double) -> String {
+    func formatDuration(_ seconds: Double) -> String {
         let totalSeconds = Int(seconds)
         let h = totalSeconds / 3600
         let m = (totalSeconds % 3600) / 60
@@ -817,7 +817,7 @@ struct WalkSummaryView: View {
         return String(format: "%d:%02d", m, s)
     }
 
-    private func formatDistance(_ meters: Double) -> String {
+    func formatDistance(_ meters: Double) -> String {
         let pref = UserPreferences.distanceMeasurementType.safeValue
         if pref == .miles {
             let miles = meters / 1609.344
@@ -826,12 +826,12 @@ struct WalkSummaryView: View {
         return String(format: "%.2f km", meters / 1000.0)
     }
 
-    private func formatSteps(_ steps: Int?) -> String {
+    func formatSteps(_ steps: Int?) -> String {
         guard let steps = steps else { return "--" }
         return "\(steps)"
     }
 
-    private func formatElevation(_ meters: Double) -> String {
+    func formatElevation(_ meters: Double) -> String {
         let pref = UserPreferences.altitudeMeasurementType.safeValue
         if pref == .feet {
             return String(format: "%.0f ft", meters * 3.28084)
@@ -839,14 +839,14 @@ struct WalkSummaryView: View {
         return String(format: "%.0f m", meters)
     }
 
-    private static let shortDateFormatter: DateFormatter = {
+    static var shortDateFormatter: DateFormatter = {
         let f = DateFormatter()
         f.dateStyle = .short
         f.timeStyle = .short
         return f
     }()
 
-    private func formatDate(_ date: Date) -> String {
+    func formatDate(_ date: Date) -> String {
         Self.shortDateFormatter.string(from: date)
     }
 }

--- a/docs/superpowers/specs/2026-03-16-share-your-walk-design.md
+++ b/docs/superpowers/specs/2026-03-16-share-your-walk-design.md
@@ -1,0 +1,477 @@
+# Share Your Walk — Design Spec
+
+## Overview
+
+A sharing feature that generates beautiful, ephemeral HTML pages from walk data. Users tap "Share" on any walk summary, customize what to include, and receive a URL at `walk.pilgrimapp.org/{id}`. The page is self-contained HTML with no JS dependencies, styled in the app's wabi-sabi aesthetic.
+
+Every shared walk is ephemeral. No permanent links. The user chooses how long it lives: 1 moon (30 days), 1 season (90 days), or 1 cycle (1 year). When it expires, the URL shows a tombstone page: "This walk has returned to the trail."
+
+This is Pilgrim's first backend service (Cloudflare Workers + R2).
+
+## Architecture
+
+```
+iOS App                     Cloudflare Worker              R2 Storage
+│                           │                              │
+├─ POST /api/share ────────►│                              │
+│  { stats, coords,         ├─ Reverse-geocode start/end   │
+│    journal, prefs,         ├─ GET Mapbox Static Image     │
+│    intervals, expiry,      ├─ Generate sumi-e SVG overlay │
+│    units }                 ├─ Generate passport stamp SVG │
+│                           ├─ Generate QR code SVG        │
+│                           ├─ Render HTML from template    │
+│                           ├─ PUT {id}.html ──────────────►│
+│                           ├─ PUT {id}-og.png ────────────►│
+│  ◄─── { url, id } ───────┤                              │
+│                           │                              │
+│                           │                              │
+Visitor ────► GET /:id ────►├─ Check expiry                │
+                            ├─ Serve HTML (or tombstone) ◄─┤
+                            │                              │
+                     Cron ──├─ Find expired walks          │
+                            ├─ Replace with tombstone ─────►│
+```
+
+## iOS: Share Preparation Screen
+
+### Entry Point
+
+Share button added to `WalkSummaryView` toolbar (trailing, before "Done"). Available both after completing a walk and when viewing past walks from the log.
+
+Tapping "Share" presents a full-screen sheet: `WalkShareView`.
+
+### WalkShareView Layout
+
+**Top: Map Preview**
+- Route drawn with sumi-e ink effect
+- Activity-colored segments (moss = walking, dawn = meditation, rust = reflection)
+- Occupies ~200pt, no horizontal padding
+
+**Stat Toggles**
+- Each stat is a toggle row in a list
+- Default ON: Distance, Duration, Elevation, Walk/Meditation/Talk breakdown
+- Default OFF: Steps
+- Section header: "Share these details"
+- Only toggled-on stats appear on the shared page
+
+**Journal Entry**
+- Text field, 140 character limit
+- Placeholder: "A few words about this walk..."
+- Section header: "Reflection"
+- Optional — empty is fine
+
+**Expiration Picker**
+- Three segmented options: "1 moon" / "1 season" / "1 cycle"
+- Maps to 30 / 90 / 365 days
+- Default: "1 season" (3 months)
+- Shows computed expiration date below: "Expires June 16, 2026"
+
+**Share Button**
+- Primary action button at bottom
+- Text: "Share Walk"
+- Triggers upload flow
+
+### Upload Flow
+
+1. Build JSON payload from selections
+2. Show loading state (indeterminate progress)
+3. POST to Worker API
+4. On success: show URL with copy button + native share sheet
+5. On failure: show error with retry option
+6. Store share metadata locally via UserDefaults (keyed by walk UUID): `{ url, id, expiry_date }`. Not in CoreStore — avoids migration for a lightweight cache. Used to show "Shared" indicator on walk rows and re-show the URL if the user taps share again on an already-shared walk.
+
+### JSON Payload
+
+```json
+{
+  "stats": {
+    "distance": 12400,
+    "active_duration": 9240,
+    "elevation_ascent": 347,
+    "elevation_descent": 210,
+    "steps": 15240,
+    "meditate_duration": 840,
+    "talk_duration": 480
+  },
+  "route": [
+    { "lat": 48.123, "lon": 11.456, "alt": 520, "ts": 1710576000 },
+    { "lat": 48.124, "lon": 11.457, "alt": 522, "ts": 1710576060 }
+  ],
+  "activity_intervals": [
+    { "type": "meditation", "start_ts": 1710576300, "end_ts": 1710577140 },
+    { "type": "talk", "start_ts": 1710577800, "end_ts": 1710578280 }
+  ],
+  "journal": "The fog lifted somewhere past the old bridge...",
+  "expiry_days": 90,
+  "units": "metric",
+  "start_date": "2026-03-16T07:30:00Z",
+  "toggled_stats": ["distance", "duration", "elevation", "activity_breakdown"]
+}
+```
+
+**Route downsampling**: Full walks can have thousands of GPS points. Downsample to ~200 points using the Ramer-Douglas-Peucker algorithm before sending. Preserves route shape, reduces payload from ~100KB to ~5KB.
+
+**Activity intervals**: Sent as timestamp ranges. Meditation intervals come directly from `walk.activityIntervals`. Talk intervals are synthesized from `walk.voiceRecordings` (each has `startDate`/`endDate`) — there is no `talk` type in `ActivityInterval.ActivityType`. The existing `ActivityTimelineBar` in `WalkSummaryView` already does an equivalent merge. The Worker maps these timestamps to route point indices by finding the nearest timestamps in the route array.
+
+**Walking duration derivation**: The Worker computes walking duration as `active_duration - meditate_duration` (talk time is NOT subtracted — talk happens while walking). This matches `WalkSummaryView.walkDuration`'s formula. Note: `WalkSnapshot.walkOnlyDuration` in the home list uses a different formula that subtracts talk. The shared page should match the summary view the user just saw.
+
+**Stats filtering**: Only include stats the user toggled on. The Worker renders only what's present in the payload.
+
+## Cloudflare Worker: API
+
+### POST /api/share
+
+**Rate limiting**: Per-device token (UUID generated on first share, stored in Keychain). Max 10 uploads per day per device.
+
+**Processing pipeline**:
+
+1. Validate payload structure and size (max 500KB)
+2. Generate unique ID (nanoid, 10 chars, URL-safe)
+3. Reverse-geocode start/end coordinates → place names (Mapbox Geocoding API)
+4. Fetch Mapbox Static Image (1280x800, style matching app's wabi-sabi map)
+5. Generate HTML page from template:
+   - Inject base64-encoded map image
+   - Generate sumi-e SVG route overlay from coordinates
+   - Generate activity-colored route segments
+   - Place meditation glow markers at meditation intervals
+   - Place distance marker stones at km/mi intervals
+   - Generate procedural passport stamp SVG
+   - Generate QR code SVG (App Store link)
+   - Apply staged reveal CSS animations
+   - Set OG meta tags
+   - Apply unit formatting (metric/imperial)
+   - Include walk character text (auto-generated from metadata)
+6. Store HTML in R2: `walks/{id}/index.html`
+7. Store OG image in R2: `walks/{id}/og.png` (the raw Mapbox static image — no SVG overlay, since Workers V8 isolate has no canvas/PNG rendering. The static map with the route drawn by Mapbox's path overlay parameter is sufficient for social previews)
+8. Store metadata in R2: `walks/{id}/meta.json` (expiry date, created date)
+9. Return `{ "url": "https://walk.pilgrimapp.org/{id}", "id": "{id}" }`
+
+### GET /:id
+
+1. Check `walks/{id}/meta.json` for expiry
+2. If expired: serve tombstone HTML
+3. If valid: serve `walks/{id}/index.html`
+4. Set appropriate cache headers (short TTL since pages expire)
+
+### Cron: Expiry Cleanup
+
+- On share creation, store expiry date in KV: key = `expiry:{id}`, value = ISO date, TTL = expiry duration + 1 day
+- Cron runs daily, reads KV keys with `expiry:` prefix, checks dates
+- Expired walks: delete HTML + OG image from R2, delete KV entry
+- Tombstone pages are generated on-the-fly by the Worker when `meta.json` exists but `index.html` does not
+- Avoids expensive R2 object listing at scale
+
+## Walk Page: HTML Design
+
+### Visual Identity
+
+Based on Alternative A ("The Journey") — timeline-narrative layout.
+
+**Colors** (light mode):
+- Background: `#F5F0E8` (parchment)
+- Text: `#2C241E` (ink)
+- Accent: `#8B7355` (stone)
+- Walking: `#7A8B6F` (moss)
+- Meditation: `#C4956A` (dawn)
+- Reflection: `#A0634B` (rust)
+- Secondary: `#B8AFA2` (fog)
+- Cards: `#EDE6D8` (parchment-secondary)
+
+**Dark mode** (via `prefers-color-scheme: dark`):
+- Background: `#141D1C`, Text: `#F0EBE1`, Accent: `#B8976E`
+- Moss: `#95A895`, Dawn: `#D4A87A`, Rust: `#C47E63`, Fog: `#6B6359`
+- Note: these are design-intent approximations. The iOS app applies dynamic seasonal color shifts via `SeasonalColorEngine`, so exact hex matching is not possible. The web page uses static values that capture the intended mood.
+
+**Typography**:
+- Display/headings/journal: Cormorant Garamond italic + regular (base64-encoded Latin subset, ~25KB)
+- Stats/labels: Lato regular (base64-encoded Latin subset, ~20KB)
+- Total font payload: ~45KB — keeps page well under 500KB target
+- Fonts inlined as `@font-face` with `src: url(data:font/woff2;base64,...)` — self-contained, no CDN, works forever
+- Fallback stacks: `'Cormorant Garamond', 'Georgia', serif` / `'Lato', -apple-system, sans-serif`
+
+**Spacing**: 8px base grid, generous vertical breathing room
+
+### Page Structure (top to bottom)
+
+1. **Map** — edge-to-edge, ~320px height
+   - Mapbox static image as CSS background
+   - SVG overlay with sumi-e ink stroke route
+   - Activity-colored segments (moss/dawn/rust)
+   - Meditation glow markers (soft dawn-colored radial gradients)
+   - Distance marker stones (small stone dots at km/mi intervals)
+   - Start dot (filled) / End dot (hollow)
+   - Gradient fade to parchment at bottom
+   - **Ink draw animation**: route animates drawing itself on load via CSS `stroke-dasharray` + `@keyframes` (3-4 seconds)
+
+2. **Date + Walk Character** — left-aligned
+   - Date: "March 16, 2026 · Morning" (Lato uppercase, fog color)
+   - Walk character: "A morning walk with moments of meditation and three spoken reflections" (italic, stone color)
+   - Auto-generated from: time of day, season, activity composition
+
+3. **Journal Entry** — hero text
+   - Large Cormorant Garamond, light weight, 22-26px
+   - Italic
+   - Max width ~480px for comfortable reading
+
+4. **Activity Timeline Bar**
+   - Horizontal bar showing walk composition
+   - Segmented by activity type with moss/dawn/rust colors
+   - Legend below: Walking · Meditation · Reflection
+
+5. **Mindful Stats** — 3-column grid
+   - Walking time (moss), Meditation time (dawn), Reflection time (rust)
+   - Parchment-secondary background cards
+   - Only shown if user toggled "activity breakdown" on
+
+6. **Movement Stats** — horizontal row with hairline borders
+   - Distance, Elevation, Steps (whichever the user toggled on)
+   - Compact: value + label, separated by thin borders
+
+7. **Elevation Profile** — SVG sparkline
+   - Stone-colored gradient fill + thin line
+   - Full width, ~60px height
+   - Only shown if user toggled "elevation" on and walk has significant elevation change (>10m)
+
+8. **Footer** — passport stamp + colophon side by side
+   - Left: procedural passport stamp (80x80px)
+   - Right: "Recorded with Pilgrim" + "pilgrimapp.org"
+
+9. **Colophon Area**
+   - QR code (80x80px, SVG-generated)
+   - "Embed this walk" via `<details>/<summary>` (pure HTML, no JS)
+
+10. **Ephemeral Notice** — very bottom
+    - "This walk returns to the trail on [date]"
+    - Extremely subtle (fog color, 0.4 opacity, italic)
+
+**Note**: Start/end place names (from geocoding) are integrated into the date line at position 2: "March 16, 2026 · Morning · Riverside Trail → Cathedral Hill". Only shown if geocoding succeeds; gracefully omitted otherwise.
+
+### Staged Reveal Animation
+
+CSS-only with `@keyframes` and `animation-delay`:
+- Map: immediate
+- Date + character: 0.5s delay
+- Journal: 1.0s delay
+- Timeline: 1.5s delay
+- Stats: 2.0s delay
+- Elevation: 2.5s delay
+- Footer: 3.0s delay
+
+Each section fades in + slides up 12px. Duration: 0.6s each. Easing: `ease-out`.
+
+### Sumi-e Ink Stroke Effect
+
+SVG filter chain applied to route path:
+```svg
+<filter id="sumi-e">
+  <feTurbulence type="turbulence" baseFrequency="0.03" numOctaves="4" seed="{walk-specific}" />
+  <feDisplacementMap in="SourceGraphic" in2="noise" scale="4" />
+</filter>
+```
+- Seed derived from walk UUID for consistent rendering
+- Shadow layer: same path, 12px width, 15% opacity, Gaussian blur for ink bleed
+- Main stroke: 4px width, round caps/joins
+
+### Procedural Passport Stamp
+
+SVG generated from walk metadata:
+- **Outer ring**: circle with rough filter (feTurbulence displacement)
+- **Inner ring**: dashed circle
+- **Top arc text**: "PILGRIM · {SEASON} {YEAR}" (Lato uppercase)
+- **Bottom arc text**: "{TIME_OF_DAY} WALK" (Lato uppercase)
+- **Center**: distance value (large Cormorant Garamond) + unit label
+
+Metadata encoding:
+- Season: derived from start date + hemisphere
+- Time of day: derived from start date hour (morning/afternoon/evening)
+- Ring count: 2 rings for <5km, 3 rings for 5-15km, 4 rings for >15km
+
+### Print Layout (@media print)
+
+- Remove: ephemeral notice, embed button, staged animations
+- Map: reduced height (300px)
+- Page break: avoid inside footer
+- Background: white
+- The printed version IS the permanent keepsake
+
+### Accessibility
+
+- Semantic HTML: `<header>`, `<main>`, `<section>`, `<footer>`
+- Map image: `alt="Walk route from {start} to {end}, {distance}"`
+- Stats: proper `aria-label` attributes
+- Color contrast: all text passes WCAG AA on parchment background
+- Route colors: distinguishable for common color vision deficiencies (moss/dawn/rust chosen deliberately)
+
+### Embed Snippet
+
+Uses `<details>/<summary>` HTML elements (no JavaScript) to toggle visibility of the iframe code block:
+```html
+<details>
+  <summary>Embed this walk</summary>
+  <code>&lt;iframe src="https://walk.pilgrimapp.org/{id}?embed=1"
+        width="100%" height="600" frameborder="0"&gt;&lt;/iframe&gt;</code>
+</details>
+```
+- `?embed=1` param hides the colophon/QR/ephemeral notice for cleaner embedding
+- Zero JavaScript on the entire page
+
+## Tombstone Page
+
+Shown when a walk's expiry date has passed.
+
+- Parchment background
+- Centered vertically
+- Pilgrim logo (small, 48px)
+- Text: "This walk has returned to the trail." (Cormorant Garamond italic, fog color)
+- Small "Recorded with Pilgrim" colophon below
+- QR code to App Store
+- OG tags still present (generic Pilgrim branding)
+- Dark mode supported
+- Generated on-the-fly by the Worker (not stored in R2)
+
+## Backend Infrastructure
+
+### Cloudflare Workers + R2
+
+- **Worker**: `share-worker` — handles upload, serving, expiry
+- **R2 Bucket**: `pilgrim-walks`
+- **Custom domain**: `walk.pilgrimapp.org` → Worker route
+- **KV Store**: rate limit counters per device token + expiry date index for cron cleanup
+
+### R2 Object Structure
+
+```
+walks/
+  {id}/
+    index.html    — the walk page
+    og.png        — OG image (Mapbox static with route overlay)
+    meta.json     — { created: ISO, expires: ISO, device_token_hash: SHA256 }
+```
+
+### API Authentication
+
+- No user accounts
+- Device token: UUID generated on first share, stored in iOS Keychain
+- Sent as `X-Device-Token` header
+- Hashed (SHA-256) before storing in meta.json (privacy)
+- Used only for rate limiting, not for ownership/editing
+
+### Rate Limits
+
+- 10 shares per device per 24-hour window
+- 500KB max payload size
+- Enforced via Cloudflare KV with TTL
+
+### Cost Estimate
+
+- R2: $0.015/GB-month storage, $0.36/million reads. At 1000 shared walks (~500KB each): ~$0.01/month storage
+- Workers: 10 million requests/month free tier
+- Mapbox Static Images: 50,000 free/month, then $0.25/1000
+- Mapbox Geocoding: 100,000 free/month
+- Total for early stage: effectively free within free tiers
+
+## Walk Character Text Generation
+
+Auto-generated description from walk metadata. No AI — deterministic template selection.
+
+**Template structure**: "{time_of_day_phrase} with {activity_description}"
+
+**Time of day phrases** (based on startDate hour):
+- 5-8: "An early morning walk"
+- 8-11: "A morning walk"
+- 11-14: "A midday walk"
+- 14-17: "An afternoon walk"
+- 17-20: "An evening walk"
+- 20-5: "A night walk"
+
+**Activity descriptions** (based on duration ratios):
+- Meditation only: "long stretches of silence"
+- Talk only: "{count} spoken reflections"
+- Both: "moments of meditation and {count} spoken reflections"
+- Neither: "steady footsteps" (walking only)
+- High meditation ratio (>30%): "deep meditation woven through each step"
+- High talk ratio (>30%): "rich spoken reflection along the way"
+
+**Season** (for stamp, based on startDate + rough hemisphere detection from coordinates):
+- March-May (N) or Sept-Nov (S): "Spring"
+- June-Aug (N) or Dec-Feb (S): "Summer"
+- Sept-Nov (N) or March-May (S): "Autumn"
+- Dec-Feb (N) or June-Aug (S): "Winter"
+
+## Key Files to Create/Modify
+
+### iOS (New Files)
+- `Pilgrim/Scenes/WalkShare/WalkShareView.swift` — share preparation screen
+- `Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift` — share flow state
+- `Pilgrim/Models/Share/ShareService.swift` — API client for Worker
+- `Pilgrim/Models/Share/RouteDownsampler.swift` — Ramer-Douglas-Peucker implementation
+- `Pilgrim/Models/Share/SharePayload.swift` — JSON payload model
+
+### iOS (Modified Files)
+- `Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift` — add share button to toolbar
+
+### Backend (Separate Repository: `pilgrim-worker`)
+- `src/index.ts` — Worker entry point, routing
+- `src/handlers/share.ts` — POST /api/share handler
+- `src/handlers/serve.ts` — GET /:id handler
+- `src/handlers/expiry.ts` — Cron expiry cleanup
+- `src/generators/html-template.ts` — HTML page generation
+- `src/generators/sumi-e-route.ts` — SVG route overlay generation
+- `src/generators/passport-stamp.ts` — procedural stamp SVG
+- `src/generators/qr-code.ts` — QR code SVG generation
+- `src/generators/walk-character.ts` — text generation
+- `src/generators/elevation.ts` — elevation profile SVG
+- `src/generators/tombstone.ts` — expired walk page
+- `src/generators/polyline.ts` — Google polyline encoding
+- `src/services/mapbox.ts` — Mapbox Static Images API
+- `src/services/geocode.ts` — Mapbox Geocoding API
+- `src/types.ts` — shared TypeScript types
+- `wrangler.toml` — Worker configuration
+
+## Existing Code to Reuse
+
+- **Route data**: `WalkInterface` (not `WalkSnapshot`) provides route coordinates via `routeData` and activity intervals via `activityIntervals`. The share screen needs access to the full `Walk` object from CoreStore, not the lightweight snapshot.
+- **Stats computation**: `WalkStats` in `Pilgrim/Models/Walk/Stats/WalkStats.swift`
+- **Elevation smoothing**: `Computation.calculateElevationData` in `Pilgrim/Models/Data/DataModels/Computation.swift`
+- **Activity timeline**: `WalkSummaryView` already renders activity timeline bars
+- **Color definitions**: `Color.swift` extension has all hex values
+- **Unit formatting**: existing `UserPreferences` tracks metric/imperial setting
+- **Mapbox token**: already configured in the app for `PilgrimMapView`
+- **Export infrastructure**: `ExportManager.swift` has file-sharing patterns (UIActivityViewController)
+
+## Verification Plan
+
+### iOS
+1. Build: `xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build`
+2. Test share button appears in WalkSummaryView toolbar
+3. Test share preparation screen opens with correct walk data
+4. Test stat toggles work and affect preview
+5. Test journal entry with character limit
+6. Test expiration picker shows correct dates
+7. Test upload flow with mock/staging Worker
+8. Test error handling (no network, Worker error)
+9. Test URL copy and native share sheet
+
+### Worker
+1. `wrangler dev` for local development
+2. Test POST /api/share with sample payload → returns URL
+3. Test GET /:id → serves correct HTML
+4. Test expired walk → serves tombstone
+5. Test rate limiting (11th request fails)
+6. Verify HTML passes W3C validator
+7. Verify OG tags render correctly (use Facebook OG debugger, Twitter card validator)
+8. Verify dark mode works
+9. Verify print layout
+10. Verify accessibility (Lighthouse audit)
+11. Test ink draw animation renders correctly
+12. Test page loads under 1 second (target: <500KB total)
+
+### End-to-End
+1. Complete a walk in the simulator
+2. Open walk summary, tap share
+3. Configure stats, write journal, pick expiration
+4. Share walk → get URL
+5. Open URL in browser → see beautiful walk page
+6. Open URL on mobile → responsive design works
+7. Share URL in iMessage → OG preview shows
+8. Wait for expiry (or manually expire) → tombstone shows


### PR DESCRIPTION
## Summary
- Share preparation screen with stat toggles, 140-char journal entry, and ephemeral expiry picker (1 moon / 1 season / 1 cycle)
- Uploads walk data as JSON to Cloudflare Worker at `walk.pilgrimapp.org`
- Worker generates self-contained HTML pages with sumi-e ink stroke route, passport stamp, elevation profile, dark mode, print layout
- Share button added to WalkSummaryView toolbar
- Design spec included at `docs/superpowers/specs/2026-03-16-share-your-walk-design.md`

### New files
| File | Purpose |
|------|---------|
| `Pilgrim/Scenes/WalkShare/WalkShareView.swift` | Share preparation screen |
| `Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift` | Payload builder + upload state |
| `Pilgrim/Models/Share/ShareService.swift` | API client, Keychain device token, UserDefaults cache |
| `Pilgrim/Models/Share/SharePayload.swift` | Encodable JSON model |
| `Pilgrim/Models/Share/RouteDownsampler.swift` | Ramer-Douglas-Peucker route compression |

### Modified files
- `WalkSummaryView.swift` — share button in toolbar + sheet presentation

### Backend
Backend Worker lives in [pilgrim-worker](https://github.com/walktalkmeditate/pilgrim-worker) (separate repo).

## Test plan
- [ ] Build succeeds on simulator
- [ ] Share button appears in walk summary toolbar
- [ ] Share sheet opens with correct walk data
- [ ] Stat toggles enable/disable correctly
- [ ] Journal entry respects 140-char limit
- [ ] Expiry picker shows correct dates for each option
- [ ] Upload flow handles success, error, and rate limiting states
- [ ] Copy button copies URL to clipboard
- [ ] Share button opens native share sheet
- [ ] Re-opening share for same walk shows cached URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)