### PR TITLE
feat: About page and mode-aware footprint walk modes

### DIFF
--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -219,6 +219,8 @@
 		B3D4E5F6A7B8C9D0E1F2A3B5 /* RecordingsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F6A7B8C9D0E1F2A3B4C6 /* RecordingsListView.swift */; };
 		B4C5D6E7F8A9B0C1D2E3F4A6 /* FeedbackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C5D6E7F8A9B0C1D2E3F4A5 /* FeedbackService.swift */; };
 		B4C5D6E7F8A9B0C1D2E3F4A8 /* FeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C5D6E7F8A9B0C1D2E3F4A7 /* FeedbackView.swift */; };
+		CC00000100000000ABOUTV02 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000ABOUTV01 /* AboutView.swift */; };
+		CC00000100000000SAFARV02 /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000SAFARV01 /* SafariView.swift */; };
 		B9C538ECD15D4CE3B5B4186E /* ActivityInsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D6AFD9DABC41629606A762 /* ActivityInsightsView.swift */; };
 		BB00AA010000000000000002 /* PilgrimV1.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00AA010000000000000001 /* PilgrimV1.swift */; };
 		BB00CC010000000000000001 /* WelcomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00CC010000000000000002 /* WelcomeViewModelTests.swift */; };
@@ -506,6 +508,8 @@
 		B4284167708855BA9866F9FF /* VoiceGuideScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceGuideScheduler.swift; sourceTree = "<group>"; };
 		B4C5D6E7F8A9B0C1D2E3F4A5 /* FeedbackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackService.swift; sourceTree = "<group>"; };
 		B4C5D6E7F8A9B0C1D2E3F4A7 /* FeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackView.swift; sourceTree = "<group>"; };
+		CC00000100000000ABOUTV01 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
+		CC00000100000000SAFARV01 /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
 		BB00AA010000000000000001 /* PilgrimV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV1.swift; sourceTree = "<group>"; };
 		BB00CC010000000000000002 /* WelcomeViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WelcomeViewModelTests.swift; sourceTree = "<group>"; };
 		BBBB000000000000000001 /* WaypointInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaypointInterface.swift; sourceTree = "<group>"; };
@@ -957,6 +961,7 @@
 				22BC99382941D9A800D9B1A5 /* WalkCard.swift */,
 				22BC99362941D9A800D9B1A5 /* WalkCardModel.swift */,
 				CC00000100000000MOONPV01 /* MoonPhaseView.swift */,
+				CC00000100000000SAFARV01 /* SafariView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1291,6 +1296,7 @@
 				A1B2C3D4E5F6A7B8C9D0E1F2 /* PermissionStatusViewModel.swift */,
 				A3B7C9D1E5F2A8B4C0D6E2F1 /* GeneralSettingsView.swift */,
 				B4C5D6E7F8A9B0C1D2E3F4A7 /* FeedbackView.swift */,
+				CC00000100000000ABOUTV01 /* AboutView.swift */,
 				FFDE354370A5891DF5C3F183 /* VoiceGuideSettingsView.swift */,
 			);
 			path = Settings;
@@ -1730,6 +1736,8 @@
 				A3B7C9D1E5F2A8B4C0D6E2F2 /* GeneralSettingsView.swift in Sources */,
 				B4C5D6E7F8A9B0C1D2E3F4A6 /* FeedbackService.swift in Sources */,
 				B4C5D6E7F8A9B0C1D2E3F4A8 /* FeedbackView.swift in Sources */,
+				CC00000100000000ABOUTV02 /* AboutView.swift in Sources */,
+				CC00000100000000SAFARV02 /* SafariView.swift in Sources */,
 				BBBB000000000000000002 /* WaypointInterface.swift in Sources */,
 				BBBB000000000000000004 /* TempWaypoint.swift in Sources */,
 				BBBB000000000000000006 /* PilgrimV6.swift in Sources */,

--- a/Pilgrim/Models/Walk/WalkMode.swift
+++ b/Pilgrim/Models/Walk/WalkMode.swift
@@ -11,6 +11,14 @@ enum WalkMode: String, CaseIterable {
         }
     }
 
+    var buttonLabel: String {
+        switch self {
+        case .wander: return "Wander"
+        case .together: return "Walk Together"
+        case .seek: return "Seek"
+        }
+    }
+
     var isAvailable: Bool {
         self == .wander
     }

--- a/Pilgrim/Scenes/Home/WalkStartView.swift
+++ b/Pilgrim/Scenes/Home/WalkStartView.swift
@@ -38,7 +38,9 @@ struct WalkStartView: View {
         }
         .onChange(of: selectedMode) { _, newMode in
             if UIAccessibility.isReduceMotionEnabled {
-                activeMode = newMode
+                withAnimation(.linear(duration: 0.2)) {
+                    activeMode = newMode
+                }
                 return
             }
             transitionGeneration += 1

--- a/Pilgrim/Scenes/Home/WalkStartView.swift
+++ b/Pilgrim/Scenes/Home/WalkStartView.swift
@@ -20,6 +20,7 @@ struct WalkStartView: View {
     @State private var seekFloatOffset: CGFloat = 0
     @State private var footprintBreathScale: CGFloat = 1.0
     @State private var togetherDriftOffset: CGSize = .zero
+    @State private var togetherCompanionsVisible = false
 
     @State private var lunarPhase = LunarPhase.current()
 
@@ -75,6 +76,7 @@ struct WalkStartView: View {
             seekFloatOffset = 0
             footprintBreathScale = 1.0
             togetherDriftOffset = .zero
+            togetherCompanionsVisible = false
         }
     }
 
@@ -114,8 +116,23 @@ struct WalkStartView: View {
                     }
                 }
             }
+            modeAtmosphere
         }
         .ignoresSafeArea()
+    }
+
+    private var modeAtmosphere: some View {
+        Group {
+            switch selectedMode {
+            case .wander:
+                Color.clear
+            case .together:
+                Color.dawn.opacity(0.01)
+            case .seek:
+                Color.fog.opacity(0.01)
+            }
+        }
+        .animation(.easeInOut(duration: 0.6), value: selectedMode)
     }
 
     // MARK: - Content
