### PR TITLE
feat: Voice Guide Packs infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,7 @@ Secrets.xcconfig
 
 # Superpowers
 .superpowers/
+.worktrees/
 
 
 # AppCode

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		0247093D7E5B019E36A98F9F /* AudioAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA2B0038D4875801C41DE26 /* AudioAsset.swift */; };
+		0379F19A766F1A45B011537D /* VoiceGuideSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90791FB10E8E34FB9BBAB3DD /* VoiceGuideSchedulerTests.swift */; };
 		03A4AA6D8DD2B3AA6E9AF157 /* PromptGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD13E8087B26CC89725C3041 /* PromptGeneratorTests.swift */; };
 		08508B6253B3427ABA939DED /* ActivityTimelineBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9CBD6B08E4C437DA90FDDB0 /* ActivityTimelineBar.swift */; };
 		0900F4294F091546C199FA0A /* WalkDataFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4181215714A52E71449BC390 /* WalkDataFactory.swift */; };
@@ -151,6 +152,7 @@
 		22FEA0B124CDDFF80007CA9C /* CustomByteFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FEA0B024CDDFF80007CA9C /* CustomByteFormatting.swift */; };
 		2B6F4CE80AB1FB057688EAA1 /* ComputationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D23FF60A762C30296A69E6 /* ComputationTests.swift */; };
 		2E59989F7B4496B95EBB0AB7 /* SoundManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263D620E1DB30C5FCA0143CC /* SoundManagement.swift */; };
+		3C55BD8AE4CD85263004E064 /* VoiceGuideManifestTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0B789354C6B8AAE45AEC71F0 /* VoiceGuideManifestTests.swift */; };
 		3DF4B121DEE87CA7EBB26207 /* VoiceGuideSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFDE354370A5891DF5C3F183 /* VoiceGuideSettingsView.swift */; };
 		3F8E37CD28D541C1838F01BD /* PilgrimV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2722224F049B455DB473E7C9 /* PilgrimV2.swift */; };
 		45ECE5D78ADACF7F238277C4 /* AudioManifestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 390BFBA7B83028EA625B0CF9 /* AudioManifestService.swift */; };
@@ -273,6 +275,7 @@
 		F1A2B3C4D5E6F7A8B9C0D1E7 /* FaviconSelectorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7A8B9C0D1E6 /* FaviconSelectorView.swift */; };
 		F28633E25671B876232C0F34 /* BackupSerializationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1AB8B7996545B4CEF51D686E /* BackupSerializationTests.swift */; };
 		FA9B9D71DB2B3EA84CC73FEE /* AudioFileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90392F316E29A62DA1F0DE0E /* AudioFileStore.swift */; };
+		FB767A6007B826D951706B85 /* VoiceGuideHistoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4E104D87032C76222B9E346E /* VoiceGuideHistoryTests.swift */; };
 		FE15922AE9DAD82F62BA4601 /* NewWalkComputationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E892B071C7BE6EBD74F3FC /* NewWalkComputationTests.swift */; };
 		PERM000100000003 /* PermissionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = PERM000100000002 /* PermissionsViewModel.swift */; };
 		PERM000100000005 /* PermissionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PERM000100000004 /* PermissionsViewModelTests.swift */; };
@@ -291,6 +294,7 @@
 
 /* Begin PBXFileReference section */
 		04D6AFD9DABC41629606A762 /* ActivityInsightsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityInsightsView.swift; sourceTree = "<group>"; };
+		0B789354C6B8AAE45AEC71F0 /* VoiceGuideManifestTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceGuideManifestTests.swift; sourceTree = "<group>"; };
 		0F5581F46A4FFE9ED1D2DCEB /* SoundSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundSettingsView.swift; sourceTree = "<group>"; };
 		16BE9557700152F043C359DC /* WalkShareView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkShareView.swift; sourceTree = "<group>"; };
 		1725921B51E95B8BB46C90E4 /* AudioDownloadManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioDownloadManager.swift; sourceTree = "<group>"; };
@@ -445,6 +449,7 @@
 		4AE6DC51742E035602E624F1 /* AudioSessionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionCoordinator.swift; sourceTree = "<group>"; };
 		4B6BF30D6A9C48219D3C115C /* PaceSparklineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaceSparklineView.swift; sourceTree = "<group>"; };
 		4B95E4FB1DF743CEF3AC77C2 /* RouteShapeView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RouteShapeView.swift; sourceTree = "<group>"; };
+		4E104D87032C76222B9E346E /* VoiceGuideHistoryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceGuideHistoryTests.swift; sourceTree = "<group>"; };
 		5A2543BE1F771480BD145035 /* VoiceGuideDownloadManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceGuideDownloadManager.swift; sourceTree = "<group>"; };
 		5D9D07CA4444A7B548B5CFA4 /* ShareService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShareService.swift; sourceTree = "<group>"; };
 		65CE1DB41D3DBD404C28973B /* VoiceGuideManagement.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceGuideManagement.swift; sourceTree = "<group>"; };
@@ -456,6 +461,7 @@
 		8C0699EE439FF3DC5E16B8E0 /* Pods-Pilgrim.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pilgrim.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Pilgrim/Pods-Pilgrim.debug.xcconfig"; sourceTree = "<group>"; };
 		8E0BF1B23139F428720EB2CF /* WalkShareViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkShareViewModel.swift; sourceTree = "<group>"; };
 		90392F316E29A62DA1F0DE0E /* AudioFileStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioFileStore.swift; sourceTree = "<group>"; };
+		90791FB10E8E34FB9BBAB3DD /* VoiceGuideSchedulerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceGuideSchedulerTests.swift; sourceTree = "<group>"; };
 		964D4C7663494F3ABBEEF84F /* ActivityIntervalInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIntervalInterface.swift; sourceTree = "<group>"; };
 		980407DB8189D982A61A73F9 /* Pods-UnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.release.xcconfig"; sourceTree = "<group>"; };
 		A1B2C3D4E5F601020304050A /* PilgrimV3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV3.swift; sourceTree = "<group>"; };
@@ -1061,6 +1067,9 @@
 				BB00CC010000000000000002 /* WelcomeViewModelTests.swift */,
 				PERM000100000004 /* PermissionsViewModelTests.swift */,
 				A1B2C3D4E5F6A7B8C9D0E1F4 /* PermissionStatusViewModelTests.swift */,
+				90791FB10E8E34FB9BBAB3DD /* VoiceGuideSchedulerTests.swift */,
+				0B789354C6B8AAE45AEC71F0 /* VoiceGuideManifestTests.swift */,
+				4E104D87032C76222B9E346E /* VoiceGuideHistoryTests.swift */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -1758,6 +1767,9 @@
 				BB00CC010000000000000001 /* WelcomeViewModelTests.swift in Sources */,
 				PERM000100000005 /* PermissionsViewModelTests.swift in Sources */,
 				A1B2C3D4E5F6A7B8C9D0E1F5 /* PermissionStatusViewModelTests.swift in Sources */,
+				0379F19A766F1A45B011537D /* VoiceGuideSchedulerTests.swift in Sources */,
+				3C55BD8AE4CD85263004E064 /* VoiceGuideManifestTests.swift in Sources */,
+				FB767A6007B826D951706B85 /* VoiceGuideHistoryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -151,24 +151,31 @@
 		22FEA0B124CDDFF80007CA9C /* CustomByteFormatting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22FEA0B024CDDFF80007CA9C /* CustomByteFormatting.swift */; };
 		2B6F4CE80AB1FB057688EAA1 /* ComputationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2D23FF60A762C30296A69E6 /* ComputationTests.swift */; };
 		2E59989F7B4496B95EBB0AB7 /* SoundManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 263D620E1DB30C5FCA0143CC /* SoundManagement.swift */; };
+		3DF4B121DEE87CA7EBB26207 /* VoiceGuideSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFDE354370A5891DF5C3F183 /* VoiceGuideSettingsView.swift */; };
 		3F8E37CD28D541C1838F01BD /* PilgrimV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2722224F049B455DB473E7C9 /* PilgrimV2.swift */; };
 		45ECE5D78ADACF7F238277C4 /* AudioManifestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 390BFBA7B83028EA625B0CF9 /* AudioManifestService.swift */; };
 		487022E2F9AD1AE6D374FF39 /* Pods_UnitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C56A574B3F5BFCBF50DB5368 /* Pods_UnitTests.framework */; };
 		4E9F3E9C7E3A4840ACD9DA73 /* ActivityIntervalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B789284BE2A474BA89993F2 /* ActivityIntervalTests.swift */; };
 		50A16B63C6F23E2D1E6210BA /* Pods_Pilgrim.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */; };
+		52C6F28B0AAB6E494591E8EF /* VoiceGuideManifestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F883597323B0CE64E69DC9 /* VoiceGuideManifestService.swift */; };
 		5EB2EE597FAA4E288699FEF4 /* WaveformGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8019A1ED39BF4E889F5DF99C /* WaveformGenerator.swift */; };
 		6AE85BCC627AF8321E753C1F /* ShareService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9D07CA4444A7B548B5CFA4 /* ShareService.swift */; };
 		6EBC9E9BD642B03C2C67D8D2 /* BellPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E5EFD54CACA590B1BE78B75 /* BellPlayer.swift */; };
 		6F172421DF5C4B98BDFDA00E /* PaceSparklineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B6BF30D6A9C48219D3C115C /* PaceSparklineView.swift */; };
 		6F242558E79A4653BAAAE3FB /* ActivityListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2FDF0BD38D9467B99B2C4D7 /* ActivityListView.swift */; };
+		6F8AA2EEEDD08C727B89AB94 /* VoiceGuideScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4284167708855BA9866F9FF /* VoiceGuideScheduler.swift */; };
 		764C2FC0EBC04F779B97EA92 /* WalkCheckpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74490DBCE024418B78E73B2 /* WalkCheckpoint.swift */; };
 		76B622EBDD59AD9489586120 /* DateFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2D4ACA7F21BA80523DF98C /* DateFactory.swift */; };
 		7C39E4160B0DA105D78F4C83 /* SharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EA6F12A77BD40C46E34D47 /* SharePayload.swift */; };
+		86DEAF7F2E18DAA455E516C8 /* VoiceGuideManifest.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2E956773703AC660C7676BD /* VoiceGuideManifest.swift */; };
 		8A200FA63DDEC6D859F1C4EE /* WalkShareViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E0BF1B23139F428720EB2CF /* WalkShareViewModel.swift */; };
 		9726AFAB9F744FDA86EEC2CF /* ActivityInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA57CE96EE3401595264807 /* ActivityInterval.swift */; };
 		9A477336A61C4C38B9D4F13C /* RouteDownsampler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6E1B5A537C865F5416F6EF2 /* RouteDownsampler.swift */; };
 		9D37F522C28D84C1E1ECCDCC /* AudioDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1725921B51E95B8BB46C90E4 /* AudioDownloadManager.swift */; };
 		A1B2C3D4E5F601020304050B /* PilgrimV3.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F601020304050A /* PilgrimV3.swift */; };
+		A1B2C3D4E5F6A7B8C9D0E1F3 /* PermissionStatusViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A7B8C9D0E1F2 /* PermissionStatusViewModel.swift */; };
+		A1B2C3D4E5F6A7B8C9D0E1F5 /* PermissionStatusViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A7B8C9D0E1F4 /* PermissionStatusViewModelTests.swift */; };
+		A3B7C9D1E5F2A8B4C0D6E2F2 /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B7C9D1E5F2A8B4C0D6E2F1 /* GeneralSettingsView.swift */; };
 		A5B6C7D8E9F0A1B2C3D4E5F7 /* PilgrimV5.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5B6C7D8E9F0A1B2C3D4E5F6 /* PilgrimV5.swift */; };
 		A7A6E8BA14A8426581C2E09D /* WaveformCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE12D19DC32D4F8FB3A35965 /* WaveformCache.swift */; };
 		AA000002FOOTPRINTSHAPE00 /* FootprintShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA000001FOOTPRINTSHAPE00 /* FootprintShape.swift */; };
@@ -178,8 +185,6 @@
 		AA0001010000000000000013 /* WalkRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001010000000000000003 /* WalkRowView.swift */; };
 		AA0001010000000000000014 /* ActiveWalkView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001010000000000000004 /* ActiveWalkView.swift */; };
 		AA0001010000000000000015 /* ActiveWalkViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001010000000000000005 /* ActiveWalkViewModel.swift */; };
-		AAAA0000000000000000F9 /* IntentionSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA0000000000000000F8 /* IntentionSettingView.swift */; };
-		AAAA0000000000000000FB /* WalkOptionsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA0000000000000000FA /* WalkOptionsSheet.swift */; };
 		AA0001010000000000000016 /* WalkSummaryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001010000000000000006 /* WalkSummaryView.swift */; };
 		AA0001010000000000000017 /* MainCoordinatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA0001010000000000000007 /* MainCoordinatorView.swift */; };
 		AA00020100000000000002 /* VoiceRecording.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA00020100000000000001 /* VoiceRecording.swift */; };