@@ -146,13 +163,14 @@ struct WalkStartView: View {
                 .padding(.bottom, Constants.UI.Padding.normal)
 
             Button(action: { onStartWalk(selectedMode) }) {
-                Text(LS["Welcome.Begin"])
+                Text(selectedMode.buttonLabel)
                     .font(Constants.Typography.button)
                     .foregroundColor(.parchment)
                     .frame(maxWidth: .infinity)
                     .padding(.vertical, 12)
                     .background(selectedMode.isAvailable ? Color.stone : Color.fog.opacity(0.2))
                     .cornerRadius(Constants.UI.CornerRadius.normal)
+                    .contentTransition(.interpolate)
             }
             .disabled(!selectedMode.isAvailable)
             .shadow(color: .stone.opacity(selectedMode.isAvailable ? 0.2 : 0), radius: 8, x: 0, y: 3)
@@ -213,6 +231,7 @@ struct WalkStartView: View {
                 x: -14 + togetherDriftOffset.width,
                 y: -10 + togetherDriftOffset.height
             )
+            .opacity(togetherCompanionsVisible ? 1 : 0)
 
             HStack(spacing: 2) {
                 FootprintShape()
@@ -229,6 +248,7 @@ struct WalkStartView: View {
                 x: 12 - togetherDriftOffset.width,
                 y: -8 - togetherDriftOffset.height
             )
+            .opacity(togetherCompanionsVisible ? 1 : 0)
 
             HStack(spacing: 2) {
                 FootprintShape()
@@ -244,13 +264,20 @@ struct WalkStartView: View {
         }
         .frame(width: 60, height: 50)
         .onAppear {
-            guard !UIAccessibility.isReduceMotionEnabled else { return }
+            if UIAccessibility.isReduceMotionEnabled {
+                togetherCompanionsVisible = true
+                return
+            }
+            withAnimation(.easeOut(duration: 0.3).delay(0.1)) {
+                togetherCompanionsVisible = true
+            }
             withAnimation(.easeInOut(duration: 6.0).repeatForever(autoreverses: true)) {
                 togetherDriftOffset = CGSize(width: 1, height: 0.5)
             }
         }
         .onDisappear {
             togetherDriftOffset = .zero
+            togetherCompanionsVisible = false
         }
     }
 

--- a/Pilgrim/Scenes/Home/WalkStartView.swift
+++ b/Pilgrim/Scenes/Home/WalkStartView.swift
@@ -14,6 +14,9 @@ struct WalkStartView: View {
     @State private var showMoon = false
     @State private var glowScale: CGFloat = 1.0
     @State private var entranceGeneration = 0
+    @State private var activeMode: WalkMode = .wander
+    @State private var footprintVisible = true
+    @State private var transitionGeneration = 0
 
     @State private var lunarPhase = LunarPhase.current()
 
@@ -33,6 +36,24 @@ struct WalkStartView: View {
                 currentQuote = mode.quotes.randomElement() ?? ""
             }
         }
+        .onChange(of: selectedMode) { _, newMode in
+            if UIAccessibility.isReduceMotionEnabled {
+                activeMode = newMode
+                return
+            }
+            transitionGeneration += 1
+            let gen = transitionGeneration
+            withAnimation(.easeIn(duration: 0.3)) {
+                footprintVisible = false
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
+                guard transitionGeneration == gen else { return }
+                activeMode = newMode
+                withAnimation(.easeOut(duration: 0.3)) {
+                    footprintVisible = true
+                }
+            }
+        }
         .onDisappear {
             entranceGeneration += 1
             breathing = false
@@ -40,6 +61,9 @@ struct WalkStartView: View {
             showQuote = false
             showMoon = false
             glowScale = 1.0
+            transitionGeneration += 1
+            footprintVisible = true
+            activeMode = .wander
         }
     }
 
@@ -107,7 +131,7 @@ struct WalkStartView: View {
 
             Spacer()
 
-            footprintPair
+            footprintDisplay
                 .padding(.bottom, Constants.UI.Padding.normal)
 
             modeSelector
@@ -132,22 +156,112 @@ struct WalkStartView: View {
         .padding(.bottom, Constants.UI.Padding.big)
     }
 
-    // MARK: - Footprint Pair
+    // MARK: - Footprint Display
 
-    private var footprintPair: some View {
+    private var footprintDisplay: some View {
+        Group {
+            switch activeMode {
+            case .wander: wanderFootprints
+            case .together: togetherFootprints
+            case .seek: seekFootprints
+            }
+        }
+        .scaleEffect(footprintVisible ? 1.0 : 1.08)
+        .opacity(footprintVisible ? 1.0 : 0.0)
+        .accessibilityHidden(true)
+    }
+
+    private var wanderFootprints: some View {
         HStack(spacing: 2) {
             FootprintShape()
                 .fill(Color.ink.opacity(0.08))
                 .frame(width: 16, height: 26)
                 .scaleEffect(x: -1)
                 .rotationEffect(.degrees(-12))
-
             FootprintShape()
                 .fill(Color.ink.opacity(0.06))
                 .frame(width: 16, height: 26)
                 .rotationEffect(.degrees(12))
         }
-        .accessibilityHidden(true)
+    }
+
+    private var togetherFootprints: some View {
+        ZStack {
+            HStack(spacing: 2) {
+                FootprintShape()
+                    .fill(Color.ink.opacity(0.06))
+                    .frame(width: 14, height: 22)
+                    .scaleEffect(x: -1)
+                    .rotationEffect(.degrees(-18))
+                FootprintShape()
+                    .fill(Color.ink.opacity(0.05))
+                    .frame(width: 14, height: 22)
+                    .rotationEffect(.degrees(6))
+            }
+            .offset(x: -14, y: -10)
+
+            HStack(spacing: 2) {
+                FootprintShape()
+                    .fill(Color.ink.opacity(0.05))
+                    .frame(width: 14, height: 22)
+                    .scaleEffect(x: -1)
+                    .rotationEffect(.degrees(8))
+                FootprintShape()
+                    .fill(Color.ink.opacity(0.04))
+                    .frame(width: 14, height: 22)
+                    .rotationEffect(.degrees(-16))
+            }
+            .offset(x: 12, y: -8)
+
+            HStack(spacing: 2) {
+                FootprintShape()
+                    .fill(Color.ink.opacity(0.10))
+                    .frame(width: 16, height: 26)
+                    .scaleEffect(x: -1)
+                    .rotationEffect(.degrees(-12))
+                FootprintShape()
+                    .fill(Color.ink.opacity(0.08))
+                    .frame(width: 16, height: 26)
+                    .rotationEffect(.degrees(12))
+            }
+        }
+        .frame(width: 60, height: 50)
+    }
+
+    private var seekFootprints: some View {
+        HStack(spacing: 2) {
+            FootprintShape()
+                .fill(Color.ink.opacity(0.10))
+                .frame(width: 16, height: 26)
+                .scaleEffect(x: -1)
+                .rotationEffect(.degrees(-12))
+
+            dissolvingDots
+                .frame(width: 16, height: 30)
+                .rotationEffect(.degrees(12))
+        }
+    }
+
+    private var dissolvingDots: some View {
+        Canvas { context, size in
+            let dots: [(x: CGFloat, y: CGFloat, r: CGFloat, a: Double)] = [
+                (0.5, 0.85, 2.5, 0.08),
+                (0.3, 0.65, 2.0, 0.07),
+                (0.7, 0.55, 2.0, 0.06),
+                (0.4, 0.38, 1.5, 0.04),
+                (0.6, 0.20, 1.5, 0.03),
+                (0.5, 0.05, 1.0, 0.02),
+            ]
+            for dot in dots {
+                let rect = CGRect(
+                    x: size.width * dot.x - dot.r,
+                    y: size.height * dot.y - dot.r,
+                    width: dot.r * 2,
+                    height: dot.r * 2
+                )
+                context.fill(Circle().path(in: rect), with: .color(.ink.opacity(dot.a)))
+            }
+        }
     }
 
     // MARK: - Mode Selector

--- a/Pilgrim/Scenes/Home/WalkStartView.swift
+++ b/Pilgrim/Scenes/Home/WalkStartView.swift
@@ -135,9 +135,6 @@ struct WalkStartView: View {
 
             Spacer()
 
-            footprintDisplay
-                .padding(.bottom, Constants.UI.Padding.normal)
-
             modeSelector
                 .padding(.bottom, Constants.UI.Padding.normal)
 
@@ -162,16 +159,19 @@ struct WalkStartView: View {
 
     // MARK: - Footprint Display
 
-    private var footprintDisplay: some View {
+    @ViewBuilder
+    private func footprintForMode(_ mode: WalkMode) -> some View {
+        let isActive = mode == activeMode
         Group {
-            switch activeMode {
+            switch mode {
             case .wander: wanderFootprints
             case .together: togetherFootprints
             case .seek: seekFootprints
             }
         }
-        .scaleEffect(footprintVisible ? 1.0 : 1.08)
-        .opacity(footprintVisible ? 1.0 : 0.0)
+        .frame(width: 60, height: 50)
+        .scaleEffect(isActive && footprintVisible ? 1.0 : (isActive ? 1.08 : 0.92))
+        .opacity(isActive && footprintVisible ? 1.0 : 0.0)
         .accessibilityHidden(true)
     }
 
@@ -282,19 +282,23 @@ struct WalkStartView: View {
 
     private var modeSelector: some View {
         VStack(spacing: Constants.UI.Padding.small) {
-            HStack(spacing: Constants.UI.Padding.big) {
+            HStack(spacing: Constants.UI.Padding.normal) {
                 ForEach(WalkMode.allCases, id: \.self) { mode in
                     Button {
                         selectedMode = mode
                     } label: {
-                        VStack(spacing: Constants.UI.Padding.xs) {
-                            Text(mode.rawValue.uppercased())
-                                .font(Constants.Typography.button)
-                                .foregroundColor(mode == selectedMode ? .stone : .fog.opacity(0.3))
-                                .fixedSize()
-                            Rectangle()
-                                .frame(height: 2)
-                                .foregroundColor(mode == selectedMode ? .stone : .clear)
+                        VStack(spacing: Constants.UI.Padding.small) {
+                            footprintForMode(mode)
+
+                            VStack(spacing: Constants.UI.Padding.xs) {
+                                Text(mode.rawValue.uppercased())
+                                    .font(Constants.Typography.button)
+                                    .foregroundColor(mode == selectedMode ? .stone : .fog.opacity(0.3))
+                                    .fixedSize()
+                                Rectangle()
+                                    .frame(height: 2)
+                                    .foregroundColor(mode == selectedMode ? .stone : .clear)
+                            }
                         }
                     }
                 }

--- a/Pilgrim/Scenes/Home/WalkStartView.swift
+++ b/Pilgrim/Scenes/Home/WalkStartView.swift
@@ -18,8 +18,12 @@ struct WalkStartView: View {
     @State private var footprintVisible = true
     @State private var transitionGeneration = 0
     @State private var seekFloatOffset: CGFloat = 0
+    @State private var footprintBreathScale: CGFloat = 1.0
+    @State private var togetherDriftOffset: CGSize = .zero
 
     @State private var lunarPhase = LunarPhase.current()
+
+    private let haptic = UIImpactFeedbackGenerator(style: .light)
 
     var body: some View {
         ZStack {
@@ -52,6 +56,7 @@ struct WalkStartView: View {
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
                 guard transitionGeneration == gen else { return }
                 activeMode = newMode
+                haptic.impactOccurred()
                 withAnimation(.easeOut(duration: 0.3)) {
                     footprintVisible = true
                 }
@@ -68,6 +73,8 @@ struct WalkStartView: View {
             footprintVisible = true
             activeMode = .wander
             seekFloatOffset = 0
+            footprintBreathScale = 1.0
+            togetherDriftOffset = .zero
         }
     }
 
@@ -170,7 +177,7 @@ struct WalkStartView: View {
             }
         }
         .frame(width: 60, height: 50)
-        .scaleEffect(isActive && footprintVisible ? 1.0 : (isActive ? 1.08 : 0.92))
+        .scaleEffect(isActive && footprintVisible ? footprintBreathScale : (isActive ? 1.08 : 0.92))
         .opacity(isActive && footprintVisible ? 1.0 : 0.0)
         .accessibilityHidden(true)
     }
@@ -202,7 +209,10 @@ struct WalkStartView: View {
                     .frame(width: 14, height: 22)
                     .rotationEffect(.degrees(6))
             }
-            .offset(x: -14, y: -10)
+            .offset(
+                x: -14 + togetherDriftOffset.width,
+                y: -10 + togetherDriftOffset.height
+            )
 
             HStack(spacing: 2) {
                 FootprintShape()
@@ -215,7 +225,10 @@ struct WalkStartView: View {
                     .frame(width: 14, height: 22)
                     .rotationEffect(.degrees(-16))
             }
-            .offset(x: 12, y: -8)
+            .offset(
+                x: 12 - togetherDriftOffset.width,
+                y: -8 - togetherDriftOffset.height
+            )
 
             HStack(spacing: 2) {
                 FootprintShape()
@@ -230,6 +243,15 @@ struct WalkStartView: View {
             }
         }
         .frame(width: 60, height: 50)
+        .onAppear {
+            guard !UIAccessibility.isReduceMotionEnabled else { return }
+            withAnimation(.easeInOut(duration: 6.0).repeatForever(autoreverses: true)) {
+                togetherDriftOffset = CGSize(width: 1, height: 0.5)
+            }
+        }
+        .onDisappear {
+            togetherDriftOffset = .zero
+        }
     }
 
     private var seekFootprints: some View {
@@ -295,9 +317,8 @@ struct WalkStartView: View {
                                     .font(Constants.Typography.button)
                                     .foregroundColor(mode == selectedMode ? .stone : .fog.opacity(0.3))
                                     .fixedSize()
-                                Rectangle()
+                                trailUnderline(for: mode)
                                     .frame(height: 2)
-                                    .foregroundColor(mode == selectedMode ? .stone : .clear)
                             }
                         }
                     }
@@ -309,6 +330,34 @@ struct WalkStartView: View {
                 .foregroundColor(.fog.opacity(0.5))
                 .contentTransition(.opacity)
                 .animation(.easeInOut(duration: 0.3), value: selectedMode)
+        }
+    }
+
+    @ViewBuilder
+    private func trailUnderline(for mode: WalkMode) -> some View {
+        if mode == selectedMode {
+            switch mode {
+            case .wander:
+                LinearGradient(
+                    colors: [.stone, .stone.opacity(0.2)],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+            case .together:
+                LinearGradient(
+                    colors: [.stone.opacity(0.3), .stone, .stone.opacity(0.3)],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+            case .seek:
+                LinearGradient(
+                    colors: [.stone.opacity(0.2), .stone],
+                    startPoint: .leading,
+                    endPoint: .trailing
+                )
+            }
+        } else {
+            Color.clear
         }
     }
 
@@ -341,6 +390,7 @@ struct WalkStartView: View {
             guard entranceGeneration == generation else { return }
             withAnimation(.easeInOut(duration: 4.0).repeatForever(autoreverses: true)) {
                 glowScale = 1.05
+                footprintBreathScale = 1.01
             }
         }
     }

--- a/Pilgrim/Scenes/Home/WalkStartView.swift
+++ b/Pilgrim/Scenes/Home/WalkStartView.swift
@@ -17,6 +17,7 @@ struct WalkStartView: View {
     @State private var activeMode: WalkMode = .wander
     @State private var footprintVisible = true
     @State private var transitionGeneration = 0
+    @State private var seekFloatOffset: CGFloat = 0
 
     @State private var lunarPhase = LunarPhase.current()
 
@@ -66,6 +67,7 @@ struct WalkStartView: View {
             transitionGeneration += 1
             footprintVisible = true
             activeMode = .wander
+            seekFloatOffset = 0
         }
     }
 
@@ -241,6 +243,16 @@ struct WalkStartView: View {
             dissolvingDots
                 .frame(width: 16, height: 30)
                 .rotationEffect(.degrees(12))
+                .offset(y: seekFloatOffset)
+                .onAppear {
+                    guard !UIAccessibility.isReduceMotionEnabled else { return }
+                    withAnimation(.easeInOut(duration: 4.0).repeatForever(autoreverses: true)) {
+                        seekFloatOffset = -2
+                    }
+                }
+                .onDisappear {
+                    seekFloatOffset = 0
+                }
         }
     }
 

--- a/Pilgrim/Scenes/Settings/AboutView.swift
+++ b/Pilgrim/Scenes/Settings/AboutView.swift
@@ -1,0 +1,387 @@
+import SwiftUI
+import CoreStore
+
+struct AboutView: View {
+
+    @State private var breathing = false
+    @State private var totalDistance: Double = 0
+    @State private var walkCount: Int = 0
+    @State private var firstWalkDate: Date?
+    @State private var hasWalks = false
+    @State private var statMode: StatMode = .distance
+    @State private var safariURL: IdentifiableURL?
+    @State private var appeared = false
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                hero
+                divider
+                pillars
+                divider
+                if hasWalks {
+                    statsWhisper
+                    footprintTrail
+                    divider
+                }
+                openSource
+                divider
+                motto
+                seasonalVignette
+                version
+            }
+            .padding(.horizontal, Constants.UI.Padding.big)
+        }
+        .scrollContentBackground(.hidden)
+        .background(Color.parchment)
+        .navigationTitle("About")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                Text("About")
+                    .font(Constants.Typography.heading)
+                    .foregroundColor(.ink)
+            }
+        }
+        .onAppear {
+            if !reduceMotion {
+                breathing = true
+            }
+        }
+        .task {
+            await loadWalkData()
+        }
+        .sheet(item: $safariURL) { item in
+            SafariView(url: item.url)
+        }
+    }
+
+    // MARK: - Hero
+
+    private var hero: some View {
+        VStack(spacing: Constants.UI.Padding.normal) {
+            PilgrimLogoView(size: 80, animated: !reduceMotion, breathing: $breathing)
+                .padding(.top, Constants.UI.Padding.big + Constants.UI.Padding.normal)
+
+            Text("Every walk is a\nsmall pilgrimage.")
+                .font(Constants.Typography.displayMedium.italic())
+                .multilineTextAlignment(.center)
+                .foregroundColor(.ink)
+
+            Text("Walking is how we think, process, and return to ourselves. Pilgrim is a quiet companion for the path \u{2014} no leaderboards, no metrics, just you and the walk.")
+                .font(Constants.Typography.body)
+                .multilineTextAlignment(.center)
+                .foregroundColor(.fog)
+                .padding(.horizontal, Constants.UI.Padding.normal)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.bottom, Constants.UI.Padding.big)
+        .sectionAppear(index: 0, appeared: appeared, reduceMotion: reduceMotion)
+    }
+
+    // MARK: - Pillars
+
+    private var pillars: some View {
+        VStack(alignment: .leading, spacing: Constants.UI.Padding.normal) {
+            Text("walk \u{00B7} talk \u{00B7} meditate")
+                .font(Constants.Typography.caption)
+                .tracking(3)
+                .foregroundColor(.stone)
+                .frame(maxWidth: .infinity)
+                .padding(.top, Constants.UI.Padding.small)
+
+            pillarRow(
+                icon: "figure.walk",
+                tint: .moss,
+                title: "walk",
+                description: "Walking as practice, not transit. Side by side, step by step \u{2014} strengthening the physical body."
+            )
+
+            pillarRow(
+                icon: "quote.bubble.fill",
+                tint: .dawn,
+                title: "talk",
+                description: "Deep reflection and connection, not small talk. Ask and share your unique perspective of reality."
+            )
+
+            pillarRow(
+                icon: "moon.stars.fill",
+                tint: .stone,
+                title: "meditate",
+                description: "Seek the peace and calmness within. Harmonize your being with the group and the environment."
+            )
+        }
+        .padding(.vertical, Constants.UI.Padding.normal)
+        .sectionAppear(index: 1, appeared: appeared, reduceMotion: reduceMotion)
+    }
+
+    private func pillarRow(icon: String, tint: Color, title: String, description: String) -> some View {
+        HStack(alignment: .top, spacing: Constants.UI.Padding.normal - Constants.UI.Padding.xs) {
+            Circle()
+                .fill(tint.opacity(Constants.UI.Opacity.light))
+                .frame(width: 36, height: 36)
+                .overlay {
+                    Image(systemName: icon)
+                        .font(.system(size: 16))
+                        .foregroundColor(tint)
+                }
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(Constants.Typography.heading)
+                    .foregroundColor(.ink)
+                Text(description)
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog)
+            }
+            .padding(.top, Constants.UI.Padding.small)
+        }
+    }
+
+    // MARK: - Stats Whisper
+
+    private var statsWhisper: some View {
+        Button {
+            withAnimation(.easeInOut(duration: 0.3)) {
+                statMode = statMode.next
+            }
+        } label: {
+            VStack(spacing: Constants.UI.Padding.xs) {
+                Group {
+                    switch statMode {
+                    case .distance:
+                        Text(formatDistance(totalDistance))
+                    case .count:
+                        Text("\(walkCount)")
+                    case .since:
+                        Text(formatSinceDate(firstWalkDate))
+                    }
+                }
+                .font(Constants.Typography.statValue)
+                .foregroundColor(.stone)
+                .contentTransition(.numericText())
+
+                Group {
+                    switch statMode {
+                    case .distance:
+                        Text("walked with Pilgrim")
+                    case .count:
+                        Text(walkCount == 1 ? "walk taken" : "walks taken")
+                    case .since:
+                        Text("walking since")
+                    }
+                }
+                .font(Constants.Typography.caption.italic())
+                .foregroundColor(.fog)
+                .contentTransition(.numericText())
+            }
+        }
+        .buttonStyle(.plain)
+        .padding(.vertical, Constants.UI.Padding.big)
+        .frame(maxWidth: .infinity)
+        .sectionAppear(index: 2, appeared: appeared, reduceMotion: reduceMotion)
+    }
+
+    // MARK: - Footprint Trail
+
+    private var footprintTrail: some View {
+        HStack(spacing: Constants.UI.Padding.normal) {
+            ForEach(0..<4, id: \.self) { index in
+                FootprintShape()
+                    .fill(Color.stone.opacity(0.08 + Double(index) * 0.04))
+                    .frame(width: 12, height: 18)
+                    .scaleEffect(x: index.isMultiple(of: 2) ? 1 : -1)
+                    .rotationEffect(.degrees(index.isMultiple(of: 2) ? -10 : 10))
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.bottom, Constants.UI.Padding.normal)
+    }
+
+    // MARK: - Open Source
+
+    private var openSource: some View {
+        VStack(alignment: .leading, spacing: Constants.UI.Padding.normal - Constants.UI.Padding.xs) {
+            Text("OPEN SOURCE")
+                .font(Constants.Typography.caption)
+                .tracking(2)
+                .foregroundColor(.stone.opacity(0.6))
+                .padding(.top, Constants.UI.Padding.big)
+
+            Text("Pilgrim is free and open source. No accounts, no tracking, no data leaves your device. Built as part of the walk \u{00B7} talk \u{00B7} meditate project.")
+                .font(Constants.Typography.body)
+                .foregroundColor(.ink)
+
+            linkRow(
+                icon: "globe",
+                label: "walktalkmeditate.org",
+                url: URL(string: "https://walktalkmeditate.org")!
+            )
+
+            linkRow(
+                icon: "chevron.left.forwardslash.chevron.right",
+                label: "Source code on GitHub",
+                url: URL(string: "https://github.com/walktalkmeditate/pilgrim-ios")!
+            )
+        }
+        .padding(.bottom, Constants.UI.Padding.big)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .sectionAppear(index: 3, appeared: appeared, reduceMotion: reduceMotion)
+    }
+
+    private func linkRow(icon: String, label: String, url: URL) -> some View {
+        Button {
+            safariURL = IdentifiableURL(url: url)
+        } label: {
+            HStack(spacing: Constants.UI.Padding.small) {
+                Image(systemName: icon)
+                    .font(.system(size: 14))
+                    .frame(width: 24, alignment: .center)
+                Text(label)
+                    .font(Constants.Typography.body)
+                Spacer()
+                Image(systemName: "chevron.right")
+                    .font(.system(size: 12))
+                    .opacity(Constants.UI.Opacity.medium)
+            }
+            .foregroundColor(.stone)
+            .padding(.vertical, Constants.UI.Padding.small + Constants.UI.Padding.xs)
+        }
+    }
+
+    // MARK: - Motto
+
+    private var motto: some View {
+        VStack(spacing: 0) {
+            Text("Slow and chill is the motto.\nRelax and release is the practice.\nPeace and harmony is the way.")
+                .font(Constants.Typography.body.italic())
+                .multilineTextAlignment(.center)
+                .foregroundColor(.stone)
+                .lineSpacing(8)
+        }
+        .padding(.vertical, Constants.UI.Padding.big + Constants.UI.Padding.normal)
+        .frame(maxWidth: .infinity)
+        .sectionAppear(index: 4, appeared: appeared, reduceMotion: reduceMotion)
+    }
+
+    // MARK: - Seasonal Vignette
+
+    private var seasonalVignette: some View {
+        SceneryItemView(type: .tree, tintColor: .stone, size: 40, walkDate: Date())
+            .frame(width: 40, height: 40)
+            .opacity(Constants.UI.Opacity.medium)
+            .frame(maxWidth: .infinity)
+            .padding(.bottom, Constants.UI.Padding.normal)
+    }
+
+    // MARK: - Version
+
+    private var version: some View {
+        Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "")
+            .font(Constants.Typography.caption)
+            .foregroundColor(.fog.opacity(0.3))
+            .frame(maxWidth: .infinity)
+            .padding(.bottom, Constants.UI.Padding.big)
+    }
+
+    // MARK: - Divider
+
+    private var divider: some View {
+        LinearGradient(
+            colors: [.clear, Color.stone.opacity(0.2), .clear],
+            startPoint: .leading,
+            endPoint: .trailing
+        )
+        .frame(maxWidth: .infinity)
+        .frame(height: 1)
+    }
+
+    // MARK: - Data
+
+    private func loadWalkData() async {
+        do {
+            let walks = try DataManager.dataStack.fetchAll(
+                From<Walk>().orderBy(.ascending(\._startDate))
+            )
+            let total = walks.reduce(0.0) { $0 + $1.distance }
+            await MainActor.run {
+                totalDistance = total
+                walkCount = walks.count
+                firstWalkDate = walks.first?.startDate
+                hasWalks = !walks.isEmpty
+                withAnimation(reduceMotion ? nil : .easeInOut(duration: Constants.UI.Motion.appear)) {
+                    appeared = true
+                }
+            }
+        } catch {
+            await MainActor.run {
+                appeared = true
+            }
+        }
+    }
+
+    // MARK: - Formatting
+
+    private func formatDistance(_ meters: Double) -> String {
+        let isMiles = UserPreferences.distanceMeasurementType.safeValue == .miles
+        if isMiles {
+            let miles = meters / 1609.344
+            if miles >= 1 {
+                return String(format: "%.1f mi", miles)
+            }
+            return String(format: "%.0f ft", meters * 3.28084)
+        }
+        if meters >= 1000 {
+            return String(format: "%.1f km", meters / 1000)
+        }
+        return String(format: "%.0f m", meters)
+    }
+
+    private func formatSinceDate(_ date: Date?) -> String {
+        guard let date else { return "" }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "MMM yyyy"
+        return formatter.string(from: date)
+    }
+}
+
+// MARK: - Helpers
+
+private enum StatMode {
+    case distance, count, since
+
+    var next: StatMode {
+        switch self {
+        case .distance: return .count
+        case .count: return .since
+        case .since: return .distance
+        }
+    }
+}
+
+private struct IdentifiableURL: Identifiable {
+    let id = UUID()
+    let url: URL
+}
+
+private struct SectionAppearModifier: ViewModifier {
+    let index: Int
+    let appeared: Bool
+    let reduceMotion: Bool
+
+    func body(content: Content) -> some View {
+        content
+            .opacity(reduceMotion || appeared ? 1 : 0)
+            .offset(y: reduceMotion || appeared ? 0 : 8)
+            .animation(
+                reduceMotion ? nil : .easeInOut(duration: Constants.UI.Motion.appear).delay(Double(index) * 0.1),
+                value: appeared
+            )
+    }
+}
+
+private extension View {
+    func sectionAppear(index: Int, appeared: Bool, reduceMotion: Bool) -> some View {
+        modifier(SectionAppearModifier(index: index, appeared: appeared, reduceMotion: reduceMotion))
+    }
+}

--- a/Pilgrim/Scenes/Settings/SettingsView.swift
+++ b/Pilgrim/Scenes/Settings/SettingsView.swift
@@ -70,6 +70,15 @@ struct SettingsView: View {
                             .font(Constants.Typography.body)
                     }
                 }
+
+                Section {
+                    NavigationLink {
+                        AboutView()
+                    } label: {
+                        Text("About")
+                            .font(Constants.Typography.body)
+                    }
+                }
             }
             .scrollContentBackground(.hidden)
             .background(Color.parchment)
@@ -93,17 +102,12 @@ struct SettingsView: View {
     }
 
     private var footer: some View {
-        VStack(spacing: 4) {
-            Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "")
-                .font(Constants.Typography.caption)
-                .foregroundColor(.fog.opacity(0.3))
-            Text("crafted with intention")
-                .font(Constants.Typography.body.italic())
-                .foregroundColor(.fog.opacity(0.25))
-        }
-        .frame(maxWidth: .infinity)
-        .padding(.top, Constants.UI.Padding.breathingRoom)
-        .padding(.bottom, Constants.UI.Padding.normal)
-        .background(Color.parchment)
+        Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "")
+            .font(Constants.Typography.caption)
+            .foregroundColor(.fog.opacity(0.3))
+            .frame(maxWidth: .infinity)
+            .padding(.top, Constants.UI.Padding.breathingRoom)
+            .padding(.bottom, Constants.UI.Padding.normal)
+            .background(Color.parchment)
     }
 }

--- a/Pilgrim/Views/SafariView.swift
+++ b/Pilgrim/Views/SafariView.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+import SafariServices
+
+struct SafariView: UIViewControllerRepresentable {
+
+    let url: URL
+
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        let config = SFSafariViewController.Configuration()
+        config.barCollapsingEnabled = true
+        let vc = SFSafariViewController(url: url, configuration: config)
+        vc.preferredControlTintColor = UIColor(named: "stone")
+        return vc
+    }
+
+    func updateUIViewController(_ vc: SFSafariViewController, context: Context) {}
+}