@@ -197,7 +202,6 @@
 		AAAA000000000000000000E1 /* CustomPromptEditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000E2 /* CustomPromptEditorView.swift */; };
 		AAAA000000000000000000F1 /* IntentionHistoryStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000F2 /* IntentionHistoryStore.swift */; };
 		AAAA000000000000000000F3 /* IntentionHistoryStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000F4 /* IntentionHistoryStoreTests.swift */; };
-		BBBB00000000000000000C /* WaypointCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB00000000000000000B /* WaypointCodableTests.swift */; };
 		AAAA000000000000000000F7 /* IntentionVoiceRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA000000000000000000F6 /* IntentionVoiceRecorder.swift */; };
 		AAAA00000000000000000EL1 /* ElevationProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00000000000000000EL2 /* ElevationProfileView.swift */; };
 		AAAA00000000000000000MB1 /* MapboxMaps in Frameworks */ = {isa = PBXBuildFile; productRef = AAAA00000000000000000MB3 /* MapboxMaps */; };
@@ -205,12 +209,23 @@
 		AAAA00000000000000000MF3 /* PilgrimAnnotation.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00000000000000000MF4 /* PilgrimAnnotation.swift */; };
 		AAAA00000000000000000MF5 /* PilgrimMapStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00000000000000000MF6 /* PilgrimMapStyle.swift */; };
 		AAAA00000000000000000MF7 /* PilgrimMapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA00000000000000000MF8 /* PilgrimMapView.swift */; };
+		AAAA0000000000000000F9 /* IntentionSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA0000000000000000F8 /* IntentionSettingView.swift */; };
+		AAAA0000000000000000FB /* WalkOptionsSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAAA0000000000000000FA /* WalkOptionsSheet.swift */; };
 		AABB000100000002 /* WelcomeAnimationState.swift in Sources */ = {isa = PBXBuildFile; fileRef = AABB000100000001 /* WelcomeAnimationState.swift */; };
 		ACF07FD2C47613FD87D08EE7 /* SoundSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5581F46A4FFE9ED1D2DCEB /* SoundSettingsView.swift */; };
+		B0261DB7EE2F64C26CF7A41F /* VoiceGuideFileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB41AD9F5C496AE9BC8C260 /* VoiceGuideFileStore.swift */; };
 		B3D4E5F6A7B8C9D0E1F2A3B5 /* RecordingsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F6A7B8C9D0E1F2A3B4C6 /* RecordingsListView.swift */; };
+		B4C5D6E7F8A9B0C1D2E3F4A6 /* FeedbackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C5D6E7F8A9B0C1D2E3F4A5 /* FeedbackService.swift */; };
+		B4C5D6E7F8A9B0C1D2E3F4A8 /* FeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C5D6E7F8A9B0C1D2E3F4A7 /* FeedbackView.swift */; };
 		B9C538ECD15D4CE3B5B4186E /* ActivityInsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D6AFD9DABC41629606A762 /* ActivityInsightsView.swift */; };
 		BB00AA010000000000000002 /* PilgrimV1.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00AA010000000000000001 /* PilgrimV1.swift */; };
 		BB00CC010000000000000001 /* WelcomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00CC010000000000000002 /* WelcomeViewModelTests.swift */; };
+		BBBB000000000000000002 /* WaypointInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000000000001 /* WaypointInterface.swift */; };
+		BBBB000000000000000004 /* TempWaypoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000000000003 /* TempWaypoint.swift */; };
+		BBBB000000000000000006 /* PilgrimV6.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000000000005 /* PilgrimV6.swift */; };
+		BBBB000000000000000008 /* Waypoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000000000007 /* Waypoint.swift */; };
+		BBBB00000000000000000A /* WaypointMarkingSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000000000009 /* WaypointMarkingSheet.swift */; };
+		BBBB00000000000000000C /* WaypointCodableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB00000000000000000B /* WaypointCodableTests.swift */; };
 		BREATH000000000000000002 /* BreathTransitionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BREATH000000000000000001 /* BreathTransitionView.swift */; };
 		C34D17383682ACAD912B2387 /* RouteShapeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B95E4FB1DF743CEF3AC77C2 /* RouteShapeView.swift */; };
 		C8297CD567634F8E9D97738B /* TalkSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1EF72AE69CD4C1599071304 /* TalkSettingsView.swift */; };
@@ -232,7 +247,6 @@
 		CC00000200000000SCENIV01 /* SceneryItemView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000SCENIV01 /* SceneryItemView.swift */; };
 		CC00000200000000SEASON01 /* SeasonalColorEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000SEASON01 /* SeasonalColorEngine.swift */; };
 		CC00000200000000SETTVW01 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000SETTVW01 /* SettingsView.swift */; };
-		A3B7C9D1E5F2A8B4C0D6E2F2 /* GeneralSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3B7C9D1E5F2A8B4C0D6E2F1 /* GeneralSettingsView.swift */; };
 		CC00000200000000TORIIG01 /* ToriiGateShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000TORIIG01 /* ToriiGateShape.swift */; };
 		CC00000200000000TREESH01 /* TreeShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000TREESH01 /* TreeShape.swift */; };
 		CC00000200000000WINTRT01 /* WinterTreeShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000WINTRT01 /* WinterTreeShape.swift */; };
@@ -241,9 +255,12 @@
 		CC00000200000000WKSTRT01 /* WalkStartView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000WKSTRT01 /* WalkStartView.swift */; };
 		CC00BB010000000000000002 /* VoiceRecordingInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00BB010000000000000001 /* VoiceRecordingInterface.swift */; };
 		CDB0F563A56A46B5981279A2 /* WalkBuilderStatusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4102471AC572B099189FB03 /* WalkBuilderStatusTests.swift */; };
+		D62B90461A22862A8FDA006C /* VoiceGuideDownloadManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A2543BE1F771480BD145035 /* VoiceGuideDownloadManager.swift */; };
 		DAEA43ECD49D4467B169B413 /* WalkSessionGuard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8134F8A37D74FB3805684F1 /* WalkSessionGuard.swift */; };
 		DBC54AC76144B10493D3E481 /* WalkShareView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 16BE9557700152F043C359DC /* WalkShareView.swift */; };
 		DD00CC0100000000000002 /* MeditateDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD00CC0100000000000001 /* MeditateDetection.swift */; };
+		E27871EF9A01D3D3C6093554 /* VoiceGuidePlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 75F7E64FC89078569CF45F03 /* VoiceGuidePlayer.swift */; };
+		E45CCFD6C6A29B3BC03CF2AB /* VoiceGuideManagement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65CE1DB41D3DBD404C28973B /* VoiceGuideManagement.swift */; };
 		EE07C2075CD444E6833A365D /* VoiceEnhancer.swift in Sources */ = {isa = PBXBuildFile; fileRef = C37A4E244FA34A828856F814 /* VoiceEnhancer.swift */; };
 		EF1533CDBBC5498EA3BFDFC6 /* ActivityIntervalInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 964D4C7663494F3ABBEEF84F /* ActivityIntervalInterface.swift */; };
 		F0F0F00100000001AABBCC01 /* CormorantGaramond-Light.otf in Resources */ = {isa = PBXBuildFile; fileRef = F0F0F00200000001AABBCC01 /* CormorantGaramond-Light.otf */; };
@@ -260,15 +277,6 @@
 		PERM000100000003 /* PermissionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = PERM000100000002 /* PermissionsViewModel.swift */; };
 		PERM000100000005 /* PermissionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PERM000100000004 /* PermissionsViewModelTests.swift */; };
 		PERM000100000007 /* PermissionsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = PERM000100000006 /* PermissionsView.swift */; };
-		A1B2C3D4E5F6A7B8C9D0E1F3 /* PermissionStatusViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A7B8C9D0E1F2 /* PermissionStatusViewModel.swift */; };
-		A1B2C3D4E5F6A7B8C9D0E1F5 /* PermissionStatusViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B2C3D4E5F6A7B8C9D0E1F4 /* PermissionStatusViewModelTests.swift */; };
-		B4C5D6E7F8A9B0C1D2E3F4A6 /* FeedbackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C5D6E7F8A9B0C1D2E3F4A5 /* FeedbackService.swift */; };
-		B4C5D6E7F8A9B0C1D2E3F4A8 /* FeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C5D6E7F8A9B0C1D2E3F4A7 /* FeedbackView.swift */; };
-		BBBB000000000000000002 /* WaypointInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000000000001 /* WaypointInterface.swift */; };
-		BBBB000000000000000004 /* TempWaypoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000000000003 /* TempWaypoint.swift */; };
-		BBBB000000000000000006 /* PilgrimV6.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000000000005 /* PilgrimV6.swift */; };
-		BBBB000000000000000008 /* Waypoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000000000007 /* Waypoint.swift */; };
-		BBBB00000000000000000A /* WaypointMarkingSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000000000009 /* WaypointMarkingSheet.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -437,9 +445,13 @@
 		4AE6DC51742E035602E624F1 /* AudioSessionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionCoordinator.swift; sourceTree = "<group>"; };
 		4B6BF30D6A9C48219D3C115C /* PaceSparklineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaceSparklineView.swift; sourceTree = "<group>"; };
 		4B95E4FB1DF743CEF3AC77C2 /* RouteShapeView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RouteShapeView.swift; sourceTree = "<group>"; };
+		5A2543BE1F771480BD145035 /* VoiceGuideDownloadManager.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceGuideDownloadManager.swift; sourceTree = "<group>"; };
 		5D9D07CA4444A7B548B5CFA4 /* ShareService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShareService.swift; sourceTree = "<group>"; };
+		65CE1DB41D3DBD404C28973B /* VoiceGuideManagement.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceGuideManagement.swift; sourceTree = "<group>"; };
 		6F17456C4D1E2DAED49B9AC6 /* SoundscapePlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundscapePlayer.swift; sourceTree = "<group>"; };
 		721BF267E7540B2B259806D1 /* XCTestCase+Combine.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "XCTestCase+Combine.swift"; sourceTree = "<group>"; };
+		74F883597323B0CE64E69DC9 /* VoiceGuideManifestService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceGuideManifestService.swift; sourceTree = "<group>"; };
+		75F7E64FC89078569CF45F03 /* VoiceGuidePlayer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceGuidePlayer.swift; sourceTree = "<group>"; };
 		8019A1ED39BF4E889F5DF99C /* WaveformGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaveformGenerator.swift; sourceTree = "<group>"; };
 		8C0699EE439FF3DC5E16B8E0 /* Pods-Pilgrim.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pilgrim.debug.xcconfig"; path = "Pods/Target Support Files/Pods-Pilgrim/Pods-Pilgrim.debug.xcconfig"; sourceTree = "<group>"; };
 		8E0BF1B23139F428720EB2CF /* WalkShareViewModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkShareViewModel.swift; sourceTree = "<group>"; };
@@ -447,6 +459,9 @@
 		964D4C7663494F3ABBEEF84F /* ActivityIntervalInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityIntervalInterface.swift; sourceTree = "<group>"; };
 		980407DB8189D982A61A73F9 /* Pods-UnitTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.release.xcconfig"; path = "Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.release.xcconfig"; sourceTree = "<group>"; };
 		A1B2C3D4E5F601020304050A /* PilgrimV3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV3.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F6A7B8C9D0E1F2 /* PermissionStatusViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionStatusViewModel.swift; sourceTree = "<group>"; };
+		A1B2C3D4E5F6A7B8C9D0E1F4 /* PermissionStatusViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PermissionStatusViewModelTests.swift; sourceTree = "<group>"; };
+		A3B7C9D1E5F2A8B4C0D6E2F1 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
 		A5B6C7D8E9F0A1B2C3D4E5F6 /* PilgrimV5.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV5.swift; sourceTree = "<group>"; };
 		A74490DBCE024418B78E73B2 /* WalkCheckpoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkCheckpoint.swift; sourceTree = "<group>"; };
 		AA000001FOOTPRINTSHAPE00 /* FootprintShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FootprintShape.swift; sourceTree = "<group>"; };
@@ -456,8 +471,6 @@
 		AA0001010000000000000003 /* WalkRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkRowView.swift; sourceTree = "<group>"; };
 		AA0001010000000000000004 /* ActiveWalkView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveWalkView.swift; sourceTree = "<group>"; };
 		AA0001010000000000000005 /* ActiveWalkViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActiveWalkViewModel.swift; sourceTree = "<group>"; };
-		AAAA0000000000000000F8 /* IntentionSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentionSettingView.swift; sourceTree = "<group>"; };
-		AAAA0000000000000000FA /* WalkOptionsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkOptionsSheet.swift; sourceTree = "<group>"; };
 		AA0001010000000000000006 /* WalkSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkSummaryView.swift; sourceTree = "<group>"; };
 		AA0001010000000000000007 /* MainCoordinatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainCoordinatorView.swift; sourceTree = "<group>"; };
 		AA00020100000000000001 /* VoiceRecording.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecording.swift; sourceTree = "<group>"; };
@@ -474,21 +487,32 @@
 		AAAA000000000000000000E2 /* CustomPromptEditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomPromptEditorView.swift; sourceTree = "<group>"; };
 		AAAA000000000000000000F2 /* IntentionHistoryStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentionHistoryStore.swift; sourceTree = "<group>"; };
 		AAAA000000000000000000F4 /* IntentionHistoryStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = IntentionHistoryStoreTests.swift; sourceTree = "<group>"; };
-		BBBB00000000000000000B /* WaypointCodableTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WaypointCodableTests.swift; sourceTree = "<group>"; };
 		AAAA000000000000000000F6 /* IntentionVoiceRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentionVoiceRecorder.swift; sourceTree = "<group>"; };
 		AAAA00000000000000000EL2 /* ElevationProfileView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ElevationProfileView.swift; sourceTree = "<group>"; };
 		AAAA00000000000000000MF2 /* RouteSegment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteSegment.swift; sourceTree = "<group>"; };
 		AAAA00000000000000000MF4 /* PilgrimAnnotation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimAnnotation.swift; sourceTree = "<group>"; };
 		AAAA00000000000000000MF6 /* PilgrimMapStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimMapStyle.swift; sourceTree = "<group>"; };
 		AAAA00000000000000000MF8 /* PilgrimMapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimMapView.swift; sourceTree = "<group>"; };
+		AAAA0000000000000000F8 /* IntentionSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentionSettingView.swift; sourceTree = "<group>"; };
+		AAAA0000000000000000FA /* WalkOptionsSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkOptionsSheet.swift; sourceTree = "<group>"; };
 		AABB000100000001 /* WelcomeAnimationState.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = WelcomeAnimationState.swift; sourceTree = "<group>"; };
 		B3E892B071C7BE6EBD74F3FC /* NewWalkComputationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NewWalkComputationTests.swift; sourceTree = "<group>"; };
+		B4284167708855BA9866F9FF /* VoiceGuideScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceGuideScheduler.swift; sourceTree = "<group>"; };
+		B4C5D6E7F8A9B0C1D2E3F4A5 /* FeedbackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackService.swift; sourceTree = "<group>"; };
+		B4C5D6E7F8A9B0C1D2E3F4A7 /* FeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackView.swift; sourceTree = "<group>"; };
 		BB00AA010000000000000001 /* PilgrimV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV1.swift; sourceTree = "<group>"; };
 		BB00CC010000000000000002 /* WelcomeViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WelcomeViewModelTests.swift; sourceTree = "<group>"; };
+		BBBB000000000000000001 /* WaypointInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaypointInterface.swift; sourceTree = "<group>"; };
+		BBBB000000000000000003 /* TempWaypoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempWaypoint.swift; sourceTree = "<group>"; };
+		BBBB000000000000000005 /* PilgrimV6.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV6.swift; sourceTree = "<group>"; };
+		BBBB000000000000000007 /* Waypoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Waypoint.swift; sourceTree = "<group>"; };
+		BBBB000000000000000009 /* WaypointMarkingSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaypointMarkingSheet.swift; sourceTree = "<group>"; };
+		BBBB00000000000000000B /* WaypointCodableTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WaypointCodableTests.swift; sourceTree = "<group>"; };
 		BREATH000000000000000001 /* BreathTransitionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BreathTransitionView.swift; sourceTree = "<group>"; };
 		C1B583B563EC4764AEDC9E50 /* Pods-UnitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UnitTests.debug.xcconfig"; path = "Pods/Target Support Files/Pods-UnitTests/Pods-UnitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		C1C8D965F1351F85D4E4F35D /* Pods-Pilgrim.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Pilgrim.release.xcconfig"; path = "Pods/Target Support Files/Pods-Pilgrim/Pods-Pilgrim.release.xcconfig"; sourceTree = "<group>"; };
 		C2D23FF60A762C30296A69E6 /* ComputationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ComputationTests.swift; sourceTree = "<group>"; };
+		C2E956773703AC660C7676BD /* VoiceGuideManifest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceGuideManifest.swift; sourceTree = "<group>"; };
 		C37A4E244FA34A828856F814 /* VoiceEnhancer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceEnhancer.swift; sourceTree = "<group>"; };
 		C56A574B3F5BFCBF50DB5368 /* Pods_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9CBD6B08E4C437DA90FDDB0 /* ActivityTimelineBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityTimelineBar.swift; sourceTree = "<group>"; };
@@ -510,7 +534,6 @@
 		CC00000100000000SCENIV01 /* SceneryItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneryItemView.swift; sourceTree = "<group>"; };
 		CC00000100000000SEASON01 /* SeasonalColorEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonalColorEngine.swift; sourceTree = "<group>"; };
 		CC00000100000000SETTVW01 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
-		A3B7C9D1E5F2A8B4C0D6E2F1 /* GeneralSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralSettingsView.swift; sourceTree = "<group>"; };
 		CC00000100000000TORIIG01 /* ToriiGateShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToriiGateShape.swift; sourceTree = "<group>"; };
 		CC00000100000000TREESH01 /* TreeShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TreeShape.swift; sourceTree = "<group>"; };
 		CC00000100000000WINTRT01 /* WinterTreeShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WinterTreeShape.swift; sourceTree = "<group>"; };
@@ -518,6 +541,7 @@
 		CC00000100000000WKMODE01 /* WalkMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkMode.swift; sourceTree = "<group>"; };
 		CC00000100000000WKSTRT01 /* WalkStartView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WalkStartView.swift; sourceTree = "<group>"; };
 		CC00BB010000000000000001 /* VoiceRecordingInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecordingInterface.swift; sourceTree = "<group>"; };
+		CDB41AD9F5C496AE9BC8C260 /* VoiceGuideFileStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceGuideFileStore.swift; sourceTree = "<group>"; };
 		D0EA6F12A77BD40C46E34D47 /* SharePayload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SharePayload.swift; sourceTree = "<group>"; };
 		D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Pilgrim.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2FDF0BD38D9467B99B2C4D7 /* ActivityListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityListView.swift; sourceTree = "<group>"; };
@@ -538,18 +562,10 @@
 		F1A2B3C4D5E6F7A8B9C0D1E4 /* PilgrimV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV4.swift; sourceTree = "<group>"; };
 		F1A2B3C4D5E6F7A8B9C0D1E6 /* FaviconSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconSelectorView.swift; sourceTree = "<group>"; };
 		F1EF72AE69CD4C1599071304 /* TalkSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TalkSettingsView.swift; sourceTree = "<group>"; };
+		FFDE354370A5891DF5C3F183 /* VoiceGuideSettingsView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceGuideSettingsView.swift; sourceTree = "<group>"; };
 		PERM000100000002 /* PermissionsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PermissionsViewModel.swift; sourceTree = "<group>"; };
 		PERM000100000004 /* PermissionsViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PermissionsViewModelTests.swift; sourceTree = "<group>"; };
 		PERM000100000006 /* PermissionsView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PermissionsView.swift; sourceTree = "<group>"; };
-		A1B2C3D4E5F6A7B8C9D0E1F2 /* PermissionStatusViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionStatusViewModel.swift; sourceTree = "<group>"; };
-		A1B2C3D4E5F6A7B8C9D0E1F4 /* PermissionStatusViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PermissionStatusViewModelTests.swift; sourceTree = "<group>"; };
-		B4C5D6E7F8A9B0C1D2E3F4A5 /* FeedbackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackService.swift; sourceTree = "<group>"; };
-		B4C5D6E7F8A9B0C1D2E3F4A7 /* FeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackView.swift; sourceTree = "<group>"; };
-		BBBB000000000000000001 /* WaypointInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaypointInterface.swift; sourceTree = "<group>"; };
-		BBBB000000000000000003 /* TempWaypoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TempWaypoint.swift; sourceTree = "<group>"; };
-		BBBB000000000000000005 /* PilgrimV6.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV6.swift; sourceTree = "<group>"; };
-		BBBB000000000000000007 /* Waypoint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Waypoint.swift; sourceTree = "<group>"; };
-		BBBB000000000000000009 /* WaypointMarkingSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaypointMarkingSheet.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1090,6 +1106,21 @@
 			path = WalkBuilder;
 			sourceTree = "<group>";
 		};
+		2C6F3C28CC1CE020CCEF6F19 /* VoiceGuide */ = {
+			isa = PBXGroup;
+			children = (
+				C2E956773703AC660C7676BD /* VoiceGuideManifest.swift */,
+				74F883597323B0CE64E69DC9 /* VoiceGuideManifestService.swift */,
+				CDB41AD9F5C496AE9BC8C260 /* VoiceGuideFileStore.swift */,
+				5A2543BE1F771480BD145035 /* VoiceGuideDownloadManager.swift */,
+				75F7E64FC89078569CF45F03 /* VoiceGuidePlayer.swift */,
+				B4284167708855BA9866F9FF /* VoiceGuideScheduler.swift */,
+				65CE1DB41D3DBD404C28973B /* VoiceGuideManagement.swift */,
+			);
+			name = VoiceGuide;
+			path = VoiceGuide;
+			sourceTree = "<group>";
+		};
 		3A2B6107FC73A26AFA4F2434 /* Audio */ = {
 			isa = PBXGroup;
 			children = (
@@ -1104,6 +1135,7 @@
 				C37A4E244FA34A828856F814 /* VoiceEnhancer.swift */,
 				8019A1ED39BF4E889F5DF99C /* WaveformGenerator.swift */,
 				EE12D19DC32D4F8FB3A35965 /* WaveformCache.swift */,
+				2C6F3C28CC1CE020CCEF6F19 /* VoiceGuide */,
 			);
 			path = Audio;
 			sourceTree = "<group>";
@@ -1139,15 +1171,6 @@
 			);
 			name = Share;
 			path = Share;
-			sourceTree = "<group>";
-		};
-		AAAA000000000000000000F5 /* Intention */ = {
-			isa = PBXGroup;
-			children = (
-				AAAA000000000000000000F2 /* IntentionHistoryStore.swift */,
-				AAAA000000000000000000F6 /* IntentionVoiceRecorder.swift */,
-			);
-			path = Intention;
 			sourceTree = "<group>";
 		};
 		AA0001010000000000000021 /* Home */ = {
@@ -1205,6 +1228,23 @@
 			path = Prompts;
 			sourceTree = "<group>";
 		};
+		AAAA000000000000000000F5 /* Intention */ = {
+			isa = PBXGroup;
+			children = (
+				AAAA000000000000000000F2 /* IntentionHistoryStore.swift */,
+				AAAA000000000000000000F6 /* IntentionVoiceRecorder.swift */,
+			);
+			path = Intention;
+			sourceTree = "<group>";
+		};
+		B4C5D6E7F8A9B0C1D2E3F4A9 /* Feedback */ = {
+			isa = PBXGroup;
+			children = (
+				B4C5D6E7F8A9B0C1D2E3F4A5 /* FeedbackService.swift */,
+			);
+			path = Feedback;
+			sourceTree = "<group>";
+		};
 		BA69BA2459A15E9F0E7493C3 /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -1242,16 +1282,9 @@
 				A1B2C3D4E5F6A7B8C9D0E1F2 /* PermissionStatusViewModel.swift */,
 				A3B7C9D1E5F2A8B4C0D6E2F1 /* GeneralSettingsView.swift */,
 				B4C5D6E7F8A9B0C1D2E3F4A7 /* FeedbackView.swift */,
+				FFDE354370A5891DF5C3F183 /* VoiceGuideSettingsView.swift */,
 			);
 			path = Settings;