--- a/docs/superpowers/plans/2026-03-18-footprint-walk-modes.md
+++ b/docs/superpowers/plans/2026-03-18-footprint-walk-modes.md
@@ -1,0 +1,316 @@
+# Footprint Walk Mode Visuals — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the footprint display above the path screen's mode selector respond to Wander/Together/Seek with distinct arrangements and a breath transition between them.
+
+**Architecture:** Replace the static `footprintPair` in `WalkStartView` with a mode-aware `footprintDisplay` that switches arrangement based on `activeMode`. A generation-counter-guarded `onChange` drives a breath transition (exhale → pause → inhale) when the user taps between modes.
+
+**Tech Stack:** SwiftUI, FootprintShape (existing custom Shape)
+
+**Spec:** `docs/superpowers/specs/2026-03-18-footprint-walk-modes-design.md`
+
+---
+
+### Task 1: Add transition state and replace footprintPair reference
+
+**Files:**
+- Modify: `Pilgrim/Scenes/Home/WalkStartView.swift`
+
+- [ ] **Step 1: Add new state properties after line 16**
+
+Add these three state vars after `entranceGeneration`:
+
+```swift
+@State private var activeMode: WalkMode = .wander
+@State private var footprintVisible = true
+@State private var transitionGeneration = 0
+```
+
+- [ ] **Step 2: Replace `footprintPair` reference in content**
+
+Change line 110 from:
+```swift
+footprintPair
+    .padding(.bottom, Constants.UI.Padding.normal)
+```
+to:
+```swift
+footprintDisplay
+    .padding(.bottom, Constants.UI.Padding.normal)
+```
+
+- [ ] **Step 3: Add onChange handler for breath transition**
+
+Add this after the existing `.onChange(of: selectedMode)` block (after line 35):
+
+```swift
+.onChange(of: selectedMode) { _, newMode in
+    if UIAccessibility.isReduceMotionEnabled {
+        activeMode = newMode
+        return
+    }
+    transitionGeneration += 1
+    let gen = transitionGeneration
+    withAnimation(.easeIn(duration: 0.3)) {
+        footprintVisible = false
+    }
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.45) {
+        guard transitionGeneration == gen else { return }
+        activeMode = newMode
+        withAnimation(.easeOut(duration: 0.3)) {
+            footprintVisible = true
+        }
+    }
+}
+```
+
+Note: There are now two `.onChange(of: selectedMode)` handlers — the existing one handles quote transitions, the new one handles footprint transitions. SwiftUI calls both.
+
+- [ ] **Step 4: Reset transition state in onDisappear**
+
+Add inside the existing `.onDisappear` block (around line 37):
+```swift
+transitionGeneration += 1
+footprintVisible = true
+activeMode = .wander
+```
+
+- [ ] **Step 5: Build to verify compiles**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build`
+Expected: BUILD SUCCEEDED (with `footprintDisplay` not yet defined — will error. Skip this step if it errors, it's resolved in Task 2.)
+
+---
+
+### Task 2: Implement the three footprint arrangements
+
+**Files:**
+- Modify: `Pilgrim/Scenes/Home/WalkStartView.swift`
+
+- [ ] **Step 1: Replace the `footprintPair` computed property (lines 137-151) with `footprintDisplay`**
+
+Replace the entire `// MARK: - Footprint Pair` section with:
+
+```swift
+// MARK: - Footprint Display
+
+private var footprintDisplay: some View {
+    Group {
+        switch activeMode {
+        case .wander: wanderFootprints
+        case .together: togetherFootprints
+        case .seek: seekFootprints
+        }
+    }
+    .scaleEffect(footprintVisible ? 1.0 : (footprintVisible ? 1.0 : 1.08))
+    .opacity(footprintVisible ? 1.0 : 0.0)
+    .accessibilityHidden(true)
+}
+
+private var wanderFootprints: some View {
+    HStack(spacing: 2) {
+        FootprintShape()
+            .fill(Color.ink.opacity(0.08))
+            .frame(width: 16, height: 26)
+            .scaleEffect(x: -1)
+            .rotationEffect(.degrees(-12))
+
+        FootprintShape()
+            .fill(Color.ink.opacity(0.06))
+            .frame(width: 16, height: 26)
+            .rotationEffect(.degrees(12))
+    }
+}
+
+private var togetherFootprints: some View {
+    ZStack {
+        // Left pair (behind, offset left)
+        HStack(spacing: 2) {
+            FootprintShape()
+                .fill(Color.ink.opacity(0.06))
+                .frame(width: 14, height: 22)
+                .scaleEffect(x: -1)
+                .rotationEffect(.degrees(-18))
+            FootprintShape()
+                .fill(Color.ink.opacity(0.05))
+                .frame(width: 14, height: 22)
+                .rotationEffect(.degrees(6))
+        }
+        .offset(x: -14, y: -10)
+
+        // Right pair (behind, offset right)
+        HStack(spacing: 2) {
+            FootprintShape()
+                .fill(Color.ink.opacity(0.05))
+                .frame(width: 14, height: 22)
+                .scaleEffect(x: -1)
+                .rotationEffect(.degrees(8))
+            FootprintShape()
+                .fill(Color.ink.opacity(0.04))
+                .frame(width: 14, height: 22)
+                .rotationEffect(.degrees(-16))
+        }
+        .offset(x: 12, y: -8)
+
+        // Front pair (yours, centered)
+        HStack(spacing: 2) {
+            FootprintShape()
+                .fill(Color.ink.opacity(0.10))
+                .frame(width: 16, height: 26)
+                .scaleEffect(x: -1)
+                .rotationEffect(.degrees(-12))
+            FootprintShape()
+                .fill(Color.ink.opacity(0.08))
+                .frame(width: 16, height: 26)
+                .rotationEffect(.degrees(12))
+        }
+    }
+    .frame(width: 60, height: 50)
+}
+
+private var seekFootprints: some View {
+    HStack(spacing: 2) {
+        // Solid left foot
+        FootprintShape()
+            .fill(Color.ink.opacity(0.10))
+            .frame(width: 16, height: 26)
+            .scaleEffect(x: -1)
+            .rotationEffect(.degrees(-12))
+
+        // Dissolving right — scattered dots
+        dissolvingDots
+            .frame(width: 16, height: 30)
+            .rotationEffect(.degrees(12))
+    }
+}
+
+private var dissolvingDots: some View {
+    Canvas { context, size in
+        let dots: [(x: CGFloat, y: CGFloat, r: CGFloat, a: Double)] = [
+            (0.5, 0.85, 2.5, 0.08),
+            (0.3, 0.65, 2.0, 0.07),
+            (0.7, 0.55, 2.0, 0.06),
+            (0.4, 0.38, 1.5, 0.04),
+            (0.6, 0.20, 1.5, 0.03),
+            (0.5, 0.05, 1.0, 0.02),
+        ]
+        for dot in dots {
+            let rect = CGRect(
+                x: size.width * dot.x - dot.r,
+                y: size.height * dot.y - dot.r,
+                width: dot.r * 2,
+                height: dot.r * 2
+            )
+            context.fill(Circle().path(in: rect), with: .color(.ink.opacity(dot.a)))
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Fix the scaleEffect logic in footprintDisplay**
+
+The `scaleEffect` line should use a ternary that differentiates exhale vs inhale. Replace the `.scaleEffect` and `.opacity` lines in `footprintDisplay` with:
+
+```swift
+.scaleEffect(footprintVisible ? 1.0 : 1.08)
+.opacity(footprintVisible ? 1.0 : 0.0)
+```
+
+Note: The exhale scales UP to 1.08 when `footprintVisible` becomes false. The inhale starts at 0.92 and scales to 1.0 — but since we set `footprintVisible = true` with `.easeOut`, the view appears at whatever SwiftUI interpolates from. For a cleaner inhale, the `activeMode` change swaps the view identity (new arrangement fades in at scale 1.0 via the easeOut), which handles the visual naturally.
+
+- [ ] **Step 3: Build and verify**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 4: Commit**
+
+```
+git add Pilgrim/Scenes/Home/WalkStartView.swift
+git commit -m "feat: mode-aware footprint display with breath transition
+
+Wander shows solo pair, Together shows three overlapping pairs,
+Seek shows one solid foot with dissolving dots. Breath transition
+(exhale/pause/inhale) animates between modes with generation
+counter for rapid-tap safety."
+```
+
+---
+
+### Task 3: Add Seek float animation
+
+**Files:**
+- Modify: `Pilgrim/Scenes/Home/WalkStartView.swift`
+
+- [ ] **Step 1: Add float state**
+
+Add after the `transitionGeneration` state var:
+
+```swift
+@State private var seekFloatOffset: CGFloat = 0
+```
+
+- [ ] **Step 2: Apply float to dissolving dots in seekFootprints**
+
+Wrap the `dissolvingDots` in the `seekFootprints` view with the offset and onAppear:
+
+```swift
+// Dissolving right — scattered dots
+dissolvingDots
+    .frame(width: 16, height: 30)
+    .rotationEffect(.degrees(12))
+    .offset(y: seekFloatOffset)
+    .onAppear {
+        guard !UIAccessibility.isReduceMotionEnabled else { return }
+        withAnimation(.easeInOut(duration: 4.0).repeatForever(autoreverses: true)) {
+            seekFloatOffset = -2
+        }
+    }
+    .onDisappear {
+        seekFloatOffset = 0
+    }
+```
+
+- [ ] **Step 3: Reset float in onDisappear**
+
+Add to the existing `.onDisappear` block:
+```swift
+seekFloatOffset = 0
+```
+
+- [ ] **Step 4: Build and verify**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 5: Commit**
+
+```
+git add Pilgrim/Scenes/Home/WalkStartView.swift
+git commit -m "feat: add subtle float animation to Seek dissolving dots"
+```
+
+---
+
+### Task 4: Visual verification
+
+- [ ] **Step 1: Run in simulator and verify all three modes**
+
+Launch the app in simulator. On the path screen:
+- **Wander** (default): Single pair of footprints, same as before
+- Tap **Together**: Breath transition plays, three overlapping pairs appear with depth
+- Tap **Seek**: Breath transition plays, one solid foot + dissolving dots floating gently upward
+- Tap back to **Wander**: Breath transition returns to single pair
+
+- [ ] **Step 2: Test rapid tapping**
+
+Quickly tap Wander → Together → Seek within 0.5s. Only the final mode (Seek) should render after the transition. No flashing of intermediate states.
+
+- [ ] **Step 3: Test reduce motion**
+
+Enable Settings → Accessibility → Reduce Motion in simulator. Switch modes — should be instant crossfade with no scale animation. Seek dots should be static (no float).
+
+- [ ] **Step 4: Test re-entrance**
+
+Switch to Settings tab, then back to Path tab. Footprints should show Wander (default reset).

--- a/docs/superpowers/specs/2026-03-18-about-page-design.md
+++ b/docs/superpowers/specs/2026-03-18-about-page-design.md
@@ -1,0 +1,199 @@
+# About Page Design
+
+## Context
+
+Pilgrim's Settings has no About page. Users have no way to learn the philosophy behind the app, connect with the walk · talk · meditate project, or understand that Pilgrim is open source and privacy-first. This page fills that gap — a contemplative scroll that builds trust, connection, and inspiration.
+
+## Emotional Arc
+
+The page moves through three layers as the user scrolls:
+
+1. **Trust** — Who made this and why (philosophy, quiet companion framing)
+2. **Connection** — The walk · talk · meditate pillars and project link
+3. **Inspiration** — Personal stats whisper + closing motto as a gentle send-off
+
+## Location
+
+- New file: `Pilgrim/Scenes/Settings/AboutView.swift`
+- Added as a NavigationLink in the existing `SettingsView.swift` — new section between the Feedback section and the footer
+
+## Scroll Structure
+
+### 1. Hero — Breathing Logo + Philosophy
+
+- `PilgrimLogoView(size: 80, animated: true, breathing: $breathing)` centered
+- `AboutView` owns `@State private var breathing = false` and sets `breathing = true` in `.onAppear` to trigger the breathing animation
+- Headline: *"Every walk is a small pilgrimage."* — `displayMedium`, italic
+- Body: *"Walking is how we think, process, and return to ourselves. Pilgrim is a quiet companion for the path — no leaderboards, no metrics, just you and the walk."* — `body`, `.fog` color
+
+### 2. walk · talk · meditate — Three Pillars
+
+Section header: **"walk · talk · meditate"** — `caption`, letter-spaced, centered, stone color
+
+Each pillar row:
+- **Icon**: Small `SceneryItemView` (tree for walk, lantern for talk, moon for meditate) at ~36pt in a circular tinted background. Uses `walkDate: Date()` for current season rendering. Gentle animation via TimelineView.
+- **Title**: lowercase — "walk", "talk", "meditate" — `heading` font
+- **Description** (from walktalkmeditate.org):
+  - walk: *"Walking as practice, not transit. Side by side, step by step — strengthening the physical body."*
+  - talk: *"Deep reflection and connection, not small talk. Ask and share your unique perspective of reality."*
+  - meditate: *"Seek the peace and calmness within. Harmonize your being with the group and the environment."*
+
+Descriptions use `body` font, `ink` color, indented under the icon.
+
+### 3. Stats Whisper
+
+- Only shown if the user has completed at least one walk
+- Displays total distance formatted with user's preferred unit (km or mi)
+- Format: large stat value on top (e.g., "127.4 km"), "walked with Pilgrim" below in italic
+- Uses `statValue` font for the number, `caption` italic for the label
+- Color: `stone` for number, `fog` for label
+
+**Data source**: Use `.task` modifier to query walks asynchronously with error handling:
+
+```swift
+.task {
+    do {
+        let walks = try DataManager.dataStack.fetchAll(From<Walk>())
+        totalDistance = walks.reduce(0) { $0 + $1.distance }
+    } catch {
+        totalDistance = 0
+    }
+}
+```
+
+**Distance formatting**: `InkScrollView.formatTotalDistance` bakes "walked" into the output string (e.g., "127.4 km walked"), which would duplicate the word with the "walked with Pilgrim" subtitle. Write a small private formatter in `AboutView` that returns only the number + unit (e.g., "127.4 km"), respecting `UserPreferences.distanceMeasurementType`.
+
+### 4. Open Source
+
+- Section label: "Open source" — `caption`, letter-spaced, uppercase (matches the Audio section header convention in SettingsView)
+- Body: *"Pilgrim is free and open source. No accounts, no tracking, no data leaves your device. Built as part of the walk · talk · meditate project."* — `body` font
+- Two tappable link rows:
+  - "walktalkmeditate.org" — opens `https://walktalkmeditate.org` in SFSafariViewController
+  - "Source code on GitHub" — opens `https://github.com/walktalkmeditate/pilgrim-ios` in SFSafariViewController
+- Link rows: SF Symbol icon + text + chevron, `stone` color, `body` font
+
+### 5. Motto Closer
+
+- Centered, italic, `body` font, `stone` color
+- Three lines:
+  - *"Slow and chill is the motto."*
+  - *"Relax and release is the practice."*
+  - *"Peace and harmony is the way."*
+
+### 6. Version Footer
+
+- App version from `CFBundleShortVersionString` — `caption`, `fog.opacity(0.3)`
+
+## Visual Design
+
+### Typography
+All from `Constants.Typography.*`:
+- Hero headline: `displayMedium` italic
+- Hero body: `body`
+- Section labels: `caption`, letter-spaced
+- Pillar titles: `heading`
+- Pillar descriptions: `body`
+- Stat value: `statValue`
+- Stat label: `caption` italic
+- Link rows: `body`
+- Motto: `body` italic
+- Version: `caption`
+
+### Colors
+- Background: `Color.parchment`
+- Text: `Color.ink` (primary), `Color.fog` (secondary)
+- Accent: `Color.stone` (links, stat value, motto)
+- Pillar icon tints: `Color.moss` (walk), `Color.dawn` (talk), `Color.stone` (meditate)
+- Dividers: gradient `transparent → stone.opacity(0.2) → transparent`
+
+### Seasonal Awareness
+- Apply `SeasonalColorEngine` to the background tint. The parchment base gains a subtle seasonal overlay — greener in spring, warmer in summer, muted in autumn, cooler in winter.
+- SceneryItemView shapes already render seasonally (bare winter trees, autumn leaves, etc.)
+
+### Animation
+- **Breathing logo**: `PilgrimLogoView` with `animated: true, breathing: $breathing` — 4s easeInOut cycle, 2% scale. Set `breathing = true` in `.onAppear`.
+- **Scenery icons**: TimelineView-based animation (tree sway, lantern flicker, moon twinkle) at 36pt. **Resource note**: Three simultaneous 30fps TimelineViews is acceptable for a settings subpage since the user won't stay here for 30+ minutes. However, if battery optimization becomes a concern, these can be replaced with static shape renders.
+- **Staggered fade-in**: Each section appears with `.opacity` transition + `.offset(y: 8)`, staggered by 0.1s delay per section on `.onAppear`. Use `Constants.UI.Motion.appear` (0.4s) duration.
+- **Reduce motion**: Use `@Environment(\.accessibilityReduceMotion) var reduceMotion`. When `reduceMotion` is true: skip fade-in stagger (show all sections immediately), render scenery shapes as static images (do not use `SceneryItemView` — use the underlying shape views directly without `TimelineView`), and disable logo breathing. `SceneryItemView` does **not** handle reduce-motion internally — `AboutView` must handle this.
+
+## Navigation Integration
+
+In `SettingsView.swift`, add a new section after the Feedback section:
+
+```swift
+Section {
+    NavigationLink {
+        AboutView()
+    } label: {
+        Text("About")
+            .font(Constants.Typography.body)
+    }
+}
+```
+
+The "About" row uses the same pattern as General, Sounds, etc. — plain text with `body` font, NavigationLink push.
+
+Simplify the existing `footer` computed property to remove "crafted with intention" since the About page now carries this sentiment. The modified footer should be:
+
+```swift
+private var footer: some View {
+    Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "")
+        .font(Constants.Typography.caption)
+        .foregroundColor(.fog.opacity(0.3))
+        .frame(maxWidth: .infinity)
+        .padding(.top, Constants.UI.Padding.breathingRoom)
+        .padding(.bottom, Constants.UI.Padding.normal)
+        .background(Color.parchment)
+}
+```
+
+## Links Implementation
+
+Create a new `SafariView` wrapper (does not exist in the project):
+
+```swift
+import SafariServices
+
+struct SafariView: UIViewControllerRepresentable {
+    let url: URL
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        SFSafariViewController(url: url)
+    }
+    func updateUIViewController(_ vc: SFSafariViewController, context: Context) {}
+}
+```
+
+Place in `Pilgrim/Views/SafariView.swift`. Use via `@State var safariURL: URL?` + `.sheet(item:)` in AboutView.
+
+## Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `Pilgrim/Scenes/Settings/AboutView.swift` | **Create** — new About page view |
+| `Pilgrim/Views/SafariView.swift` | **Create** — SFSafariViewController wrapper |
+| `Pilgrim/Scenes/Settings/SettingsView.swift` | **Modify** — add About NavigationLink, simplify footer |
+
+## Reused Components
+
+- `PilgrimLogoView` — `Pilgrim/Views/PilgrimLogoView.swift`
+- `SceneryItemView` — `Pilgrim/Views/Scenery/SceneryItemView.swift` (tree, lantern, moon types)
+- `SeasonalColorEngine` — `Pilgrim/Models/SeasonalColorEngine.swift`
+- `Constants.Typography.*` — `Pilgrim/Models/Constants.swift`
+- `Constants.UI.Motion.*` — appear timing
+- `Color.parchment/stone/ink/fog/moss/dawn` — `Pilgrim/Extensions/SwiftUI/Color.swift`
+- `DataManager.dataStack` — `Pilgrim/Models/Data/DataManager.swift`
+- `Walk` type alias — `Pilgrim/Models/Data/DataModels/Versions/`
+- `UserPreferences.distanceMeasurementType` — `Pilgrim/Models/Preferences/UserPreferences.swift`
+- `InkScrollView.formatTotalDistance` pattern — `Pilgrim/Scenes/Home/InkScrollView.swift` (private static func, reference for formatting logic only — do not call directly)
+
+## Verification
+
+1. **Build**: `xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build`
+2. **Visual check**: Settings → About should show all 6 sections with proper typography, colors, and animations
+3. **Breathing logo**: Logo should gently pulse (2% scale, 4s cycle)
+4. **Scenery shapes**: Tree, lantern, and moon should render with seasonal awareness and gentle animation
+5. **Stats whisper**: Should show real total distance (or be hidden if no walks exist)
+6. **Links**: Tapping walktalkmeditate.org and GitHub should open SFSafariViewController
+7. **Seasonal colors**: Run in simulator with different dates to verify tint shifts
+8. **Reduce motion**: Enable Accessibility → Reduce Motion in simulator — fade-in stagger should be skipped
+9. **Unit test**: Test distance formatting with both metric and imperial preferences