-			sourceTree = "<group>";
-		};
-		B4C5D6E7F8A9B0C1D2E3F4A9 /* Feedback */ = {
-			isa = PBXGroup;
-			children = (
-				B4C5D6E7F8A9B0C1D2E3F4A5 /* FeedbackService.swift */,
-			);
-			path = Feedback;
 			sourceTree = "<group>";
 		};
 		F0F0F00300000000AABBCC00 /* Fonts */ = {
@@ -1693,6 +1726,14 @@
 				BBBB000000000000000006 /* PilgrimV6.swift in Sources */,
 				BBBB000000000000000008 /* Waypoint.swift in Sources */,
 				BBBB00000000000000000A /* WaypointMarkingSheet.swift in Sources */,
+				86DEAF7F2E18DAA455E516C8 /* VoiceGuideManifest.swift in Sources */,
+				52C6F28B0AAB6E494591E8EF /* VoiceGuideManifestService.swift in Sources */,
+				B0261DB7EE2F64C26CF7A41F /* VoiceGuideFileStore.swift in Sources */,
+				D62B90461A22862A8FDA006C /* VoiceGuideDownloadManager.swift in Sources */,
+				E27871EF9A01D3D3C6093554 /* VoiceGuidePlayer.swift in Sources */,
+				6F8AA2EEEDD08C727B89AB94 /* VoiceGuideScheduler.swift in Sources */,
+				E45CCFD6C6A29B3BC03CF2AB /* VoiceGuideManagement.swift in Sources */,
+				3DF4B121DEE87CA7EBB26207 /* VoiceGuideSettingsView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pilgrim/AppDelegate.swift
+++ b/Pilgrim/AppDelegate.swift
@@ -39,6 +39,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ObservableObject {
                 
                 self.appLaunchState = .done
                 AudioManifestService.shared.syncIfNeeded()
+                VoiceGuideManifestService.shared.syncIfNeeded()
 
                 // check permissions
                 // show changelog

--- a/Pilgrim/Models/Audio/SoundManagement.swift
+++ b/Pilgrim/Models/Audio/SoundManagement.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Combine
 
-final class SoundManagement {
+final class SoundManagement: ObservableObject {
 
     private let bellPlayer = BellPlayer.shared
     private let soundscapePlayer = SoundscapePlayer.shared
@@ -9,6 +9,23 @@ final class SoundManagement {
     private let fileStore = AudioFileStore.shared
     private var pendingSoundscapeStart: DispatchWorkItem?
     private var pendingEndBell: DispatchWorkItem?
+
+    @Published private(set) var isSoundscapePlaying = false
+    private var soundscapeCancellable: AnyCancellable?
+
+    init() {
+        soundscapeCancellable = soundscapePlayer.$isPlaying
+            .receive(on: DispatchQueue.main)
+            .assign(to: \.isSoundscapePlaying, on: self)
+    }
+
+    func toggleSoundscape() {
+        if soundscapePlayer.isPlaying {
+            stopSoundscape()
+        } else {
+            startSoundscape()
+        }
+    }
 
     private var isSoundsEnabled: Bool {
         UserPreferences.soundsEnabled.value

--- a/Pilgrim/Models/Audio/SoundManagement.swift
+++ b/Pilgrim/Models/Audio/SoundManagement.swift
@@ -16,7 +16,7 @@ final class SoundManagement: ObservableObject {
     init() {
         soundscapeCancellable = soundscapePlayer.$isPlaying
             .receive(on: DispatchQueue.main)
-            .assign(to: \.isSoundscapePlaying, on: self)
+            .sink { [weak self] in self?.isSoundscapePlaying = $0 }
     }
 
     func toggleSoundscape() {

--- a/Pilgrim/Models/Audio/SoundscapePlayer.swift
+++ b/Pilgrim/Models/Audio/SoundscapePlayer.swift
@@ -11,6 +11,7 @@ final class SoundscapePlayer: NSObject, ObservableObject {
 
     private var activePlayer: AVAudioPlayer?
     private var targetVolume: Float = 0.4
+    var currentTargetVolume: Float { targetVolume }
     private let coordinator = AudioSessionCoordinator.shared
     private let fileStore = AudioFileStore.shared
 

--- a/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideDownloadManager.swift
+++ b/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideDownloadManager.swift
@@ -37,6 +37,7 @@ final class VoiceGuideDownloadManager: ObservableObject {
 
             var completed = 0
             for prompt in missing {
+                guard !Task.isCancelled else { break }
                 let success = await download(prompt: prompt, packId: pack.id)
                 if !success {
                     _ = await download(prompt: prompt, packId: pack.id)

--- a/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideDownloadManager.swift
+++ b/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideDownloadManager.swift
@@ -1,0 +1,83 @@
+import Foundation
+import Combine
+
+final class VoiceGuideDownloadManager: ObservableObject {
+
+    static let shared = VoiceGuideDownloadManager()
+
+    @Published var downloadProgress: [String: Double] = [:]
+    @Published private(set) var activeDownloads: Set<String> = []
+
+    private let fileStore = VoiceGuideFileStore.shared
+    private let session: URLSession
+    private var downloadTasks: [String: Task<Void, Never>] = [:]
+
+    private init() {
+        let config = URLSessionConfiguration.default
+        config.httpMaximumConnectionsPerHost = 2
+        session = URLSession(configuration: config)
+    }
+
+    func downloadPack(_ pack: VoiceGuidePack) {
+        guard !activeDownloads.contains(pack.id) else { return }
+
+        activeDownloads.insert(pack.id)
+        downloadProgress[pack.id] = 0
+
+        let task = Task {
+            let missing = pack.prompts.filter { !fileStore.isAvailable($0, packId: pack.id) }
+            let total = missing.count
+            guard total > 0 else {
+                await MainActor.run {
+                    self.downloadProgress[pack.id] = 1.0
+                    self.activeDownloads.remove(pack.id)
+                }
+                return
+            }
+
+            var completed = 0
+            for prompt in missing {
+                let success = await download(prompt: prompt, packId: pack.id)
+                if !success {
+                    _ = await download(prompt: prompt, packId: pack.id)
+                }
+                completed += 1
+                await MainActor.run {
+                    self.downloadProgress[pack.id] = Double(completed) / Double(total)
+                }
+            }
+
+            await MainActor.run {
+                self.activeDownloads.remove(pack.id)
+            }
+        }
+        downloadTasks[pack.id] = task
+    }
+
+    func cancelDownload(packId: String) {
+        downloadTasks[packId]?.cancel()
+        downloadTasks[packId] = nil
+        activeDownloads.remove(packId)
+        downloadProgress[packId] = nil
+    }
+
+    private func download(prompt: VoiceGuidePrompt, packId: String) async -> Bool {
+        let url = Config.VoiceGuide.baseURL
+            .appendingPathComponent(packId)
+            .appendingPathComponent("\(prompt.id).aac")
+
+        do {
+            let (tempURL, response) = try await session.download(from: url)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                return false
+            }
+            let dest = fileStore.destinationURL(for: prompt, packId: packId)
+            try? FileManager.default.removeItem(at: dest)
+            try FileManager.default.moveItem(at: tempURL, to: dest)
+            return true
+        } catch {
+            print("[VoiceGuideDownloadManager] Download error for \(prompt.id): \(error)")
+            return false
+        }
+    }
+}

--- a/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideFileStore.swift
+++ b/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideFileStore.swift
@@ -1,0 +1,57 @@
+import Foundation
+
+final class VoiceGuideFileStore {
+
+    static let shared = VoiceGuideFileStore()
+
+    private let fileManager = FileManager.default
+    private let baseDirectory: URL
+
+    private init() {
+        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        baseDirectory = appSupport.appendingPathComponent("Audio/voiceguide", isDirectory: true)
+    }
+
+    func localURL(for prompt: VoiceGuidePrompt, packId: String) -> URL? {
+        let url = fileURL(for: prompt, packId: packId)
+        return fileManager.fileExists(atPath: url.path) ? url : nil
+    }
+
+    func isAvailable(_ prompt: VoiceGuidePrompt, packId: String) -> Bool {
+        fileManager.fileExists(atPath: fileURL(for: prompt, packId: packId).path)
+    }
+
+    func isPackDownloaded(_ pack: VoiceGuidePack) -> Bool {
+        pack.prompts.allSatisfy { isAvailable($0, packId: pack.id) }
+    }
+
+    func destinationURL(for prompt: VoiceGuidePrompt, packId: String) -> URL {
+        let dir = baseDirectory.appendingPathComponent(packId, isDirectory: true)
+        try? fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("\(prompt.id).aac")
+    }
+
+    func deletePackFiles(_ packId: String) {
+        let dir = baseDirectory.appendingPathComponent(packId, isDirectory: true)
+        try? fileManager.removeItem(at: dir)
+    }
+
+    func packDiskUsage(_ packId: String) -> Int {
+        let dir = baseDirectory.appendingPathComponent(packId, isDirectory: true)
+        guard let enumerator = fileManager.enumerator(at: dir, includingPropertiesForKeys: [.fileSizeKey]) else {
+            return 0
+        }
+        var total = 0
+        for case let url as URL in enumerator {
+            let size = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+            total += size
+        }
+        return total
+    }
+
+    private func fileURL(for prompt: VoiceGuidePrompt, packId: String) -> URL {
+        baseDirectory
+            .appendingPathComponent(packId, isDirectory: true)
+            .appendingPathComponent("\(prompt.id).aac")
+    }
+}

--- a/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideManagement.swift
+++ b/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideManagement.swift
@@ -92,9 +92,10 @@ final class VoiceGuideManagement: ObservableObject {
         isMeditatingPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] meditating in
-                if meditating { self?.pauseGuide() }
-                else { self?.resumeGuide() }
-                self?.scheduler?.updateIsMeditating(meditating)
+                guard let self, self.isActive else { return }
+                if meditating { self.pauseGuide() }
+                else { self.resumeGuide() }
+                self.scheduler?.updateIsMeditating(meditating)
             }
             .store(in: &cancellables)
     }

--- a/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideManagement.swift
+++ b/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideManagement.swift
@@ -8,7 +8,8 @@ final class VoiceGuideManagement: ObservableObject {
 
     private var scheduler: VoiceGuideScheduler?
     private let player = VoiceGuidePlayer.shared
-    private var cancellables: [AnyCancellable] = []
+    private var walkStateBindings: [AnyCancellable] = []
+    private var schedulerCancellables: [AnyCancellable] = []
     private var generation = 0
     private var currentPackId: String?
 
@@ -45,7 +46,7 @@ final class VoiceGuideManagement: ObservableObject {
             persistHistory(for: packId, scheduler: scheduler)
         }
         scheduler = nil
-        cancellables.removeAll()
+        schedulerCancellables.removeAll()
         isActive = false
         isPaused = false
         currentPackId = nil
@@ -74,12 +75,12 @@ final class VoiceGuideManagement: ObservableObject {
         statusPublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] status in self?.scheduler?.updateStatus(status) }
-            .store(in: &cancellables)
+            .store(in: &walkStateBindings)
 
         startDatePublisher
             .receive(on: DispatchQueue.main)
             .sink { [weak self] date in self?.scheduler?.updateWalkStartDate(date) }
-            .store(in: &cancellables)
+            .store(in: &walkStateBindings)
 
         isRecordingVoicePublisher
             .receive(on: DispatchQueue.main)
@@ -87,7 +88,7 @@ final class VoiceGuideManagement: ObservableObject {
                 if recording { self?.player.stop() }
                 self?.scheduler?.updateIsRecordingVoice(recording)
             }
-            .store(in: &cancellables)
+            .store(in: &walkStateBindings)
 
         isMeditatingPublisher
             .receive(on: DispatchQueue.main)
@@ -97,7 +98,7 @@ final class VoiceGuideManagement: ObservableObject {
                 else { self.resumeGuide() }
                 self.scheduler?.updateIsMeditating(meditating)
             }
-            .store(in: &cancellables)
+            .store(in: &walkStateBindings)
     }
 
     private func playPrompt(_ prompt: VoiceGuidePrompt, packId: String, generation: Int) {

--- a/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideManagement.swift
+++ b/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideManagement.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Combine
+
+final class VoiceGuideManagement: ObservableObject {
+
+    @Published private(set) var isActive = false
+    @Published private(set) var isPaused = false
+
+    private var scheduler: VoiceGuideScheduler?
+    private let player = VoiceGuidePlayer.shared
+    private var cancellables: [AnyCancellable] = []
+    private var generation = 0
+    private var currentPackId: String?
+
+    var packName: String? {
+        guard isActive, let packId = currentPackId else { return nil }
+        return VoiceGuideManifestService.shared.pack(byId: packId)?.name
+    }
+
+    var hasLastPrompt: Bool { player.hasLastPrompt }
+
+    func startGuiding(pack: VoiceGuidePack) {
+        stopGuiding()
+
+        generation += 1
+        let capturedGeneration = generation
+        currentPackId = pack.id
+
+        let sched = VoiceGuideScheduler(pack: pack)
+        sched.setPlayedHistory(loadHistory(for: pack.id))
+        sched.onShouldPlay = { [weak self] prompt in
+            self?.playPrompt(prompt, packId: pack.id, generation: capturedGeneration)
+        }
+        scheduler = sched
+        isActive = true
+        isPaused = false
+
+        sched.start()
+    }
+
+    func stopGuiding() {
+        scheduler?.stop()
+        player.stop()
+        if let packId = currentPackId, let scheduler {
+            persistHistory(for: packId, scheduler: scheduler)
+        }
+        scheduler = nil
+        cancellables.removeAll()
+        isActive = false
+        isPaused = false
+        currentPackId = nil
+    }
+
+    func pauseGuide() {
+        scheduler?.pause()
+        isPaused = true
+    }
+
+    func resumeGuide() {
+        scheduler?.resume()
+        isPaused = false
+    }
+
+    func replayLastPrompt() {
+        player.replayLast()
+    }
+
+    func bindWalkState(
+        statusPublisher: AnyPublisher<WalkBuilder.Status, Never>,
+        startDatePublisher: AnyPublisher<Date?, Never>,
+        isRecordingVoicePublisher: AnyPublisher<Bool, Never>,
+        isMeditatingPublisher: AnyPublisher<Bool, Never>
+    ) {
+        statusPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] status in self?.scheduler?.updateStatus(status) }
+            .store(in: &cancellables)
+
+        startDatePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] date in self?.scheduler?.updateWalkStartDate(date) }
+            .store(in: &cancellables)
+
+        isRecordingVoicePublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] recording in
+                if recording { self?.player.stop() }
+                self?.scheduler?.updateIsRecordingVoice(recording)
+            }
+            .store(in: &cancellables)
+
+        isMeditatingPublisher
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] meditating in
+                if meditating { self?.pauseGuide() }
+                else { self?.resumeGuide() }
+                self?.scheduler?.updateIsMeditating(meditating)
+            }
+            .store(in: &cancellables)
+    }
+
+    private func playPrompt(_ prompt: VoiceGuidePrompt, packId: String, generation: Int) {
+        player.play(prompt: prompt, packId: packId) { [weak self] in
+            guard let self, self.generation == generation else { return }
+            self.scheduler?.markPlayed(prompt.id)
+        }
+    }
+
+    // MARK: - History Persistence
+
+    private var historyFileURL: URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let dir = appSupport.appendingPathComponent("Audio/voiceguide", isDirectory: true)
+        try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("history.json")
+    }
+
+    private func loadHistory(for packId: String) -> Set<String> {
+        guard let data = try? Data(contentsOf: historyFileURL),
+              let dict = try? JSONDecoder().decode([String: [String]].self, from: data),
+              let ids = dict[packId] else {
+            return []
+        }
+        return Set(ids)
+    }
+
+    private func persistHistory(for packId: String, scheduler: VoiceGuideScheduler) {
+        var dict: [String: [String]] = [:]
+        if let data = try? Data(contentsOf: historyFileURL),
+           let existing = try? JSONDecoder().decode([String: [String]].self, from: data) {
+            dict = existing
+        }
+        dict[packId] = Array(scheduler.playedPromptIds)
+        if let data = try? JSONEncoder().encode(dict) {
+            try? data.write(to: historyFileURL)
+        }
+    }
+}

--- a/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideManagement.swift
+++ b/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideManagement.swift
@@ -102,6 +102,10 @@ final class VoiceGuideManagement: ObservableObject {
     }
 
     private func playPrompt(_ prompt: VoiceGuidePrompt, packId: String, generation: Int) {
+        guard VoiceGuideFileStore.shared.isAvailable(prompt, packId: packId) else {
+            scheduler?.markPlayed(prompt.id)
+            return
+        }
         player.play(prompt: prompt, packId: packId) { [weak self] in
             guard let self, self.generation == generation else { return }
             self.scheduler?.markPlayed(prompt.id)
@@ -133,6 +137,12 @@ final class VoiceGuideManagement: ObservableObject {
             dict = existing
         }
         dict[packId] = Array(scheduler.playedPromptIds)
+
+        let knownPacks = Set(VoiceGuideManifestService.shared.packs.map(\.id))
+        if !knownPacks.isEmpty {
+            dict = dict.filter { knownPacks.contains($0.key) }
+        }
+
         if let data = try? JSONEncoder().encode(dict) {
             try? data.write(to: historyFileURL)
         }

--- a/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideManifest.swift
+++ b/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideManifest.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+struct VoiceGuideManifest: Codable {
+    let version: String
+    let packs: [VoiceGuidePack]
+}
+
+struct VoiceGuidePack: Codable, Identifiable {
+    let id: String
+    let version: String
+    let name: String
+    let tagline: String
+    let description: String
+    let theme: String
+    let iconName: String
+    let type: String
+    let walkTypes: [String]
+    let scheduling: PromptDensity
+    let totalDurationSec: Double
+    let totalSizeBytes: Int
+    let prompts: [VoiceGuidePrompt]
+}
+
+struct PromptDensity: Codable {
+    let densityMinSec: Int
+    let densityMaxSec: Int
+    let minSpacingSec: Int
+    let initialDelaySec: Int
+    let walkEndBufferSec: Int
+}
+
+struct VoiceGuidePrompt: Codable, Identifiable {
+    let id: String
+    let seq: Int
+    let durationSec: Double
+    let fileSizeBytes: Int
+    let r2Key: String
+}

--- a/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideManifestService.swift
+++ b/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideManifestService.swift
@@ -1,0 +1,76 @@
+import Foundation
+import Combine
+
+final class VoiceGuideManifestService: ObservableObject {
+
+    static let shared = VoiceGuideManifestService()
+
+    @Published private(set) var packs: [VoiceGuidePack] = []
+    @Published private(set) var isSyncing = false
+
+    private let fileManager = FileManager.default
+
+    private var localManifestURL: URL {
+        let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first!
+        let dir = appSupport.appendingPathComponent("Audio/voiceguide", isDirectory: true)
+        try? fileManager.createDirectory(at: dir, withIntermediateDirectories: true)
+        return dir.appendingPathComponent("manifest.json")
+    }
+
+    private init() {
+        loadLocalManifest()
+    }
+
+    func syncIfNeeded() {
+        Task { @MainActor in
+            guard !isSyncing else { return }
+            isSyncing = true
+
+            let remote = await fetchRemoteManifest()
+
+            if let remote {
+                let localVersion = (try? Data(contentsOf: localManifestURL))
+                    .flatMap { try? JSONDecoder().decode(VoiceGuideManifest.self, from: $0) }?
+                    .version
+
+                if localVersion != remote.version {
+                    saveLocalManifest(remote)
+                }
+                packs = remote.packs
+            }
+
+            isSyncing = false
+        }
+    }
+
+    func pack(byId id: String) -> VoiceGuidePack? {
+        packs.first { $0.id == id }
+    }
+
+    private func fetchRemoteManifest() async -> VoiceGuideManifest? {
+        do {
+            let (data, response) = try await URLSession.shared.data(from: Config.VoiceGuide.manifestURL)
+            guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+                return nil
+            }
+            return try JSONDecoder().decode(VoiceGuideManifest.self, from: data)
+        } catch {
+            print("[VoiceGuideManifestService] Failed to fetch manifest: \(error)")
+            return nil
+        }
+    }
+
+    private func loadLocalManifest() {
+        guard fileManager.fileExists(atPath: localManifestURL.path),
+              let data = try? Data(contentsOf: localManifestURL),
+              let saved = try? JSONDecoder().decode(VoiceGuideManifest.self, from: data) else {
+            return
+        }
+        packs = saved.packs
+    }
+
+    private func saveLocalManifest(_ manifest: VoiceGuideManifest) {
+        guard let data = try? JSONEncoder().encode(manifest) else { return }
+        try? data.write(to: localManifestURL)
+    }
+}

--- a/Pilgrim/Models/Audio/VoiceGuide/VoiceGuidePlayer.swift
+++ b/Pilgrim/Models/Audio/VoiceGuide/VoiceGuidePlayer.swift
@@ -9,7 +9,7 @@ final class VoiceGuidePlayer: NSObject, AVAudioPlayerDelegate {
     private let soundscapePlayer = SoundscapePlayer.shared
     private let fileStore = VoiceGuideFileStore.shared
 
-    private var preDuckVolume: Float = 0
+    private var preDuckVolume: Float?
     private var onFinished: (() -> Void)?
     private var lastPromptId: String?
     private var lastPackId: String?
@@ -29,7 +29,8 @@ final class VoiceGuidePlayer: NSObject, AVAudioPlayerDelegate {
         lastPromptId = prompt.id
         lastPackId = packId
 
-        preDuckVolume = soundscapePlayer.currentTargetVolume
+        let currentVolume = soundscapePlayer.currentTargetVolume
+        preDuckVolume = currentVolume
         let duckLevel = Float(UserPreferences.voiceGuideDuckLevel.value)
         soundscapePlayer.setVolume(duckLevel, animated: true)
 
@@ -44,13 +45,13 @@ final class VoiceGuidePlayer: NSObject, AVAudioPlayerDelegate {
             player = p
         } catch {
             print("[VoiceGuidePlayer] Playback error: \(error)")
-            soundscapePlayer.setVolume(preDuckVolume, animated: true)
-            coordinator.deactivate(consumer: "voiceguide")
+            restoreAndDeactivate()
             self.onFinished = nil
         }
     }
 
     func stop() {
+        guard player != nil else { return }
         player?.stop()
         player = nil
         restoreAndDeactivate()
@@ -75,9 +76,9 @@ final class VoiceGuidePlayer: NSObject, AVAudioPlayerDelegate {
     }
 
     private func restoreAndDeactivate() {
-        if preDuckVolume > 0 {
-            soundscapePlayer.setVolume(preDuckVolume, animated: true)
-            preDuckVolume = 0
+        if let volume = preDuckVolume {
+            soundscapePlayer.setVolume(volume, animated: true)
+            preDuckVolume = nil
         }
         coordinator.deactivate(consumer: "voiceguide")
     }

--- a/Pilgrim/Models/Audio/VoiceGuide/VoiceGuidePlayer.swift
+++ b/Pilgrim/Models/Audio/VoiceGuide/VoiceGuidePlayer.swift
@@ -1,0 +1,84 @@
+import AVFoundation
+
+final class VoiceGuidePlayer: NSObject, AVAudioPlayerDelegate {
+
+    static let shared = VoiceGuidePlayer()
+
+    private var player: AVAudioPlayer?
+    private let coordinator = AudioSessionCoordinator.shared
+    private let soundscapePlayer = SoundscapePlayer.shared
+    private let fileStore = VoiceGuideFileStore.shared
+
+    private var preDuckVolume: Float = 0
+    private var onFinished: (() -> Void)?
+    private var lastPromptId: String?
+    private var lastPackId: String?
+
+    var isPlaying: Bool { player?.isPlaying ?? false }
+    var hasLastPrompt: Bool { lastPromptId != nil }
+
+    private override init() { super.init() }
+
+    func play(prompt: VoiceGuidePrompt, packId: String, onFinished: (() -> Void)? = nil) {
+        guard AVAudioSession.sharedInstance().category != .playAndRecord else { return }
+        guard let url = fileStore.localURL(for: prompt, packId: packId) else { return }
+
+        stop()
+
+        self.onFinished = onFinished
+        lastPromptId = prompt.id
+        lastPackId = packId
+
+        preDuckVolume = soundscapePlayer.currentTargetVolume
+        let duckLevel = Float(UserPreferences.voiceGuideDuckLevel.value)
+        soundscapePlayer.setVolume(duckLevel, animated: true)
+
+        coordinator.activate(for: .playbackOnly, consumer: "voiceguide")
+
+        do {
+            let p = try AVAudioPlayer(contentsOf: url)
+            p.delegate = self
+            p.volume = Float(UserPreferences.voiceGuideVolume.value)
+            p.prepareToPlay()
+            p.play()
+            player = p
+        } catch {
+            print("[VoiceGuidePlayer] Playback error: \(error)")
+            soundscapePlayer.setVolume(preDuckVolume, animated: true)
+            coordinator.deactivate(consumer: "voiceguide")
+            self.onFinished = nil
+        }
+    }
+
+    func stop() {
+        player?.stop()
+        player = nil
+        restoreAndDeactivate()
+    }
+
+    func replayLast() {
+        guard let promptId = lastPromptId,
+              let packId = lastPackId,
+              let pack = VoiceGuideManifestService.shared.pack(byId: packId),
+              let prompt = pack.prompts.first(where: { $0.id == promptId }) else { return }
+        play(prompt: prompt, packId: packId)
+    }
+
+    func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        DispatchQueue.main.async { [weak self] in
+            self?.player = nil
+            self?.restoreAndDeactivate()
+            let callback = self?.onFinished
+            self?.onFinished = nil
+            callback?()
+        }
+    }
+
+    private func restoreAndDeactivate() {
+        if preDuckVolume > 0 {
+            soundscapePlayer.setVolume(preDuckVolume, animated: true)
+            preDuckVolume = 0
+        }
+        coordinator.deactivate(consumer: "voiceguide")
+    }
+}

--- a/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideScheduler.swift
+++ b/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideScheduler.swift
@@ -11,7 +11,6 @@ final class VoiceGuideScheduler {
     }
 
     private let pack: VoiceGuidePack
-    private let fileStore = VoiceGuideFileStore.shared
     private var cancellables: [AnyCancellable] = []
 
     private var walkState = WalkState()
@@ -73,6 +72,8 @@ final class VoiceGuideScheduler {
         isPlaying = true
     }
 
+    func testTick() { tick() }
+
     private func tick() {
         guard walkState.status == .recording,
               !walkState.isRecordingVoice,
@@ -91,7 +92,6 @@ final class VoiceGuideScheduler {
         }
 
         guard let prompt = nextPrompt() else { return }
-        guard fileStore.isAvailable(prompt, packId: pack.id) else { return }
 
         markPlaybackStarted()
         onShouldPlay?(prompt)

--- a/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideScheduler.swift
+++ b/Pilgrim/Models/Audio/VoiceGuide/VoiceGuideScheduler.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Combine
+
+final class VoiceGuideScheduler {
+
+    struct WalkState {
+        var status: WalkBuilder.Status = .waiting
+        var isRecordingVoice = false
+        var isMeditating = false
+        var walkStartDate: Date?
+    }
+
+    private let pack: VoiceGuidePack
+    private let fileStore = VoiceGuideFileStore.shared
+    private var cancellables: [AnyCancellable] = []
+
+    private var walkState = WalkState()
+    private var isPaused = false
+    private var isPlaying = false
+    private var lastPromptTime: Date?
+    private var nextIntervalSec: TimeInterval = 0
+    private(set) var playedPromptIds: Set<String> = []
+
+    var onShouldPlay: ((VoiceGuidePrompt) -> Void)?
+
+    init(pack: VoiceGuidePack) {
+        self.pack = pack
+        drawNextInterval()
+    }
+
+    func start() {
+        Timer.TimerPublisher(interval: 30, runLoop: .main, mode: .default)
+            .autoconnect()
+            .sink { [weak self] _ in self?.tick() }
+            .store(in: &cancellables)
+    }
+
+    func stop() {
+        cancellables.removeAll()
+    }
+
+    func pause() { isPaused = true }
+    func resume() { isPaused = false }
+
+    func updateStatus(_ status: WalkBuilder.Status) {
+        walkState.status = status
+    }
+
+    func updateIsRecordingVoice(_ recording: Bool) {
+        walkState.isRecordingVoice = recording
+    }
+
+    func updateIsMeditating(_ meditating: Bool) {
+        walkState.isMeditating = meditating
+    }
+
+    func updateWalkStartDate(_ date: Date?) {
+        walkState.walkStartDate = date
+    }
+
+    func markPlayed(_ promptId: String) {
+        playedPromptIds.insert(promptId)
+        lastPromptTime = Date()
+        isPlaying = false
+        drawNextInterval()
+    }
+
+    func setPlayedHistory(_ ids: Set<String>) {
+        playedPromptIds = ids
+    }
+
+    func markPlaybackStarted() {
+        isPlaying = true
+    }
+
+    private func tick() {
+        guard walkState.status == .recording,
+              !walkState.isRecordingVoice,
+              !walkState.isMeditating,
+              !isPaused,
+              !isPlaying else { return }
+
+        guard let startDate = walkState.walkStartDate else { return }
+
+        let elapsed = Date().timeIntervalSince(startDate)
+        guard elapsed >= TimeInterval(pack.scheduling.initialDelaySec) else { return }
+
+        if let lastTime = lastPromptTime {
+            let sinceLast = Date().timeIntervalSince(lastTime)
+            guard sinceLast >= nextIntervalSec else { return }
+        }
+
+        guard let prompt = nextPrompt() else { return }
+        guard fileStore.isAvailable(prompt, packId: pack.id) else { return }
+
+        markPlaybackStarted()
+        onShouldPlay?(prompt)
+    }
+
+    private func nextPrompt() -> VoiceGuidePrompt? {
+        let sorted = pack.prompts.sorted { $0.seq < $1.seq }
+        if let unplayed = sorted.first(where: { !playedPromptIds.contains($0.id) }) {
+            return unplayed
+        }
+        playedPromptIds.removeAll()
+        return sorted.first
+    }
+
+    private func drawNextInterval() {
+        let min = pack.scheduling.densityMinSec
+        let max = pack.scheduling.densityMaxSec
+        nextIntervalSec = TimeInterval(Int.random(in: min...max))
+    }
+}

--- a/Pilgrim/Models/Config.swift
+++ b/Pilgrim/Models/Config.swift
@@ -85,4 +85,9 @@ enum Config {
         static let manifestURL = URL(string: "https://cdn.pilgrimapp.org/audio/manifest.json")!
     }
 
+    enum VoiceGuide {
+        static let manifestURL = URL(string: "https://cdn.pilgrimapp.org/voiceguide/manifest.json")!
+        static let baseURL = URL(string: "https://cdn.pilgrimapp.org/voiceguide")!
+    }
+
 }

--- a/Pilgrim/Models/Preferences/UserPreferences.swift
+++ b/Pilgrim/Models/Preferences/UserPreferences.swift
@@ -44,6 +44,11 @@ struct UserPreferences {
     static let selectedSoundscapeId = UserPreference.Optional<String>(key: "selectedSoundscapeId", defaultValue: "gentle-stream")
     static let breathRhythm = UserPreference.Required<Int>(key: "breathRhythm", defaultValue: 0)
 
+    static let voiceGuideEnabled = UserPreference.Required<Bool>(key: "voiceGuideEnabled", defaultValue: false)
+    static let selectedVoiceGuidePackId = UserPreference.Optional<String>(key: "selectedVoiceGuidePackId")
+    static let voiceGuideVolume = UserPreference.Required<Double>(key: "voiceGuideVolume", defaultValue: 0.8)
+    static let voiceGuideDuckLevel = UserPreference.Required<Double>(key: "voiceGuideDuckLevel", defaultValue: 0.15)
+
     static let beginWithIntention = UserPreference.Required<Bool>(key: "beginWithIntention", defaultValue: false)
 
     static let dynamicVoiceEnabled = UserPreference.Required<Bool>(key: "dynamicVoiceEnabled", defaultValue: true)

--- a/Pilgrim/Models/Walk/WalkBuilder/Components/VoiceRecordingManagement.swift
+++ b/Pilgrim/Models/Walk/WalkBuilder/Components/VoiceRecordingManagement.swift
@@ -81,6 +81,7 @@ public class VoiceRecordingManagement: NSObject, WalkBuilderComponent {
     public func startRecording() {
         guard isWalkActive, !isRecording else { return }
 
+        VoiceGuidePlayer.shared.stop()
         configureAudioSession()
 
         guard let dir = ensureRecordingsDirectory() else { return }

--- a/Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift
+++ b/Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift
@@ -73,7 +73,21 @@ struct ActiveWalkView: View {
                     }
                 },
                 currentIntention: viewModel.intention,
-                waypointCount: viewModel.waypoints.count
+                waypointCount: viewModel.waypoints.count,
+                soundscapeName: viewModel.currentSoundscapeName,
+                isSoundscapeMuted: SoundscapePlayer.shared.isMuted,
+                onToggleSoundscape: { SoundscapePlayer.shared.toggleMute() },
+                voiceGuidePackName: viewModel.voiceGuidePackName,
+                isVoiceGuidePaused: viewModel.isVoiceGuidePaused,
+                hasLastPrompt: viewModel.voiceGuideManagement.hasLastPrompt,
+                onToggleVoiceGuide: {
+                    if viewModel.voiceGuideManagement.isPaused {
+                        viewModel.voiceGuideManagement.resumeGuide()
+                    } else {
+                        viewModel.voiceGuideManagement.pauseGuide()
+                    }
+                },
+                onReplayPrompt: { viewModel.voiceGuideManagement.replayLastPrompt() }
             )
             .presentationDetents([.medium])
             .presentationDragIndicator(.visible)
@@ -203,6 +217,12 @@ struct ActiveWalkView: View {
                         .foregroundColor(.fog.opacity(0.6))
                         .lineLimit(2)
                         .multilineTextAlignment(.center)
+                }
+
+                if let guideName = viewModel.voiceGuidePackName {
+                    Text("Guide: \(guideName)")
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.fog.opacity(0.6))
                 }
 
                 if viewModel.currentSoundscapeName != nil || SoundscapePlayer.shared.isMuted {

--- a/Pilgrim/Scenes/ActiveWalk/ActiveWalkViewModel.swift
+++ b/Pilgrim/Scenes/ActiveWalk/ActiveWalkViewModel.swift
@@ -14,6 +14,7 @@ class ActiveWalkViewModel: ObservableObject, Identifiable {
     private let liveStats: LiveStats
     let voiceRecordingManagement: VoiceRecordingManagement
     let soundManagement = SoundManagement()
+    let voiceGuideManagement = VoiceGuideManagement()
     private var sessionGuard: WalkSessionGuard?
 
     @Published var status: WalkBuilder.Status = .waiting
@@ -33,6 +34,8 @@ class ActiveWalkViewModel: ObservableObject, Identifiable {
     @Published var meditateTime: String = "0:00"
     @Published var paceHistory: [Double] = []
     @Published var currentSoundscapeName: String?
+    @Published var voiceGuidePackName: String?
+    @Published var isVoiceGuidePaused = false
     @Published var intention: String?
     @Published var waypoints: [TempWaypoint] = []
 
@@ -67,6 +70,7 @@ class ActiveWalkViewModel: ObservableObject, Identifiable {
         bindLiveStats()
         bindTimers()
         bindSoundscape()
+        bindVoiceGuide()
         bindCompletedRecordings()
 
         let guard_ = WalkSessionGuard()
@@ -128,6 +132,7 @@ class ActiveWalkViewModel: ObservableObject, Identifiable {
     func startRecording() {
         builder.setStatus(.recording)
         soundManagement.onWalkStart()
+        startVoiceGuideIfEnabled()
     }
 
     func resume() {
@@ -138,12 +143,14 @@ class ActiveWalkViewModel: ObservableObject, Identifiable {
         sessionGuard?.stopAndCleanup()
         finalizeMeditation()
         soundManagement.onWalkEnd()
+        voiceGuideManagement.stopGuiding()
         builder.setStatus(.ready)
     }
 
     func cancel() {
         sessionGuard?.stopAndCleanup()
         soundManagement.onWalkEnd()
+        voiceGuideManagement.stopGuiding()
     }
 
     func toggleVoiceRecording() {
@@ -294,6 +301,32 @@ class ActiveWalkViewModel: ObservableObject, Identifiable {
             .map { $0?.displayName }
             .sink { [weak self] in self?.currentSoundscapeName = $0 }
             .store(in: &cancellables)
+    }
+
+    private func bindVoiceGuide() {
+        voiceGuideManagement.bindWalkState(
+            statusPublisher: builder.statusPublisher,
+            startDatePublisher: builder.startDatePublisher,
+            isRecordingVoicePublisher: voiceRecordingManagement.$isRecording.eraseToAnyPublisher(),
+            isMeditatingPublisher: $isMeditating.eraseToAnyPublisher()
+        )
+
+        voiceGuideManagement.$isActive
+            .combineLatest(voiceGuideManagement.$isPaused)
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] isActive, isPaused in
+                self?.voiceGuidePackName = isActive ? self?.voiceGuideManagement.packName : nil
+                self?.isVoiceGuidePaused = isPaused
+            }
+            .store(in: &cancellables)
+    }
+
+    private func startVoiceGuideIfEnabled() {
+        guard UserPreferences.voiceGuideEnabled.value,
+              let packId = UserPreferences.selectedVoiceGuidePackId.value,
+              let pack = VoiceGuideManifestService.shared.pack(byId: packId),
+              VoiceGuideFileStore.shared.isPackDownloaded(pack) else { return }
+        voiceGuideManagement.startGuiding(pack: pack)
     }
 
     private func activityType(at timestamp: Date) -> String {

--- a/Pilgrim/Scenes/ActiveWalk/WalkOptionsSheet.swift
+++ b/Pilgrim/Scenes/ActiveWalk/WalkOptionsSheet.swift
@@ -8,6 +8,16 @@ struct WalkOptionsSheet: View {
     let currentIntention: String?
     let waypointCount: Int
 
+    var soundscapeName: String?
+    var isSoundscapeMuted: Bool = false
+    var onToggleSoundscape: (() -> Void)?
+
+    var voiceGuidePackName: String?
+    var isVoiceGuidePaused: Bool = false
+    var hasLastPrompt: Bool = false
+    var onToggleVoiceGuide: (() -> Void)?
+    var onReplayPrompt: (() -> Void)?
+
     var body: some View {
         VStack(spacing: 0) {
             Text("Options")
@@ -35,11 +45,61 @@ struct WalkOptionsSheet: View {
                         onDropWaypoint()
                     }
                 }
+
+                if isRecording {
+                    audioSection
+                }
             }
             .padding(.horizontal, Constants.UI.Padding.normal)
             .padding(.top, Constants.UI.Padding.big)
 
             Spacer()
+        }
+    }
+
+    @ViewBuilder
+    private var audioSection: some View {
+        let hasSoundscape = soundscapeName != nil || isSoundscapeMuted
+        let hasVoiceGuide = voiceGuidePackName != nil
+
+        if hasSoundscape || hasVoiceGuide {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Audio")
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog.opacity(0.5))
+                    .padding(.top, 8)
+                    .padding(.leading, 4)
+
+                if hasSoundscape {
+                    optionRow(
+                        icon: isSoundscapeMuted ? "speaker.slash" : "speaker.wave.2",
+                        title: "Soundscape",
+                        subtitle: isSoundscapeMuted ? "Paused" : soundscapeName
+                    ) {
+                        onToggleSoundscape?()
+                    }
+                }
+
+                if hasVoiceGuide {
+                    optionRow(
+                        icon: isVoiceGuidePaused ? "play.circle" : "pause.circle",
+                        title: "Voice Guide",
+                        subtitle: isVoiceGuidePaused ? "Paused — \(voiceGuidePackName!)" : voiceGuidePackName
+                    ) {
+                        onToggleVoiceGuide?()
+                    }
+
+                    if hasLastPrompt {
+                        optionRow(
+                            icon: "arrow.counterclockwise",
+                            title: "Replay Last Prompt",
+                            subtitle: nil
+                        ) {
+                            onReplayPrompt?()
+                        }
+                    }
+                }
+            }
         }
     }
 

--- a/Pilgrim/Scenes/ActiveWalk/WalkOptionsSheet.swift
+++ b/Pilgrim/Scenes/ActiveWalk/WalkOptionsSheet.swift
@@ -84,7 +84,7 @@ struct WalkOptionsSheet: View {
                     optionRow(
                         icon: isVoiceGuidePaused ? "play.circle" : "pause.circle",
                         title: "Voice Guide",
-                        subtitle: isVoiceGuidePaused ? "Paused — \(voiceGuidePackName!)" : voiceGuidePackName
+                        subtitle: isVoiceGuidePaused ? "Paused — \(voiceGuidePackName ?? "")" : voiceGuidePackName
                     ) {
                         onToggleVoiceGuide?()
                     }

--- a/Pilgrim/Scenes/Settings/SettingsView.swift
+++ b/Pilgrim/Scenes/Settings/SettingsView.swift
@@ -44,6 +44,19 @@ struct SettingsView: View {
                         Text("Talks")
                             .font(Constants.Typography.body)
                     }
+
+                    NavigationLink {
+                        VoiceGuideSettingsView()
+                    } label: {
+                        HStack {
+                            Text("Voice Guide")
+                                .font(Constants.Typography.body)
+                            Spacer()
+                            Text(UserPreferences.voiceGuideEnabled.value ? "On" : "Off")
+                                .font(Constants.Typography.caption)
+                                .foregroundColor(.fog)
+                        }
+                    }
                 } header: {
                     Text("Audio")
                         .font(Constants.Typography.caption)

--- a/Pilgrim/Scenes/Settings/VoiceGuideSettingsView.swift
+++ b/Pilgrim/Scenes/Settings/VoiceGuideSettingsView.swift
@@ -1,0 +1,195 @@
+import SwiftUI
+
+struct VoiceGuideSettingsView: View {
+
+    @ObservedObject private var manifestService = VoiceGuideManifestService.shared
+    @ObservedObject private var downloadManager = VoiceGuideDownloadManager.shared
+    @State private var enabled = UserPreferences.voiceGuideEnabled.value
+    @State private var selectedPackId = UserPreferences.selectedVoiceGuidePackId.value
+    @State private var volume = UserPreferences.voiceGuideVolume.value
+    @State private var duckLevel = UserPreferences.voiceGuideDuckLevel.value
+
+    private let fileStore = VoiceGuideFileStore.shared
+
+    var body: some View {
+        List {
+            enableSection
+            if enabled {
+                if manifestService.isSyncing && manifestService.packs.isEmpty {
+                    loadingSection
+                } else if manifestService.packs.isEmpty {
+                    emptySection
+                } else {
+                    packsSection
+                    volumeSection
+                }
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .background(Color.parchment)
+        .navigationTitle("Voice Guide")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                Text("Voice Guide")
+                    .font(Constants.Typography.heading)
+                    .foregroundColor(.ink)
+            }
+        }
+        .onAppear {
+            manifestService.syncIfNeeded()
+        }
+    }
+
+    // MARK: - Sections
+
+    private var enableSection: some View {
+        Section {
+            Toggle(isOn: $enabled) {
+                Text("Voice Guide")
+                    .font(Constants.Typography.body)
+            }
+            .tint(.stone)
+            .onChange(of: enabled) { _, val in
+                UserPreferences.voiceGuideEnabled.value = val
+            }
+        }
+    }
+
+    private var loadingSection: some View {
+        Section {
+            HStack {
+                SwiftUI.ProgressView()
+                    .tint(.stone)
+                Text("Loading packs...")
+                    .font(Constants.Typography.body)
+                    .foregroundColor(.fog)
+            }
+        }
+    }
+
+    private var emptySection: some View {
+        Section {
+            Text("Connect to the internet to browse voice guide packs")
+                .font(Constants.Typography.body)
+                .foregroundColor(.fog)
+        }
+    }
+
+    private var packsSection: some View {
+        Section {
+            ForEach(manifestService.packs) { pack in
+                packRow(pack)
+            }
+        } header: {
+            Text("Packs")
+                .font(Constants.Typography.caption)
+        }
+    }
+
+    private var volumeSection: some View {
+        Section {
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text("Guide Volume")
+                        .font(Constants.Typography.body)
+                        .foregroundColor(.ink)
+                    Spacer()
+                    Text("\(Int(volume * 100))%")
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.fog)
+                }
+                Slider(value: $volume, in: 0...1)
+                    .tint(.stone)
+                    .onChange(of: volume) { _, val in
+                        UserPreferences.voiceGuideVolume.value = val
+                    }
+            }
+
+            VStack(alignment: .leading, spacing: 6) {
+                HStack {
+                    Text("Soundscape during guide")
+                        .font(Constants.Typography.body)
+                        .foregroundColor(.ink)
+                    Spacer()
+                    Text("\(Int(duckLevel * 100))%")
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.fog)
+                }
+                Slider(value: $duckLevel, in: 0...1)
+                    .tint(.stone)
+                    .onChange(of: duckLevel) { _, val in
+                        UserPreferences.voiceGuideDuckLevel.value = val
+                    }
+            }
+        } header: {
+            Text("Volume")
+                .font(Constants.Typography.caption)
+        }
+    }
+
+    // MARK: - Rows
+
+    private func packRow(_ pack: VoiceGuidePack) -> some View {
+        let isSelected = selectedPackId == pack.id
+        let isDownloaded = fileStore.isPackDownloaded(pack)
+        let isDownloading = downloadManager.activeDownloads.contains(pack.id)
+        let progress = downloadManager.downloadProgress[pack.id] ?? 0
+
+        return Button {
+            if isDownloaded {
+                selectedPackId = pack.id
+                UserPreferences.selectedVoiceGuidePackId.value = pack.id
+            }
+        } label: {
+            HStack(spacing: 12) {
+                Image(systemName: pack.iconName)
+                    .font(.title2)
+                    .foregroundColor(.stone)
+                    .frame(width: 28)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(pack.name)
+                        .font(Constants.Typography.body)
+                        .foregroundColor(.ink)
+                    Text(pack.tagline)
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.fog)
+                        .lineLimit(1)
+                }
+
+                Spacer()
+
+                if isDownloading {
+                    SwiftUI.ProgressView(value: progress)
+                        .tint(.stone)
+                        .frame(width: 40)
+                } else if !isDownloaded {
+                    Button {
+                        downloadManager.downloadPack(pack)
+                    } label: {
+                        Image(systemName: "arrow.down.circle")
+                            .foregroundColor(.stone)
+                    }
+                    .buttonStyle(.plain)
+                } else if isSelected {
+                    Image(systemName: "checkmark")
+                        .foregroundColor(.stone)
+                }
+            }
+        }
+        .swipeActions(edge: .trailing) {
+            if isDownloaded && !isSelected {
+                Button(role: .destructive) {
+                    fileStore.deletePackFiles(pack.id)
+                    if selectedPackId == pack.id {
+                        selectedPackId = nil
+                        UserPreferences.selectedVoiceGuidePackId.value = nil
+                    }
+                } label: {
+                    Label("Delete", systemImage: "trash")
+                }
+            }
+        }
+    }
+}

--- a/Pilgrim/Support Files/Info.plist
+++ b/Pilgrim/Support Files/Info.plist
@@ -39,6 +39,7 @@
 	<key>UIBackgroundModes</key>
 	<array>
 		<string>location</string>
+		<string>audio</string>
 	</array>
 	<key>UIAppFonts</key>
 	<array>

--- a/UnitTests/VoiceGuideHistoryTests.swift
+++ b/UnitTests/VoiceGuideHistoryTests.swift
@@ -1,0 +1,70 @@
+import XCTest
+@testable import Pilgrim
+
+final class VoiceGuideHistoryTests: XCTestCase {
+
+    private var historyURL: URL!
+
+    override func setUp() {
+        super.setUp()
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("voiceguide_test_\(UUID().uuidString)")
+        try? FileManager.default.createDirectory(at: tmp, withIntermediateDirectories: true)
+        historyURL = tmp.appendingPathComponent("history.json")
+    }
+
+    override func tearDown() {
+        try? FileManager.default.removeItem(at: historyURL.deletingLastPathComponent())
+        super.tearDown()
+    }
+
+    func testWriteAndReadHistory() throws {
+        let history: [String: [String]] = ["breeze": ["breeze_01", "breeze_02"]]
+        let data = try JSONEncoder().encode(history)
+        try data.write(to: historyURL)
+
+        let readData = try Data(contentsOf: historyURL)
+        let decoded = try JSONDecoder().decode([String: [String]].self, from: readData)
+        XCTAssertEqual(Set(decoded["breeze"]!), Set(["breeze_01", "breeze_02"]))
+    }
+
+    func testMultiplePacksCoexist() throws {
+        var history: [String: [String]] = [:]
+        history["breeze"] = ["breeze_01"]
+        history["sage"] = ["sage_01", "sage_02"]
+
+        let data = try JSONEncoder().encode(history)
+        try data.write(to: historyURL)
+
+        let readData = try Data(contentsOf: historyURL)
+        let decoded = try JSONDecoder().decode([String: [String]].self, from: readData)
+        XCTAssertEqual(decoded["breeze"]?.count, 1)
+        XCTAssertEqual(decoded["sage"]?.count, 2)
+    }
+
+    func testMissingFileReturnsEmpty() {
+        let data = try? Data(contentsOf: historyURL)
+        XCTAssertNil(data)
+    }
+
+    func testCorruptedFileHandledGracefully() throws {
+        try "not json".data(using: .utf8)!.write(to: historyURL)
+
+        let data = try Data(contentsOf: historyURL)
+        let decoded = try? JSONDecoder().decode([String: [String]].self, from: data)
+        XCTAssertNil(decoded)
+    }
+
+    func testHistoryMaxSize() throws {
+        var history: [String: [String]] = [:]
+        let ids = (1...100).map { "prompt_\($0)" }
+        history["large_pack"] = ids
+
+        let data = try JSONEncoder().encode(history)
+        try data.write(to: historyURL)
+
+        let readData = try Data(contentsOf: historyURL)
+        let decoded = try JSONDecoder().decode([String: [String]].self, from: readData)
+        XCTAssertEqual(decoded["large_pack"]?.count, 100)
+    }
+}

--- a/UnitTests/VoiceGuideManifestTests.swift
+++ b/UnitTests/VoiceGuideManifestTests.swift
@@ -1,0 +1,111 @@
+import XCTest
+@testable import Pilgrim
+
+final class VoiceGuideManifestTests: XCTestCase {
+
+    private let sampleJSON = """
+    {
+      "version": "2026-03-17T00:00:00Z",
+      "packs": [
+        {
+          "id": "breeze",
+          "version": "1",
+          "name": "Breeze",
+          "tagline": "A gentle questioner",
+          "description": "Soft open-ended questions",
+          "theme": "presence",
+          "iconName": "wind",
+          "type": "voiceGuide",
+          "walkTypes": ["wander"],
+          "scheduling": {
+            "densityMinSec": 720,
+            "densityMaxSec": 1080,
+            "minSpacingSec": 600,
+            "initialDelaySec": 300,
+            "walkEndBufferSec": 300
+          },
+          "totalDurationSec": 120.5,
+          "totalSizeBytes": 50000,
+          "prompts": [
+            {
+              "id": "breeze_01",
+              "seq": 1,
+              "durationSec": 10.5,
+              "fileSizeBytes": 5000,
+              "r2Key": "voiceguide/breeze/breeze_01.aac"
+            },
+            {
+              "id": "breeze_02",
+              "seq": 2,
+              "durationSec": 8.3,
+              "fileSizeBytes": 4000,
+              "r2Key": "voiceguide/breeze/breeze_02.aac"
+            }
+          ]
+        }
+      ]
+    }
+    """.data(using: .utf8)!
+
+    func testDecodeManifest() throws {
+        let manifest = try JSONDecoder().decode(VoiceGuideManifest.self, from: sampleJSON)
+        XCTAssertEqual(manifest.version, "2026-03-17T00:00:00Z")
+        XCTAssertEqual(manifest.packs.count, 1)
+    }
+
+    func testDecodePack() throws {
+        let manifest = try JSONDecoder().decode(VoiceGuideManifest.self, from: sampleJSON)
+        let pack = manifest.packs[0]
+
+        XCTAssertEqual(pack.id, "breeze")
+        XCTAssertEqual(pack.name, "Breeze")
+        XCTAssertEqual(pack.tagline, "A gentle questioner")
+        XCTAssertEqual(pack.iconName, "wind")
+        XCTAssertEqual(pack.type, "voiceGuide")
+        XCTAssertEqual(pack.walkTypes, ["wander"])
+        XCTAssertEqual(pack.totalDurationSec, 120.5)
+        XCTAssertEqual(pack.totalSizeBytes, 50000)
+    }
+
+    func testDecodeScheduling() throws {
+        let manifest = try JSONDecoder().decode(VoiceGuideManifest.self, from: sampleJSON)
+        let scheduling = manifest.packs[0].scheduling
+
+        XCTAssertEqual(scheduling.densityMinSec, 720)
+        XCTAssertEqual(scheduling.densityMaxSec, 1080)
+        XCTAssertEqual(scheduling.minSpacingSec, 600)
+        XCTAssertEqual(scheduling.initialDelaySec, 300)
+        XCTAssertEqual(scheduling.walkEndBufferSec, 300)
+    }
+
+    func testDecodePrompts() throws {
+        let manifest = try JSONDecoder().decode(VoiceGuideManifest.self, from: sampleJSON)
+        let prompts = manifest.packs[0].prompts
+
+        XCTAssertEqual(prompts.count, 2)
+        XCTAssertEqual(prompts[0].id, "breeze_01")
+        XCTAssertEqual(prompts[0].seq, 1)
+        XCTAssertEqual(prompts[0].durationSec, 10.5)
+        XCTAssertEqual(prompts[0].fileSizeBytes, 5000)
+        XCTAssertEqual(prompts[0].r2Key, "voiceguide/breeze/breeze_01.aac")
+    }
+
+    func testRoundTrip() throws {
+        let manifest = try JSONDecoder().decode(VoiceGuideManifest.self, from: sampleJSON)
+        let encoded = try JSONEncoder().encode(manifest)
+        let decoded = try JSONDecoder().decode(VoiceGuideManifest.self, from: encoded)
+
+        XCTAssertEqual(decoded.version, manifest.version)
+        XCTAssertEqual(decoded.packs.count, manifest.packs.count)
+        XCTAssertEqual(decoded.packs[0].id, manifest.packs[0].id)
+        XCTAssertEqual(decoded.packs[0].prompts.count, manifest.packs[0].prompts.count)
+    }
+
+    func testEmptyPacksDecodes() throws {
+        let json = """
+        {"version": "1", "packs": []}
+        """.data(using: .utf8)!
+        let manifest = try JSONDecoder().decode(VoiceGuideManifest.self, from: json)
+        XCTAssertTrue(manifest.packs.isEmpty)
+    }
+}

--- a/UnitTests/VoiceGuideSchedulerTests.swift
+++ b/UnitTests/VoiceGuideSchedulerTests.swift
@@ -1,0 +1,212 @@
+import XCTest
+@testable import Pilgrim
+
+final class VoiceGuideSchedulerTests: XCTestCase {
+
+    private func makePack(
+        promptCount: Int = 5,
+        densityMin: Int = 60,
+        densityMax: Int = 120,
+        initialDelay: Int = 30,
+        walkEndBuffer: Int = 30
+    ) -> VoiceGuidePack {
+        let prompts = (1...promptCount).map { (i: Int) -> VoiceGuidePrompt in
+            VoiceGuidePrompt(
+                id: "test_\(String(format: "%02d", i))",
+                seq: i,
+                durationSec: 5.0,
+                fileSizeBytes: 1000,
+                r2Key: "voiceguide/test/test_\(String(format: "%02d", i)).aac"
+            )
+        }
+        return VoiceGuidePack(
+            id: "test",
+            version: "1",
+            name: "Test",
+            tagline: "Test pack",
+            description: "A test pack",
+            theme: "test",
+            iconName: "star",
+            type: "voiceGuide",
+            walkTypes: ["wander"],
+            scheduling: PromptDensity(
+                densityMinSec: densityMin,
+                densityMaxSec: densityMax,
+                minSpacingSec: 60,
+                initialDelaySec: initialDelay,
+                walkEndBufferSec: walkEndBuffer
+            ),
+            totalDurationSec: Double(promptCount) * 5.0,
+            totalSizeBytes: promptCount * 1000,
+            prompts: prompts
+        )
+    }
+
+    // MARK: - Condition Checks
+
+    func testTick_requiresRecordingStatus() {
+        let pack = makePack(densityMin: 0, densityMax: 0, initialDelay: 0)
+        let scheduler = VoiceGuideScheduler(pack: pack)
+
+        var firedPrompt: VoiceGuidePrompt?
+        scheduler.onShouldPlay = { (prompt: VoiceGuidePrompt) in firedPrompt = prompt }
+
+        scheduler.updateWalkStartDate(Date().addingTimeInterval(-100))
+        scheduler.updateStatus(.waiting)
+        scheduler.testTick()
+        XCTAssertNil(firedPrompt)
+
+        scheduler.updateStatus(.paused)
+        scheduler.testTick()
+        XCTAssertNil(firedPrompt)
+
+        scheduler.updateStatus(.recording)
+        scheduler.testTick()
+        XCTAssertNotNil(firedPrompt)
+    }
+
+    func testTick_blockedByVoiceRecording() {
+        let pack = makePack(densityMin: 0, densityMax: 0, initialDelay: 0)
+        let scheduler = VoiceGuideScheduler(pack: pack)
+
+        var firedCount = 0
+        scheduler.onShouldPlay = { (_: VoiceGuidePrompt) in firedCount += 1 }
+
+        scheduler.updateWalkStartDate(Date().addingTimeInterval(-100))
+        scheduler.updateStatus(.recording)
+        scheduler.updateIsRecordingVoice(true)
+        scheduler.testTick()
+        XCTAssertEqual(firedCount, 0)
+
+        scheduler.updateIsRecordingVoice(false)
+        scheduler.testTick()
+        XCTAssertEqual(firedCount, 1)
+    }
+
+    func testTick_blockedByMeditation() {
+        let pack = makePack(densityMin: 0, densityMax: 0, initialDelay: 0)
+        let scheduler = VoiceGuideScheduler(pack: pack)
+
+        var firedCount = 0
+        scheduler.onShouldPlay = { (_: VoiceGuidePrompt) in firedCount += 1 }
+
+        scheduler.updateWalkStartDate(Date().addingTimeInterval(-100))
+        scheduler.updateStatus(.recording)
+        scheduler.updateIsMeditating(true)
+        scheduler.testTick()
+        XCTAssertEqual(firedCount, 0)
+    }
+
+    func testTick_blockedByPause() {
+        let pack = makePack(densityMin: 0, densityMax: 0, initialDelay: 0)
+        let scheduler = VoiceGuideScheduler(pack: pack)
+
+        var firedCount = 0
+        scheduler.onShouldPlay = { (_: VoiceGuidePrompt) in firedCount += 1 }
+
+        scheduler.updateWalkStartDate(Date().addingTimeInterval(-100))
+        scheduler.updateStatus(.recording)
+        scheduler.pause()
+        scheduler.testTick()
+        XCTAssertEqual(firedCount, 0)
+
+        scheduler.resume()
+        scheduler.testTick()
+        XCTAssertEqual(firedCount, 1)
+    }
+
+    func testTick_respectsInitialDelay() {
+        let pack = makePack(densityMin: 0, densityMax: 0, initialDelay: 300)
+        let scheduler = VoiceGuideScheduler(pack: pack)
+
+        var firedCount = 0
+        scheduler.onShouldPlay = { (_: VoiceGuidePrompt) in firedCount += 1 }
+
+        scheduler.updateStatus(.recording)
+        scheduler.updateWalkStartDate(Date().addingTimeInterval(-60))
+        scheduler.testTick()
+        XCTAssertEqual(firedCount, 0, "Should not fire before initial delay")
+
+        scheduler.updateWalkStartDate(Date().addingTimeInterval(-301))
+        scheduler.testTick()
+        XCTAssertEqual(firedCount, 1, "Should fire after initial delay")
+    }
+
+    // MARK: - Prompt Ordering
+
+    func testNextPrompt_playsInSequentialOrder() {
+        let pack = makePack(promptCount: 3, densityMin: 0, densityMax: 0, initialDelay: 0)
+        let scheduler = VoiceGuideScheduler(pack: pack)
+
+        var playedIds: [String] = []
+        scheduler.onShouldPlay = { (prompt: VoiceGuidePrompt) in playedIds.append(prompt.id) }
+
+        scheduler.updateWalkStartDate(Date().addingTimeInterval(-100))
+        scheduler.updateStatus(.recording)
+
+        scheduler.testTick()
+        scheduler.markPlayed(playedIds.last!)
+        scheduler.testTick()
+        scheduler.markPlayed(playedIds.last!)
+        scheduler.testTick()
+
+        XCTAssertEqual(playedIds, ["test_01", "test_02", "test_03"])
+    }
+
+    func testNextPrompt_wrapsAround() {
+        let pack = makePack(promptCount: 2, densityMin: 0, densityMax: 0, initialDelay: 0)
+        let scheduler = VoiceGuideScheduler(pack: pack)
+
+        var playedIds: [String] = []
+        scheduler.onShouldPlay = { (prompt: VoiceGuidePrompt) in playedIds.append(prompt.id) }
+
+        scheduler.updateWalkStartDate(Date().addingTimeInterval(-100))
+        scheduler.updateStatus(.recording)
+
+        scheduler.testTick()
+        scheduler.markPlayed(playedIds.last!)
+        scheduler.testTick()
+        scheduler.markPlayed(playedIds.last!)
+        scheduler.testTick()
+
+        XCTAssertEqual(playedIds, ["test_01", "test_02", "test_01"])
+    }
+
+    func testSetPlayedHistory_skipsAlreadyPlayed() {
+        let pack = makePack(promptCount: 3, densityMin: 0, densityMax: 0, initialDelay: 0)
+        let scheduler = VoiceGuideScheduler(pack: pack)
+        scheduler.setPlayedHistory(Set(["test_01", "test_02"]))
+
+        var firedId: String?
+        scheduler.onShouldPlay = { (p: VoiceGuidePrompt) in firedId = p.id }
+
+        scheduler.updateWalkStartDate(Date().addingTimeInterval(-100))
+        scheduler.updateStatus(.recording)
+        scheduler.testTick()
+
+        XCTAssertEqual(firedId, "test_03")
+    }
+
+    // MARK: - Playback State
+
+    func testIsPlaying_blocksNextTick() {
+        let pack = makePack(densityMin: 0, densityMax: 0, initialDelay: 0)
+        let scheduler = VoiceGuideScheduler(pack: pack)
+
+        var firedCount = 0
+        scheduler.onShouldPlay = { (_: VoiceGuidePrompt) in firedCount += 1 }
+
+        scheduler.updateWalkStartDate(Date().addingTimeInterval(-100))
+        scheduler.updateStatus(.recording)
+
+        scheduler.testTick()
+        XCTAssertEqual(firedCount, 1)
+
+        scheduler.testTick()
+        XCTAssertEqual(firedCount, 1, "Should not fire while previous is playing")
+
+        scheduler.markPlayed("test_01")
+        scheduler.testTick()
+        XCTAssertEqual(firedCount, 2)
+    }
+}


### PR DESCRIPTION
## Summary
- **iOS infrastructure** (Stages 1-5): Codable data models, CDN manifest service, file store, download manager, player with soundscape ducking, Combine-based scheduler with density jitter, management coordinator with generation counter, settings UI (pack browser + volume controls), and full active walk integration (options sheet audio controls, voice guide indicator)
- **Content pipeline** (Stage 6): New `voiceguide` CLI group in Dhyama tools with generate, draft, audition, review, preview, publish, and manifest commands. Breeze starter pack catalog (18 prompts)
- **Dhyama cleanup** (Stage 0): Removed abandoned app/web/admin/supabase code, focused repo on audio tools only

### New iOS files (7)
- `VoiceGuideManifest.swift` — Codable types (pack, prompt, scheduling density)
- `VoiceGuideManifestService.swift` — CDN fetch/cache, version-based updates
- `VoiceGuideFileStore.swift` — Pack-scoped local storage under ApplicationSupport
- `VoiceGuideDownloadManager.swift` — Per-pack download with progress tracking
- `VoiceGuidePlayer.swift` — One-shot playback with soundscape duck/restore
- `VoiceGuideScheduler.swift` — 30s Combine timer, density-based jitter, sequential prompts
- `VoiceGuideManagement.swift` — Coordinator with generation counter, cross-walk history

### Modified iOS files (10)
- `Config.swift` — VoiceGuide CDN URLs
- `UserPreferences.swift` — enabled, packId, volume, duckLevel
- `SoundscapePlayer.swift` — public `currentTargetVolume` accessor
- `SoundManagement.swift` — `toggleSoundscape()`, ObservableObject
- `ActiveWalkViewModel.swift` — Voice guide lifecycle wiring
- `WalkOptionsSheet.swift` — Audio section (soundscape + voice guide controls)
- `ActiveWalkView.swift` — Pass audio state, show guide indicator
- `VoiceRecordingManagement.swift` — Stop voice guide on recording start
- `SettingsView.swift` — Voice Guide nav link
- `Info.plist` — audio background mode

## Test plan
- [x] `xcodebuild build` — compiles cleanly
- [x] `xcodebuild test` — 127 tests, 0 failures
- [ ] Manual: enable voice guide in Settings, start walk, verify prompt plays after initial delay
- [ ] Manual: verify soundscape ducks during prompt, restores after
- [ ] Manual: verify options sheet shows pause/resume and replay controls
- [ ] Manual: verify prompt history persists across walks
- [ ] Dhyama: `dhyama-audio voiceguide manifest` builds correctly
- [ ] Dhyama: `dhyama-audio voiceguide generate --pack breeze` produces audio (requires reference voice)

🤖 Generated with [Claude Code](https://claude.com/claude-code)