--- a/docs/superpowers/specs/2026-03-18-footprint-walk-modes-design.md
+++ b/docs/superpowers/specs/2026-03-18-footprint-walk-modes-design.md
@@ -1,0 +1,93 @@
+# Footprint Walk Mode Visuals
+
+## Context
+
+The path screen's mode selector (Wander / Together / Seek) shows a single static footprint pair above it regardless of which mode is selected. Each mode has a distinct philosophy — solo contemplation, communal walking, stepping into the unknown — but the footprints don't reflect this. This change makes the footprint display mode-aware with a breathing transition between modes.
+
+## Three Footprint Arrangements
+
+### Wander (solo)
+
+One pair of footprints — left and right foot, slightly rotated inward, low opacity. This is essentially what exists today in `footprintPair`.
+
+- Left foot: `FootprintShape`, mirrored (`scaleEffect(x: -1)`), rotated -12°, opacity 0.08
+- Right foot: `FootprintShape`, rotated 12°, opacity 0.06
+- Size: 16×26pt per foot, spacing: 2pt
+- Color: `Color.ink`
+
+### Together (group pilgrimage)
+
+Three pairs of footprints overlapping at different angles and opacities, like a small group gathered on the trail.
+
+- **Front pair** (yours): Same as Wander — centered, strongest opacity (0.10 / 0.08)
+- **Left pair**: Offset ~(-14, -10) from center, rotated -18°/+6°, opacity 0.06 / 0.05
+- **Right pair**: Offset ~(12, -8) from center, rotated +8°/-16°, opacity 0.05 / 0.04
+- Each pair uses the same `FootprintShape` at 14×22pt (slightly smaller than the front pair to suggest depth)
+- All in `Color.ink`
+
+The back pairs are smaller and more transparent, creating a sense of depth — others walking with you, slightly behind.
+
+### Seek (transcendent)
+
+One solid left footprint, and where the right foot should be — scattered dots dissolving upward.
+
+- **Left foot**: `FootprintShape`, mirrored, rotated -12°, opacity 0.10, 16×26pt, `Color.ink`
+- **Dissolving right**: 5-6 small circles (3-5pt diameter) arranged in a loose upward drift where the right foot would be. Opacity fades from 0.08 (bottom) to 0.02 (top). Positioned in a ~16×30pt area, offset slightly upward from the right foot's normal position.
+- Circles use `Color.ink` fills
+
+The dissolving dots have a subtle continuous float animation (gentle upward drift of ~2pt over 4s, looping) when Seek is active. Use the same `onAppear` / generation-counter pattern as the existing `glowScale` animation in `WalkStartView`: start the float from `onAppear` of the Seek footprint view, and the animation naturally stops when the view is removed during the breath transition (since `activeMode` changes, the Seek view is replaced). Do NOT use `withAnimation(.repeatForever)` + state mutation — per CLAUDE.md resource safety guidelines.
+
+## Breath Transition
+
+When the user taps a different mode, the footprint arrangement transitions with a breathing metaphor:
+
+1. **Exhale** (0.3s easeIn): Current footprints scale up to 1.08 + opacity fades to 0
+2. **Pause** (0.15s): Empty space — a beat of stillness
+3. **Inhale** (0.3s easeOut): New footprints scale from 0.92 → 1.0 + opacity fades in
+
+Total duration: ~0.75s.
+
+Implementation: Use `@State private var footprintVisible = true`, `@State private var activeMode: WalkMode`, and `@State private var transitionGeneration = 0`. When `selectedMode` changes via `.onChange`:
+1. Increment `transitionGeneration` (cancels any in-flight transition)
+2. Capture `let gen = transitionGeneration`
+3. Set `footprintVisible = false` (triggers exhale)
+4. After 0.45s delay, guard `transitionGeneration == gen` before proceeding
+5. Update `activeMode` to the new mode and set `footprintVisible = true` (triggers inhale)
+
+The generation counter ensures rapid taps (A → B → C within 0.45s) only complete the final transition. Stale callbacks become no-ops.
+
+The scale + opacity are driven by `footprintVisible` with an `.animation(.easeIn(duration: 0.3))` for exhale and `.easeOut(duration: 0.3)` for inhale.
+
+### Reduce Motion
+
+When `UIAccessibility.isReduceMotionEnabled`:
+- No scale animation, no breath pause
+- Instant crossfade (opacity only, 0.2s) between arrangements
+- Seek's dissolving dots are static (no float animation)
+
+## File Changes
+
+| File | Action |
+|------|--------|
+| `Pilgrim/Scenes/Home/WalkStartView.swift` | **Modify** — replace `footprintPair` with mode-aware `footprintDisplay`, add breath transition logic |
+
+No new files needed. All changes are within `WalkStartView.swift`. The `FootprintShape` is reused as-is.
+
+## Reused Components
+
+- `FootprintShape` — `Pilgrim/Views/FootprintShape.swift`
+- `Constants.UI.Padding.*` — spacing
+- Opacity values use inline literals (0.02–0.10) matching the existing `footprintPair` pattern — `Constants.UI.Opacity` values don't map to these fine-grained levels
+- `Color.ink` — footprint fill color
+- Generation counter pattern — already used in `WalkStartView` for entrance animations
+
+## Verification
+
+1. **Build**: `xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build`
+2. **Wander**: Shows single pair of footprints (unchanged from current)
+3. **Together**: Shows three overlapping pairs with depth (back pairs smaller, more transparent)
+4. **Seek**: Shows one solid foot + dissolving dots floating upward
+5. **Transition**: Tapping between modes triggers breath animation (exhale → pause → inhale)
+6. **Reduce motion**: Instant crossfade, no scale, no float animation on Seek dots
+7. **Re-entrance**: `selectedMode` resets to `.wander` on tab recreation (it's `@State`), so footprints correctly show Wander on return. No persistence needed — this matches the existing behavior where the mode selector always starts on Wander
+8. **Rapid tapping**: Quickly tapping Wander → Together → Seek should only complete the final transition to Seek, with no flash of intermediate states


### PR DESCRIPTION
## Summary

- **About page** in Settings with breathing Pilgrim logo, walk · talk · meditate philosophy pillars, tappable cycling stats (distance/count/since), open source links via SFSafariViewController, closing motto, seasonal tree vignette, and footprint trail
- **Mode-aware footprints** on path screen: Wander (solo pair), Together (three overlapping pairs with companion drift), Seek (one foot + dissolving dots floating upward)
- **Breath transition** between modes (exhale/pause/inhale) with generation counter for rapid-tap safety
- **Polish**: haptic feedback on stamp, footprint breathing synced to logo, trail gradient underlines, mode atmosphere tinting, staggered Together arrival, mode-named begin button

## Test plan

- [ ] Settings → About: verify all 6 sections render with correct typography, colors, and animations
- [ ] About: breathing logo pulses, stats cycle on tap, links open SFSafariViewController
- [ ] About: reduce motion skips animations, renders static shapes
- [ ] Path screen: tap Wander/Together/Seek — footprints transition with breath animation above each word
- [ ] Path screen: Together companions arrive with stagger, drift subtly
- [ ] Path screen: Seek dots float upward gently
- [ ] Path screen: rapid tap between modes — only final mode renders
- [ ] Path screen: begin button text changes per mode ("Wander" / "Walk Together" / "Seek")
- [ ] Path screen: background tint shifts subtly per mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)