### PR TITLE
feat: WeatherKit integration with visual overlay and prompt context

### DIFF
--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -3,10 +3,12 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
+		WTHRSVC0000000000000001 /* WeatherService.swift in Sources */ = {isa = PBXBuildFile; fileRef = WTHRSVC0000000000000002 /* WeatherService.swift */; };
+		WTHRSVC0000000000000005 /* WeatherKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = WTHRSVC0000000000000004 /* WeatherKit.framework */; settings = {ATTRIBUTES = (Required, ); }; };
 		0247093D7E5B019E36A98F9F /* AudioAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA2B0038D4875801C41DE26 /* AudioAsset.swift */; };
 		0379F19A766F1A45B011537D /* VoiceGuideSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90791FB10E8E34FB9BBAB3DD /* VoiceGuideSchedulerTests.swift */; };
 		03A4AA6D8DD2B3AA6E9AF157 /* PromptGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD13E8087B26CC89725C3041 /* PromptGeneratorTests.swift */; };
@@ -219,8 +221,6 @@
 		B3D4E5F6A7B8C9D0E1F2A3B5 /* RecordingsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F6A7B8C9D0E1F2A3B4C6 /* RecordingsListView.swift */; };
 		B4C5D6E7F8A9B0C1D2E3F4A6 /* FeedbackService.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C5D6E7F8A9B0C1D2E3F4A5 /* FeedbackService.swift */; };
 		B4C5D6E7F8A9B0C1D2E3F4A8 /* FeedbackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4C5D6E7F8A9B0C1D2E3F4A7 /* FeedbackView.swift */; };
-		CC00000100000000ABOUTV02 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000ABOUTV01 /* AboutView.swift */; };
-		CC00000100000000SAFARV02 /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000SAFARV01 /* SafariView.swift */; };
 		B9C538ECD15D4CE3B5B4186E /* ActivityInsightsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 04D6AFD9DABC41629606A762 /* ActivityInsightsView.swift */; };
 		BB00AA010000000000000002 /* PilgrimV1.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00AA010000000000000001 /* PilgrimV1.swift */; };
 		BB00CC010000000000000001 /* WelcomeViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB00CC010000000000000002 /* WelcomeViewModelTests.swift */; };
@@ -233,6 +233,8 @@
 		BREATH000000000000000002 /* BreathTransitionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BREATH000000000000000001 /* BreathTransitionView.swift */; };
 		C34D17383682ACAD912B2387 /* RouteShapeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B95E4FB1DF743CEF3AC77C2 /* RouteShapeView.swift */; };
 		C8297CD567634F8E9D97738B /* TalkSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1EF72AE69CD4C1599071304 /* TalkSettingsView.swift */; };
+		CC00000100000000ABOUTV02 /* AboutView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000ABOUTV01 /* AboutView.swift */; };
+		CC00000100000000SAFARV02 /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000SAFARV01 /* SafariView.swift */; };
 		CC00000200000000BTRFLY01 /* ButterflyShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000BTRFLY01 /* ButterflyShape.swift */; };
 		CC00000200000000CALLIG01 /* CalligraphyPathRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000CALLIG01 /* CalligraphyPathRenderer.swift */; };
 		CC00000200000000DEBUGS01 /* DebugDataSeeder.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000DEBUGS01 /* DebugDataSeeder.swift */; };
@@ -295,6 +297,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		WTHRSVC0000000000000002 /* WeatherService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherService.swift; sourceTree = "<group>"; };
+		WTHRSVC0000000000000004 /* WeatherKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WeatherKit.framework; path = System/Library/Frameworks/WeatherKit.framework; sourceTree = SDKROOT; };
 		04D6AFD9DABC41629606A762 /* ActivityInsightsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityInsightsView.swift; sourceTree = "<group>"; };
 		0B789354C6B8AAE45AEC71F0 /* VoiceGuideManifestTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceGuideManifestTests.swift; sourceTree = "<group>"; };
 		0F5581F46A4FFE9ED1D2DCEB /* SoundSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundSettingsView.swift; sourceTree = "<group>"; };
@@ -508,8 +512,6 @@
 		B4284167708855BA9866F9FF /* VoiceGuideScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceGuideScheduler.swift; sourceTree = "<group>"; };
 		B4C5D6E7F8A9B0C1D2E3F4A5 /* FeedbackService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackService.swift; sourceTree = "<group>"; };
 		B4C5D6E7F8A9B0C1D2E3F4A7 /* FeedbackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackView.swift; sourceTree = "<group>"; };
-		CC00000100000000ABOUTV01 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
-		CC00000100000000SAFARV01 /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
 		BB00AA010000000000000001 /* PilgrimV1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV1.swift; sourceTree = "<group>"; };
 		BB00CC010000000000000002 /* WelcomeViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WelcomeViewModelTests.swift; sourceTree = "<group>"; };
 		BBBB000000000000000001 /* WaypointInterface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaypointInterface.swift; sourceTree = "<group>"; };
@@ -526,6 +528,7 @@
 		C37A4E244FA34A828856F814 /* VoiceEnhancer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceEnhancer.swift; sourceTree = "<group>"; };
 		C56A574B3F5BFCBF50DB5368 /* Pods_UnitTests.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UnitTests.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		C9CBD6B08E4C437DA90FDDB0 /* ActivityTimelineBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityTimelineBar.swift; sourceTree = "<group>"; };
+		CC00000100000000ABOUTV01 /* AboutView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutView.swift; sourceTree = "<group>"; };
 		CC00000100000000BTRFLY01 /* ButterflyShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButterflyShape.swift; sourceTree = "<group>"; };
 		CC00000100000000CALLIG01 /* CalligraphyPathRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CalligraphyPathRenderer.swift; sourceTree = "<group>"; };
 		CC00000100000000DEBUGS01 /* DebugDataSeeder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugDataSeeder.swift; sourceTree = "<group>"; };
@@ -540,6 +543,7 @@
 		CC00000100000000MOONPV01 /* MoonPhaseView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoonPhaseView.swift; sourceTree = "<group>"; };
 		CC00000100000000MOONSH01 /* MoonShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MoonShape.swift; sourceTree = "<group>"; };
 		CC00000100000000MOUNTN01 /* MountainShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MountainShape.swift; sourceTree = "<group>"; };
+		CC00000100000000SAFARV01 /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
 		CC00000100000000SCENER01 /* SceneryGenerator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneryGenerator.swift; sourceTree = "<group>"; };
 		CC00000100000000SCENIV01 /* SceneryItemView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneryItemView.swift; sourceTree = "<group>"; };
 		CC00000100000000SEASON01 /* SeasonalColorEngine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SeasonalColorEngine.swift; sourceTree = "<group>"; };
@@ -583,6 +587,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				WTHRSVC0000000000000005 /* WeatherKit.framework in Frameworks */,
 				AAAA000000000000000000A1 /* WhisperKit in Frameworks */,
 				AAAA00000000000000000MB1 /* MapboxMaps in Frameworks */,
 				50A16B63C6F23E2D1E6210BA /* Pods_Pilgrim.framework in Frameworks */,
@@ -860,10 +865,19 @@
 		22B6CF6B22CA0841002D2FB0 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				WTHRSVC0000000000000004 /* WeatherKit.framework */,
 				D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */,
 				C56A574B3F5BFCBF50DB5368 /* Pods_UnitTests.framework */,
 			);
 			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		WTHRSVC0000000000000003 /* Weather */ = {
+			isa = PBXGroup;
+			children = (
+				WTHRSVC0000000000000002 /* WeatherService.swift */,
+			);
+			path = Weather;
 			sourceTree = "<group>";
 		};
 		22B6CF7422CA0A28002D2FB0 /* Models */ = {
@@ -875,6 +889,7 @@
 				22DBFBD32348AB8000DE6E92 /* Data */,
 				3A2B6107FC73A26AFA4F2434 /* Audio */,
 				B4C5D6E7F8A9B0C1D2E3F4A9 /* Feedback */,
+				WTHRSVC0000000000000003 /* Weather */,
 				22A2D43423E313A3003580EC /* Formatting */,
 				22BD1F3F2474638200415A06 /* ApplicationStateObservation.swift */,
 				22BD1F41247463DF00415A06 /* ApplicationState.swift */,
@@ -1131,7 +1146,6 @@
 				B4284167708855BA9866F9FF /* VoiceGuideScheduler.swift */,
 				65CE1DB41D3DBD404C28973B /* VoiceGuideManagement.swift */,
 			);
-			name = VoiceGuide;
 			path = VoiceGuide;
 			sourceTree = "<group>";
 		};
@@ -1161,7 +1175,6 @@
 				4181215714A52E71449BC390 /* WalkDataFactory.swift */,
 				721BF267E7540B2B259806D1 /* XCTestCase+Combine.swift */,
 			);
-			name = Helpers;
 			path = Helpers;
 			sourceTree = "<group>";
 		};
@@ -1172,7 +1185,6 @@
 				8E0BF1B23139F428720EB2CF /* WalkShareViewModel.swift */,
 				4B95E4FB1DF743CEF3AC77C2 /* RouteShapeView.swift */,
 			);
-			name = WalkShare;
 			path = WalkShare;
 			sourceTree = "<group>";
 		};
@@ -1183,7 +1195,6 @@
 				E6E1B5A537C865F5416F6EF2 /* RouteDownsampler.swift */,
 				5D9D07CA4444A7B548B5CFA4 /* ShareService.swift */,
 			);
-			name = Share;
 			path = Share;
 			sourceTree = "<group>";
 		};
@@ -1477,9 +1488,13 @@
 			inputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Pilgrim/Pods-Pilgrim-frameworks-${CONFIGURATION}-input-files.xcfilelist",
 			);
+			inputPaths = (
+			);
 			name = "[CP] Embed Pods Frameworks";
 			outputFileListPaths = (
 				"${PODS_ROOT}/Target Support Files/Pods-Pilgrim/Pods-Pilgrim-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			outputPaths = (
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
@@ -1751,6 +1766,7 @@
 				6F8AA2EEEDD08C727B89AB94 /* VoiceGuideScheduler.swift in Sources */,
 				E45CCFD6C6A29B3BC03CF2AB /* VoiceGuideManagement.swift in Sources */,
 				3DF4B121DEE87CA7EBB26207 /* VoiceGuideSettingsView.swift in Sources */,
+				WTHRSVC0000000000000001 /* WeatherService.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1957,7 +1973,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = QT27QDFZ7N;
+				DEVELOPMENT_TEAM = YCF2TGZAX8;
 				INFOPLIST_FILE = "$(SRCROOT)/Pilgrim/Support Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1982,7 +1998,7 @@
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = QT27QDFZ7N;
+				DEVELOPMENT_TEAM = YCF2TGZAX8;
 				INFOPLIST_FILE = "$(SRCROOT)/Pilgrim/Support Files/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		WTHRSVC0000000000000001 /* WeatherService.swift in Sources */ = {isa = PBXBuildFile; fileRef = WTHRSVC0000000000000002 /* WeatherService.swift */; };
 		WTHRSVC0000000000000005 /* WeatherKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = WTHRSVC0000000000000004 /* WeatherKit.framework */; settings = {ATTRIBUTES = (Required, ); }; };
+		WTHOVR0000000000000001 /* WeatherOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = WTHOVR0000000000000002 /* WeatherOverlayView.swift */; };
+		WTHVIG0000000000000001 /* WeatherVignetteView.swift in Sources */ = {isa = PBXBuildFile; fileRef = WTHVIG0000000000000002 /* WeatherVignetteView.swift */; };
 		0247093D7E5B019E36A98F9F /* AudioAsset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2CA2B0038D4875801C41DE26 /* AudioAsset.swift */; };
 		0379F19A766F1A45B011537D /* VoiceGuideSchedulerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90791FB10E8E34FB9BBAB3DD /* VoiceGuideSchedulerTests.swift */; };
 		03A4AA6D8DD2B3AA6E9AF157 /* PromptGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD13E8087B26CC89725C3041 /* PromptGeneratorTests.swift */; };
@@ -299,6 +301,8 @@
 /* Begin PBXFileReference section */
 		WTHRSVC0000000000000002 /* WeatherService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherService.swift; sourceTree = "<group>"; };
 		WTHRSVC0000000000000004 /* WeatherKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = WeatherKit.framework; path = System/Library/Frameworks/WeatherKit.framework; sourceTree = SDKROOT; };
+		WTHOVR0000000000000002 /* WeatherOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherOverlayView.swift; sourceTree = "<group>"; };
+		WTHVIG0000000000000002 /* WeatherVignetteView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WeatherVignetteView.swift; sourceTree = "<group>"; };
 		04D6AFD9DABC41629606A762 /* ActivityInsightsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityInsightsView.swift; sourceTree = "<group>"; };
 		0B789354C6B8AAE45AEC71F0 /* VoiceGuideManifestTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceGuideManifestTests.swift; sourceTree = "<group>"; };
 		0F5581F46A4FFE9ED1D2DCEB /* SoundSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundSettingsView.swift; sourceTree = "<group>"; };
@@ -876,6 +880,8 @@
 			isa = PBXGroup;
 			children = (
 				WTHRSVC0000000000000002 /* WeatherService.swift */,
+				WTHOVR0000000000000002 /* WeatherOverlayView.swift */,
+				WTHVIG0000000000000002 /* WeatherVignetteView.swift */,
 			);
 			path = Weather;
 			sourceTree = "<group>";
@@ -1767,6 +1773,8 @@
 				E45CCFD6C6A29B3BC03CF2AB /* VoiceGuideManagement.swift in Sources */,
 				3DF4B121DEE87CA7EBB26207 /* VoiceGuideSettingsView.swift in Sources */,
 				WTHRSVC0000000000000001 /* WeatherService.swift in Sources */,
+				WTHOVR0000000000000001 /* WeatherOverlayView.swift in Sources */,
+				WTHVIG0000000000000001 /* WeatherVignetteView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pilgrim.xcodeproj/xcshareddata/xcschemes/Pilgrim.xcscheme
+++ b/Pilgrim.xcodeproj/xcshareddata/xcschemes/Pilgrim.xcscheme
@@ -70,13 +70,6 @@
             ReferencedContainer = "container:Pilgrim.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
-      <EnvironmentVariables>
-         <EnvironmentVariable
-            key = "DEBUG_WEATHER"
-            value = "overcast"
-            isEnabled = "YES">
-         </EnvironmentVariable>
-      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Pilgrim.xcodeproj/xcshareddata/xcschemes/Pilgrim.xcscheme
+++ b/Pilgrim.xcodeproj/xcshareddata/xcschemes/Pilgrim.xcscheme
@@ -70,6 +70,13 @@
             ReferencedContainer = "container:Pilgrim.xcodeproj">
          </BuildableReference>
       </BuildableProductRunnable>
+      <EnvironmentVariables>
+         <EnvironmentVariable
+            key = "DEBUG_WEATHER"
+            value = "overcast"
+            isEnabled = "YES">
+         </EnvironmentVariable>
+      </EnvironmentVariables>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/Pilgrim/AppDelegate.swift
+++ b/Pilgrim/AppDelegate.swift
@@ -70,13 +70,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ObservableObject {
             }
         )
         
-        #if DEBUG
-        if let weatherArg = ProcessInfo.processInfo.environment["DEBUG_WEATHER"] {
-            WeatherService.debugOverride = WeatherCondition(rawValue: weatherArg)
-            print("[DEBUG] Weather override: \(weatherArg)")
-        }
-        #endif
-
         return true
     }
 

--- a/Pilgrim/AppDelegate.swift
+++ b/Pilgrim/AppDelegate.swift
@@ -70,6 +70,13 @@ class AppDelegate: UIResponder, UIApplicationDelegate, ObservableObject {
             }
         )
         
+        #if DEBUG
+        if let weatherArg = ProcessInfo.processInfo.environment["DEBUG_WEATHER"] {
+            WeatherService.debugOverride = WeatherCondition(rawValue: weatherArg)
+            print("[DEBUG] Weather override: \(weatherArg)")
+        }
+        #endif
+
         return true
     }
 

--- a/Pilgrim/Models/Data/DataManager.swift
+++ b/Pilgrim/Models/Data/DataManager.swift
@@ -210,6 +210,10 @@ struct DataManager {
                 walk._meditateDuration .= object.meditateDuration
 
                 walk._favicon .= object.favicon
+                walk._weatherCondition .= object.weatherCondition
+                walk._weatherTemperature .= object.weatherTemperature
+                walk._weatherHumidity .= object.weatherHumidity
+                walk._weatherWindSpeed .= object.weatherWindSpeed
 
                 persistRelatedEntities(from: object, to: walk, in: transaction)
                 walks.append(walk)
@@ -446,6 +450,10 @@ struct DataManager {
                 walk._talkDuration .= object.talkDuration
                 walk._meditateDuration .= object.meditateDuration
                 walk._favicon .= object.favicon
+                walk._weatherCondition .= object.weatherCondition
+                walk._weatherTemperature .= object.weatherTemperature
+                walk._weatherHumidity .= object.weatherHumidity
+                walk._weatherWindSpeed .= object.weatherWindSpeed
 
                 persistNewRelatedEntities(from: object, to: walk, in: transaction)
                 return walk

--- a/Pilgrim/Models/Data/DataModels/Walk.swift
+++ b/Pilgrim/Models/Data/DataModels/Walk.swift
@@ -144,6 +144,10 @@ extension Walk: WalkInterface {
     public var activityIntervals: [ActivityIntervalInterface] { threadSafeSyncReturn { self._activityIntervals.value } }
     public var favicon: String? { threadSafeSyncReturn { self._favicon.value } }
     public var waypoints: [WaypointInterface] { threadSafeSyncReturn { Array(self._waypoints.value) as [WaypointInterface] } }
+    public var weatherCondition: String? { threadSafeSyncReturn { self._weatherCondition.value } }
+    public var weatherTemperature: Double? { threadSafeSyncReturn { self._weatherTemperature.value } }
+    public var weatherHumidity: Double? { threadSafeSyncReturn { self._weatherHumidity.value } }
+    public var weatherWindSpeed: Double? { threadSafeSyncReturn { self._weatherWindSpeed.value } }
 
 }
 
@@ -180,7 +184,11 @@ extension Walk: TempValueConvertible {
                 voiceRecordings: self._voiceRecordings.value.map { $0.asTemp },
                 activityIntervals: self._activityIntervals.value.map { $0.asTemp },
                 favicon: self._favicon.value,
-                waypoints: self._waypoints.value.map { $0.asTemp }
+                waypoints: self._waypoints.value.map { $0.asTemp },
+                weatherCondition: self._weatherCondition.value,
+                weatherTemperature: self._weatherTemperature.value,
+                weatherHumidity: self._weatherHumidity.value,
+                weatherWindSpeed: self._weatherWindSpeed.value
             )
         }
     }

--- a/Pilgrim/Models/Data/NewWalk.swift
+++ b/Pilgrim/Models/Data/NewWalk.swift
@@ -23,7 +23,7 @@ import Foundation
 
 class NewWalk: TempWalk {
     
-    init(workoutType: Walk.WalkType, distance: Double, steps: Int?, startDate: Date, endDate: Date, isRace: Bool, comment: String?, isUserModified: Bool, finishedRecording: Bool, heartRates: [TempV4.WorkoutHeartRateDataSample], routeData: [TempV4.WorkoutRouteDataSample], pauses: [TempV4.WorkoutPause], workoutEvents: [TempV4.WorkoutEvent], voiceRecordings: [TempV4.VoiceRecording] = [], activityIntervals: [TempV4.ActivityInterval] = [], waypoints: [TempV4.Waypoint] = []) {
+    init(workoutType: Walk.WalkType, distance: Double, steps: Int?, startDate: Date, endDate: Date, isRace: Bool, comment: String?, isUserModified: Bool, finishedRecording: Bool, heartRates: [TempV4.WorkoutHeartRateDataSample], routeData: [TempV4.WorkoutRouteDataSample], pauses: [TempV4.WorkoutPause], workoutEvents: [TempV4.WorkoutEvent], voiceRecordings: [TempV4.VoiceRecording] = [], activityIntervals: [TempV4.ActivityInterval] = [], waypoints: [TempV4.Waypoint] = [], weatherCondition: String? = nil, weatherTemperature: Double? = nil, weatherHumidity: Double? = nil, weatherWindSpeed: Double? = nil) {
 
         let bodyWeight: Double? = UserPreferences.weight.value
         let burnedEnergy: Double? = bodyWeight != nil ? Computation.calculateBurnedEnergy(for: workoutType, distance: distance, weight: bodyWeight!) : nil
@@ -69,6 +69,10 @@ class NewWalk: TempWalk {
             activityIntervals: activityIntervals,
             waypoints: waypoints
         )
+        self.weatherCondition = weatherCondition
+        self.weatherTemperature = weatherTemperature
+        self.weatherHumidity = weatherHumidity
+        self.weatherWindSpeed = weatherWindSpeed
     }
     
     required init(from decoder: Decoder) throws {

--- a/Pilgrim/Models/Data/Temp/Versions/TempV4.swift
+++ b/Pilgrim/Models/Data/Temp/Versions/TempV4.swift
@@ -46,6 +46,10 @@ public enum TempV4 {
         public var talkDuration: Double
         public var meditateDuration: Double
         public var favicon: String?
+        public var weatherCondition: String?
+        public var weatherTemperature: Double?
+        public var weatherHumidity: Double?
+        public var weatherWindSpeed: Double?
 
         var _waypoints: [TempV4.Waypoint]
 
@@ -65,7 +69,7 @@ public enum TempV4 {
         public var waypoints: [WaypointInterface] { _waypoints }
         public var events: [EventInterface] { throwOnAccess() }
         
-        public init(uuid: UUID?, workoutType: Walk.WalkType, distance: Double, steps: Int?, startDate: Date, endDate: Date, burnedEnergy: Double?, isRace: Bool, comment: String?, isUserModified: Bool, healthKitUUID: UUID?, finishedRecording: Bool, ascend: Double, descend: Double, activeDuration: Double, pauseDuration: Double, dayIdentifier: String, talkDuration: Double = 0, meditateDuration: Double = 0, heartRates: [TempV4.WorkoutHeartRateDataSample], routeData: [TempV4.WorkoutRouteDataSample], pauses: [TempV4.WorkoutPause], workoutEvents: [TempV4.WorkoutEvent], voiceRecordings: [TempV4.VoiceRecording] = [], activityIntervals: [TempV4.ActivityInterval] = [], favicon: String? = nil, waypoints: [TempV4.Waypoint] = []) {
+        public init(uuid: UUID?, workoutType: Walk.WalkType, distance: Double, steps: Int?, startDate: Date, endDate: Date, burnedEnergy: Double?, isRace: Bool, comment: String?, isUserModified: Bool, healthKitUUID: UUID?, finishedRecording: Bool, ascend: Double, descend: Double, activeDuration: Double, pauseDuration: Double, dayIdentifier: String, talkDuration: Double = 0, meditateDuration: Double = 0, heartRates: [TempV4.WorkoutHeartRateDataSample], routeData: [TempV4.WorkoutRouteDataSample], pauses: [TempV4.WorkoutPause], workoutEvents: [TempV4.WorkoutEvent], voiceRecordings: [TempV4.VoiceRecording] = [], activityIntervals: [TempV4.ActivityInterval] = [], favicon: String? = nil, waypoints: [TempV4.Waypoint] = [], weatherCondition: String? = nil, weatherTemperature: Double? = nil, weatherHumidity: Double? = nil, weatherWindSpeed: Double? = nil) {
             self.uuid = uuid
             self.workoutType = workoutType
             self.distance = distance
@@ -93,6 +97,10 @@ public enum TempV4 {
             self._activityIntervals = activityIntervals
             self.favicon = favicon
             self._waypoints = waypoints
+            self.weatherCondition = weatherCondition
+            self.weatherTemperature = weatherTemperature
+            self.weatherHumidity = weatherHumidity
+            self.weatherWindSpeed = weatherWindSpeed
         }
         
         private enum CodingKeys: String, CodingKey {
@@ -100,6 +108,7 @@ public enum TempV4 {
             case burnedEnergy, isRace, comment, isUserModified, healthKitUUID
             case finishedRecording, ascend, descend, activeDuration, pauseDuration
             case dayIdentifier, talkDuration, meditateDuration, favicon
+            case weatherCondition, weatherTemperature, weatherHumidity, weatherWindSpeed
             case _waypoints, _heartRates, _routeData, _pauses
             case _workoutEvents, _voiceRecordings, _activityIntervals
         }
@@ -126,6 +135,10 @@ public enum TempV4 {
             talkDuration = try container.decode(Double.self, forKey: .talkDuration)
             meditateDuration = try container.decode(Double.self, forKey: .meditateDuration)
             favicon = try container.decodeIfPresent(String.self, forKey: .favicon)
+            weatherCondition = try container.decodeIfPresent(String.self, forKey: .weatherCondition)
+            weatherTemperature = try container.decodeIfPresent(Double.self, forKey: .weatherTemperature)
+            weatherHumidity = try container.decodeIfPresent(Double.self, forKey: .weatherHumidity)
+            weatherWindSpeed = try container.decodeIfPresent(Double.self, forKey: .weatherWindSpeed)
             _waypoints = try container.decodeIfPresent([TempV4.Waypoint].self, forKey: ._waypoints) ?? []
             _heartRates = try container.decode([TempV4.WorkoutHeartRateDataSample].self, forKey: ._heartRates)
             _routeData = try container.decode([TempV4.WorkoutRouteDataSample].self, forKey: ._routeData)

--- a/Pilgrim/Models/PromptGenerator.swift
+++ b/Pilgrim/Models/PromptGenerator.swift
@@ -402,7 +402,9 @@ struct PromptGenerator {
               let condition = WeatherCondition(rawValue: conditionStr),
               let temp = walk.weatherTemperature else { return nil }
 
-        var parts = [condition.label, String(format: "%.0f°C", temp)]
+        let imperial = UserPreferences.distanceMeasurementType.safeValue == .miles
+        let tempStr = imperial ? String(format: "%.0f°F", temp * 9 / 5 + 32) : String(format: "%.0f°C", temp)
+        var parts = [condition.label, tempStr]
 
         if let humidity = walk.weatherHumidity {
             parts.append("humidity \(Int(humidity * 100))%")

--- a/Pilgrim/Models/PromptGenerator.swift
+++ b/Pilgrim/Models/PromptGenerator.swift
@@ -407,23 +407,14 @@ struct PromptGenerator {
               let temp = walk.weatherTemperature else { return nil }
 
         let imperial = UserPreferences.distanceMeasurementType.safeValue == .miles
-        let tempStr = imperial ? String(format: "%.0f°F", temp * 9 / 5 + 32) : String(format: "%.0f°C", temp)
-        var parts = [condition.label, tempStr]
+        var parts = [condition.label, WeatherSnapshot.formatTemperature(temp, imperial: imperial)]
 
         if let humidity = walk.weatherHumidity {
             parts.append("humidity \(Int(humidity * 100))%")
         }
 
         if let wind = walk.weatherWindSpeed {
-            let desc: String
-            switch wind {
-            case ..<2: desc = "calm"
-            case 2..<5: desc = "gentle breeze"
-            case 5..<10: desc = "moderate wind"
-            case 10..<15: desc = "strong wind"
-            default: desc = "very strong wind"
-            }
-            parts.append(desc)
+            parts.append(WeatherSnapshot.describeWind(wind))
         }
 
         return "Weather: \(parts.joined(separator: ", "))"

--- a/Pilgrim/Models/PromptGenerator.swift
+++ b/Pilgrim/Models/PromptGenerator.swift
@@ -83,6 +83,7 @@ struct PromptGenerator {
         let date: Date
         let placeName: String?
         let transcriptionPreview: String
+        let weatherCondition: String?
     }
 
     struct WaypointContext {
@@ -389,10 +390,13 @@ struct PromptGenerator {
         guard !snippets.isEmpty else { return nil }
         let lines = snippets.map { snippet in
             let dateStr = shortDateFormatter.string(from: snippet.date)
+            let weatherStr = snippet.weatherCondition
+                .flatMap { WeatherCondition(rawValue: $0)?.label.lowercased() }
+                .map { " in \($0)" } ?? ""
             if let place = snippet.placeName {
-                return "[\(dateStr) – \(place)] \"\(snippet.transcriptionPreview)\""
+                return "[\(dateStr) – \(place)\(weatherStr)] \"\(snippet.transcriptionPreview)\""
             }
-            return "[\(dateStr)] \"\(snippet.transcriptionPreview)\""
+            return "[\(dateStr)\(weatherStr)] \"\(snippet.transcriptionPreview)\""
         }
         return "**Recent Walk Context (for continuity):**\n\n" + lines.joined(separator: "\n\n")
     }

--- a/Pilgrim/Models/PromptGenerator.swift
+++ b/Pilgrim/Models/PromptGenerator.swift
@@ -103,7 +103,8 @@ struct PromptGenerator {
         routeSpeeds: [Double] = [],
         recentWalkSnippets: [WalkSnippet] = [],
         intention: String? = nil,
-        waypoints: [WaypointContext] = []
+        waypoints: [WaypointContext] = [],
+        weather: String? = nil
     ) -> GeneratedPrompt {
         let combinedText = formatRecordings(recordings)
         let meditationText = formatMeditations(meditations)
@@ -206,7 +207,8 @@ struct PromptGenerator {
             pace: pace,
             recentWalks: recentWalks,
             intention: intention,
-            waypoints: waypoints
+            waypoints: waypoints,
+            weather: weather
         )
         return GeneratedPrompt(style: style, customStyle: nil, text: prompt)
     }
@@ -222,7 +224,8 @@ struct PromptGenerator {
         routeSpeeds: [Double] = [],
         recentWalkSnippets: [WalkSnippet] = [],
         intention: String? = nil,
-        waypoints: [WaypointContext] = []
+        waypoints: [WaypointContext] = [],
+        weather: String? = nil
     ) -> GeneratedPrompt {
         let combinedText = formatRecordings(recordings)
         let meditationText = formatMeditations(meditations)
@@ -245,7 +248,8 @@ struct PromptGenerator {
             pace: pace,
             recentWalks: recentWalks,
             intention: intention,
-            waypoints: waypoints
+            waypoints: waypoints,
+            weather: weather
         )
         return GeneratedPrompt(style: nil, customStyle: customStyle, text: prompt)
     }
@@ -260,7 +264,8 @@ struct PromptGenerator {
         routeSpeeds: [Double] = [],
         recentWalkSnippets: [WalkSnippet] = [],
         intention: String? = nil,
-        waypoints: [WaypointContext] = []
+        waypoints: [WaypointContext] = [],
+        weather: String? = nil
     ) -> [GeneratedPrompt] {
         PromptStyle.allCases.map { style in
             generate(
@@ -274,7 +279,8 @@ struct PromptGenerator {
                 routeSpeeds: routeSpeeds,
                 recentWalkSnippets: recentWalkSnippets,
                 intention: intention,
-                waypoints: waypoints
+                waypoints: waypoints,
+                weather: weather
             )
         }
     }
@@ -391,6 +397,32 @@ struct PromptGenerator {
         return "**Recent Walk Context (for continuity):**\n\n" + lines.joined(separator: "\n\n")
     }
 
+    static func formatWeather(_ walk: WalkInterface) -> String? {
+        guard let conditionStr = walk.weatherCondition,
+              let condition = WeatherCondition(rawValue: conditionStr),
+              let temp = walk.weatherTemperature else { return nil }
+
+        var parts = [condition.label, String(format: "%.0f°C", temp)]
+
+        if let humidity = walk.weatherHumidity {
+            parts.append("humidity \(Int(humidity * 100))%")
+        }
+
+        if let wind = walk.weatherWindSpeed {
+            let desc: String
+            switch wind {
+            case ..<2: desc = "calm"
+            case 2..<5: desc = "gentle breeze"
+            case 5..<10: desc = "moderate wind"
+            case 10..<15: desc = "strong wind"
+            default: desc = "very strong wind"
+            }
+            parts.append(desc)
+        }
+
+        return "Weather: \(parts.joined(separator: ", "))"
+    }
+
     private static func formatMetadata(duration: Double, distance: Double, startDate: Date) -> String {
         let durationMin = Int(duration / 60)
         let distanceStr = distanceFormatter.string(from: Measurement(value: distance, unit: UnitLength.meters))
@@ -414,7 +446,7 @@ struct PromptGenerator {
 
     // MARK: - Prompt Builder
 
-    private static func buildPrompt(preamble: String, instruction: String, transcription: String, meditations: String?, metadata: String, location: String?, pace: String?, recentWalks: String?, intention: String? = nil, waypoints: [WaypointContext] = []) -> String {
+    private static func buildPrompt(preamble: String, instruction: String, transcription: String, meditations: String?, metadata: String, location: String?, pace: String?, recentWalks: String?, intention: String? = nil, waypoints: [WaypointContext] = [], weather: String? = nil) -> String {
         var sections = """
             \(preamble)
 
@@ -422,6 +454,10 @@ struct PromptGenerator {
 
             **Context:** \(metadata)
             """
+
+        if let weather = weather {
+            sections += " | \(weather)"
+        }
 
         if let intention = intention {
             sections += "\n\n**The walker's intention:** \"\(intention)\"\nThis intention was set deliberately before the walk began. It represents what the walker chose to carry with them. Let it be the lens through which you interpret everything below."

--- a/Pilgrim/Models/PromptGenerator.swift
+++ b/Pilgrim/Models/PromptGenerator.swift
@@ -83,7 +83,7 @@ struct PromptGenerator {
         let date: Date
         let placeName: String?
         let transcriptionPreview: String
-        let weatherCondition: String?
+        var weatherCondition: String? = nil
     }
 
     struct WaypointContext {

--- a/Pilgrim/Models/Share/SharePayload.swift
+++ b/Pilgrim/Models/Share/SharePayload.swift
@@ -21,6 +21,8 @@ struct SharePayload: Encodable {
         let steps: Int?
         let meditateDuration: Double?
         let talkDuration: Double?
+        let weatherCondition: String?
+        let weatherTemperature: Double?
 
         enum CodingKeys: String, CodingKey {
             case distance
@@ -30,6 +32,8 @@ struct SharePayload: Encodable {
             case steps
             case meditateDuration = "meditate_duration"
             case talkDuration = "talk_duration"
+            case weatherCondition = "weather_condition"
+            case weatherTemperature = "weather_temperature"
         }
     }
 

--- a/Pilgrim/Models/Walk/WalkBuilder/WalkBuilder.swift
+++ b/Pilgrim/Models/Walk/WalkBuilder/WalkBuilder.swift
@@ -453,6 +453,7 @@ public class WalkBuilder: ApplicationStateObserver {
         activityIntervalsRelay.accept([])
         waypointsRelay.accept([])
         lastPause = nil
+        weatherSnapshot = nil
         resetRelay.accept(nil)
     }
     

--- a/Pilgrim/Models/Walk/WalkBuilder/WalkBuilder.swift
+++ b/Pilgrim/Models/Walk/WalkBuilder/WalkBuilder.swift
@@ -103,7 +103,9 @@ public class WalkBuilder: ApplicationStateObserver {
     public func addWaypoint(_ waypoint: TempWaypoint) {
         waypointsRelay.accept(waypointsRelay.value + [waypoint])
     }
-    
+
+    var weatherSnapshot: WeatherSnapshot?
+
     // MARK: - Initialisation
     
     /**
@@ -391,7 +393,11 @@ public class WalkBuilder: ApplicationStateObserver {
             workoutEvents: [],
             voiceRecordings: voiceRecordingsRelay.value,
             activityIntervals: activityIntervalsRelay.value,
-            waypoints: waypointsRelay.value
+            waypoints: waypointsRelay.value,
+            weatherCondition: weatherSnapshot?.condition.rawValue,
+            weatherTemperature: weatherSnapshot?.temperature,
+            weatherHumidity: weatherSnapshot?.humidity,
+            weatherWindSpeed: weatherSnapshot?.windSpeed
         )
     }
 
@@ -419,10 +425,14 @@ public class WalkBuilder: ApplicationStateObserver {
             workoutEvents: [],
             voiceRecordings: voiceRecordingsRelay.value,
             activityIntervals: activityIntervalsRelay.value,
-            waypoints: waypointsRelay.value
+            waypoints: waypointsRelay.value,
+            weatherCondition: weatherSnapshot?.condition.rawValue,
+            weatherTemperature: weatherSnapshot?.temperature,
+            weatherHumidity: weatherSnapshot?.humidity,
+            weatherWindSpeed: weatherSnapshot?.windSpeed
         )
     }
-    
+
     // MARK: - Preparation
     
     /// Resets the `WalkBuilder` and it's components and prepares them for another recording.

--- a/Pilgrim/Models/Walk/WalkSessionGuard.swift
+++ b/Pilgrim/Models/Walk/WalkSessionGuard.swift
@@ -273,7 +273,11 @@ class WalkSessionGuard {
             workoutEvents: walk._workoutEvents,
             voiceRecordings: walk._voiceRecordings,
             activityIntervals: walk._activityIntervals,
-            waypoints: walk._waypoints
+            waypoints: walk._waypoints,
+            weatherCondition: walk.weatherCondition,
+            weatherTemperature: walk.weatherTemperature,
+            weatherHumidity: walk.weatherHumidity,
+            weatherWindSpeed: walk.weatherWindSpeed
         )
         recovered.uuid = checkpoint.walkUUID
 

--- a/Pilgrim/Models/Weather/WeatherOverlayView.swift
+++ b/Pilgrim/Models/Weather/WeatherOverlayView.swift
@@ -4,9 +4,7 @@ struct WeatherOverlayView: View {
 
     let condition: WeatherCondition?
 
-    private var reduceMotion: Bool {
-        UIAccessibility.isReduceMotionEnabled
-    }
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
 
     var body: some View {
         if let condition {

--- a/Pilgrim/Models/Weather/WeatherOverlayView.swift
+++ b/Pilgrim/Models/Weather/WeatherOverlayView.swift
@@ -179,19 +179,29 @@ private struct RainCanvas: View {
 private struct LightningFlashView: View {
 
     @State private var flashOpacity: Double = 0
+    @State private var generation = 0
 
     var body: some View {
         Color.white.opacity(flashOpacity)
-            .onAppear { runFlashCycle() }
+            .onAppear {
+                generation += 1
+                runFlashCycle(generation: generation)
+            }
+            .onDisappear {
+                generation += 1
+                flashOpacity = 0
+            }
     }
 
-    private func runFlashCycle() {
+    private func runFlashCycle(generation gen: Int) {
         let delay = Double.random(in: 10...14)
         DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            guard generation == gen else { return }
             withAnimation(.easeIn(duration: 0.05)) { flashOpacity = 0.06 }
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                guard generation == gen else { return }
                 withAnimation(.easeOut(duration: 0.05)) { flashOpacity = 0 }
-                runFlashCycle()
+                runFlashCycle(generation: gen)
             }
         }
     }

--- a/Pilgrim/Models/Weather/WeatherOverlayView.swift
+++ b/Pilgrim/Models/Weather/WeatherOverlayView.swift
@@ -1,0 +1,296 @@
+import SwiftUI
+
+struct WeatherOverlayView: View {
+
+    let condition: WeatherCondition?
+
+    private var reduceMotion: Bool {
+        UIAccessibility.isReduceMotionEnabled
+    }
+
+    var body: some View {
+        if let condition {
+            ZStack {
+                staticTint(for: condition)
+                if !reduceMotion {
+                    particleLayer(for: condition)
+                }
+            }
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
+        } else {
+            Color.clear
+                .allowsHitTesting(false)
+                .accessibilityHidden(true)
+        }
+    }
+
+    // MARK: - Static Tints
+
+    @ViewBuilder
+    private func staticTint(for condition: WeatherCondition) -> some View {
+        switch condition {
+        case .clear:
+            Color.orange.opacity(0.01)
+        case .overcast:
+            Color.gray.opacity(0.02)
+        case .lightRain:
+            Color(white: 0.55).opacity(0.01)
+        case .heavyRain:
+            Color(white: 0.4).opacity(0.02)
+        case .thunderstorm:
+            Color.black.opacity(0.03)
+        case .fog:
+            RadialGradient(
+                colors: [Color.white.opacity(0.04), Color.white.opacity(0.01)],
+                center: .center,
+                startRadius: 0,
+                endRadius: 400
+            )
+        case .haze:
+            Color.brown.opacity(0.02)
+        case .partlyCloudy, .snow, .wind:
+            Color.clear
+        }
+    }
+
+    // MARK: - Particle Layers
+
+    @ViewBuilder
+    private func particleLayer(for condition: WeatherCondition) -> some View {
+        switch condition {
+        case .partlyCloudy:
+            CloudDriftCanvas()
+        case .lightRain:
+            RainCanvas(particleCount: 20, opacity: 0.03)
+        case .heavyRain:
+            RainCanvas(particleCount: 40, opacity: 0.03)
+        case .thunderstorm:
+            LightningFlashView()
+        case .snow:
+            SnowCanvas()
+        case .wind:
+            WindStreakCanvas()
+        case .clear, .overcast, .fog, .haze:
+            EmptyView()
+        }
+    }
+}
+
+// MARK: - Cloud Drift (partlyCloudy)
+
+private struct CloudDriftCanvas: View {
+
+    private struct Cloud {
+        var x: Double
+        let y: Double
+        let width: Double
+        let height: Double
+        let speed: Double
+        let opacity: Double
+    }
+
+    private static func makeClouds() -> [Cloud] {
+        [
+            Cloud(x: 0.05, y: 0.15, width: 180, height: 50, speed: 0.0003, opacity: 0.03),
+            Cloud(x: 0.40, y: 0.35, width: 220, height: 60, speed: 0.0004, opacity: 0.04),
+            Cloud(x: 0.75, y: 0.55, width: 260, height: 70, speed: 0.0005, opacity: 0.05),
+        ]
+    }
+
+    private let clouds = makeClouds()
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 1.0 / 10)) { timeline in
+            Canvas { context, size in
+                let now: Double = timeline.date.timeIntervalSinceReferenceDate
+                for cloud in clouds {
+                    let divisor: Double = size.width + cloud.width
+                    let xOffset: Double = (now * cloud.speed * size.width)
+                        .truncatingRemainder(dividingBy: divisor)
+                    let drawX: Double = xOffset - cloud.width * 0.5
+                    let drawY: Double = cloud.y * size.height
+                    let rect = CGRect(x: drawX, y: drawY, width: cloud.width, height: cloud.height)
+                    context.opacity = cloud.opacity
+                    context.fill(
+                        Ellipse().path(in: rect),
+                        with: .color(.fog)
+                    )
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Rain (lightRain / heavyRain)
+
+private struct RainCanvas: View {
+
+    let particleCount: Int
+    let opacity: Double
+
+    private struct Drop {
+        var y: Double
+        let x: Double
+        let length: Double
+        let speed: Double
+    }
+
+    @State private var drops: [Drop] = []
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 1.0 / 20)) { timeline in
+            Canvas { context, size in
+                let now = timeline.date.timeIntervalSinceReferenceDate
+                for drop in drops {
+                    let progress = (now * drop.speed).truncatingRemainder(dividingBy: 1.2)
+                    let yPos = progress * size.height
+                    let xPos = drop.x * size.width + progress * 12
+
+                    var path = Path()
+                    path.move(to: CGPoint(x: xPos, y: yPos))
+                    path.addLine(to: CGPoint(x: xPos + 2, y: yPos + drop.length))
+
+                    context.stroke(
+                        path,
+                        with: .color(.ink.opacity(opacity)),
+                        lineWidth: 0.8
+                    )
+                }
+            }
+        }
+        .onAppear { seedDrops() }
+    }
+
+    private func seedDrops() {
+        drops = (0..<particleCount).map { _ in
+            Drop(
+                y: Double.random(in: 0...1),
+                x: Double.random(in: 0...1),
+                length: Double.random(in: 12...22),
+                speed: Double.random(in: 0.35...0.6)
+            )
+        }
+    }
+}
+
+// MARK: - Lightning Flash (thunderstorm)
+
+private struct LightningFlashView: View {
+
+    @State private var flashOpacity: Double = 0
+
+    var body: some View {
+        Color.white.opacity(flashOpacity)
+            .onAppear { runFlashCycle() }
+    }
+
+    private func runFlashCycle() {
+        let delay = Double.random(in: 10...14)
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) {
+            withAnimation(.easeIn(duration: 0.05)) { flashOpacity = 0.06 }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) {
+                withAnimation(.easeOut(duration: 0.05)) { flashOpacity = 0 }
+                runFlashCycle()
+            }
+        }
+    }
+}
+
+// MARK: - Snow
+
+private struct SnowCanvas: View {
+
+    private struct Flake {
+        let x: Double
+        let speed: Double
+        let drift: Double
+        let phase: Double
+    }
+
+    @State private var flakes: [Flake] = []
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 1.0 / 15)) { timeline in
+            Canvas { context, size in
+                let now = timeline.date.timeIntervalSinceReferenceDate
+                for flake in flakes {
+                    let progress = (now * flake.speed + flake.phase)
+                        .truncatingRemainder(dividingBy: 1.3)
+                    let yPos = progress * size.height
+                    let sineOffset = sin(now * flake.drift) * 15
+                    let xPos = flake.x * size.width + sineOffset
+
+                    let rect = CGRect(x: xPos - 2, y: yPos - 2, width: 4, height: 4)
+                    context.opacity = 0.04
+                    context.fill(
+                        Circle().path(in: rect),
+                        with: .color(.white)
+                    )
+                }
+            }
+        }
+        .onAppear { seedFlakes() }
+    }
+
+    private func seedFlakes() {
+        flakes = (0..<25).map { _ in
+            Flake(
+                x: Double.random(in: 0...1),
+                speed: Double.random(in: 0.12...0.25),
+                drift: Double.random(in: 0.4...1.0),
+                phase: Double.random(in: 0...1.3)
+            )
+        }
+    }
+}
+
+// MARK: - Wind Streaks
+
+private struct WindStreakCanvas: View {
+
+    private struct Streak {
+        let y: Double
+        let speed: Double
+        let length: Double
+        let phase: Double
+    }
+
+    @State private var streaks: [Streak] = []
+
+    var body: some View {
+        TimelineView(.periodic(from: .now, by: 1.0 / 15)) { timeline in
+            Canvas { context, size in
+                let now = timeline.date.timeIntervalSinceReferenceDate
+                for streak in streaks {
+                    let progress = ((now * streak.speed + streak.phase)
+                        .truncatingRemainder(dividingBy: 1.4))
+                    let xPos = progress * (size.width + streak.length) - streak.length
+                    let yPos = streak.y * size.height
+
+                    var path = Path()
+                    path.move(to: CGPoint(x: xPos, y: yPos))
+                    path.addLine(to: CGPoint(x: xPos + streak.length, y: yPos - 3))
+
+                    context.stroke(
+                        path,
+                        with: .color(.fog.opacity(0.03)),
+                        lineWidth: 0.6
+                    )
+                }
+            }
+        }
+        .onAppear { seedStreaks() }
+    }
+
+    private func seedStreaks() {
+        streaks = (0..<12).map { _ in
+            Streak(
+                y: Double.random(in: 0.05...0.95),
+                speed: Double.random(in: 0.5...0.9),
+                length: Double.random(in: 40...80),
+                phase: Double.random(in: 0...1.4)
+            )
+        }
+    }
+}

--- a/Pilgrim/Models/Weather/WeatherService.swift
+++ b/Pilgrim/Models/Weather/WeatherService.swift
@@ -55,10 +55,24 @@ struct WeatherSnapshot: Codable {
     }
 
     func formattedTemperature(imperial: Bool) -> String {
+        Self.formatTemperature(temperature, imperial: imperial)
+    }
+
+    static func formatTemperature(_ celsius: Double, imperial: Bool) -> String {
         if imperial {
-            return String(format: "%.0f°F", temperature * 9 / 5 + 32)
+            return String(format: "%.0f°F", celsius * 9 / 5 + 32)
         }
-        return String(format: "%.0f°C", temperature)
+        return String(format: "%.0f°C", celsius)
+    }
+
+    static func describeWind(_ metersPerSecond: Double) -> String {
+        switch metersPerSecond {
+        case ..<2: return "calm"
+        case 2..<5: return "gentle breeze"
+        case 5..<10: return "moderate wind"
+        case 10..<15: return "strong wind"
+        default: return "very strong wind"
+        }
     }
 }
 

--- a/Pilgrim/Models/Weather/WeatherService.swift
+++ b/Pilgrim/Models/Weather/WeatherService.swift
@@ -68,23 +68,7 @@ final class WeatherService {
     private let service = WeatherKit.WeatherService.shared
     private init() {}
 
-    #if DEBUG
-    static var debugOverride: WeatherCondition?
-    #endif
-
     func fetchCurrent(for location: CLLocation) async -> WeatherSnapshot? {
-        #if DEBUG
-        if let override = Self.debugOverride {
-            try? await Task.sleep(nanoseconds: 500_000_000)
-            return WeatherSnapshot(
-                condition: override,
-                temperature: 14,
-                humidity: 0.72,
-                windSpeed: override == .wind ? 12 : 3.5
-            )
-        }
-        #endif
-
         do {
             let weather = try await service.weather(for: location, including: .current)
             let windSpeedMS = weather.wind.speed.converted(to: .metersPerSecond).value

--- a/Pilgrim/Models/Weather/WeatherService.swift
+++ b/Pilgrim/Models/Weather/WeatherService.swift
@@ -1,0 +1,112 @@
+import Foundation
+import WeatherKit
+import CoreLocation
+
+enum WeatherCondition: String, Codable, CaseIterable {
+    case clear, partlyCloudy, overcast
+    case lightRain, heavyRain, thunderstorm
+    case snow, fog, wind, haze
+
+    var icon: String {
+        switch self {
+        case .clear: return "sun.max.fill"
+        case .partlyCloudy: return "cloud.sun.fill"
+        case .overcast: return "cloud.fill"
+        case .lightRain: return "cloud.drizzle.fill"
+        case .heavyRain: return "cloud.heavyrain.fill"
+        case .thunderstorm: return "cloud.bolt.fill"
+        case .snow: return "cloud.snow.fill"
+        case .fog: return "cloud.fog.fill"
+        case .wind: return "wind"
+        case .haze: return "sun.haze.fill"
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .clear: return "Clear"
+        case .partlyCloudy: return "Partly cloudy"
+        case .overcast: return "Overcast"
+        case .lightRain: return "Light rain"
+        case .heavyRain: return "Heavy rain"
+        case .thunderstorm: return "Thunderstorm"
+        case .snow: return "Snow"
+        case .fog: return "Foggy"
+        case .wind: return "Windy"
+        case .haze: return "Hazy"
+        }
+    }
+}
+
+struct WeatherSnapshot: Codable {
+    let condition: WeatherCondition
+    let temperature: Double
+    let humidity: Double
+    let windSpeed: Double
+
+    var description: String {
+        "\(condition.label), \(String(format: "%.0f", temperature))°C"
+    }
+
+    func formattedTemperature(imperial: Bool) -> String {
+        if imperial {
+            return String(format: "%.0f°F", temperature * 9 / 5 + 32)
+        }
+        return String(format: "%.0f°C", temperature)
+    }
+}
+
+final class WeatherService {
+
+    static let shared = WeatherService()
+    private let service = WeatherKit.WeatherService.shared
+    private init() {}
+
+    func fetchCurrent(for location: CLLocation) async -> WeatherSnapshot? {
+        do {
+            let weather = try await service.weather(for: location, including: .current)
+            let windSpeedMS = weather.wind.speed.converted(to: .metersPerSecond).value
+            let condition = mapCondition(weather.condition, windSpeed: windSpeedMS)
+            return WeatherSnapshot(
+                condition: condition,
+                temperature: weather.temperature.converted(to: .celsius).value,
+                humidity: weather.humidity,
+                windSpeed: windSpeedMS
+            )
+        } catch {
+            print("[WeatherService] Failed to fetch weather: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private func mapCondition(_ condition: WeatherKit.WeatherCondition, windSpeed: Double) -> WeatherCondition {
+        if windSpeed > 10 { return .wind }
+
+        switch condition {
+        case .clear, .mostlyClear, .hot:
+            return .clear
+        case .partlyCloudy:
+            return .partlyCloudy
+        case .cloudy, .mostlyCloudy:
+            return .overcast
+        case .drizzle:
+            return .lightRain
+        case .rain:
+            return windSpeed > 5 ? .heavyRain : .lightRain
+        case .heavyRain:
+            return .heavyRain
+        case .thunderstorms, .tropicalStorm, .hurricane, .isolatedThunderstorms, .scatteredThunderstorms, .strongStorms:
+            return .thunderstorm
+        case .snow, .flurries, .sleet, .freezingRain, .blizzard, .heavySnow, .freezingDrizzle, .blowingSnow, .wintryMix:
+            return .snow
+        case .foggy:
+            return .fog
+        case .windy, .breezy:
+            return .wind
+        case .haze, .smoky, .blowingDust:
+            return .haze
+        @unknown default:
+            return .clear
+        }
+    }
+}

--- a/Pilgrim/Models/Weather/WeatherService.swift
+++ b/Pilgrim/Models/Weather/WeatherService.swift
@@ -2,7 +2,7 @@ import Foundation
 import WeatherKit
 import CoreLocation
 
-enum WeatherCondition: String, Codable, CaseIterable {
+enum WeatherCondition: String, Codable {
     case clear, partlyCloudy, overcast
     case lightRain, heavyRain, thunderstorm
     case snow, fog, wind, haze
@@ -44,8 +44,14 @@ struct WeatherSnapshot: Codable {
     let humidity: Double
     let windSpeed: Double
 
-    var description: String {
-        "\(condition.label), \(String(format: "%.0f", temperature))°C"
+    var windDescription: String {
+        switch windSpeed {
+        case ..<2: return "calm"
+        case 2..<5: return "gentle breeze"
+        case 5..<10: return "moderate wind"
+        case 10..<15: return "strong wind"
+        default: return "very strong wind"
+        }
     }
 
     func formattedTemperature(imperial: Bool) -> String {

--- a/Pilgrim/Models/Weather/WeatherService.swift
+++ b/Pilgrim/Models/Weather/WeatherService.swift
@@ -68,7 +68,23 @@ final class WeatherService {
     private let service = WeatherKit.WeatherService.shared
     private init() {}
 
+    #if DEBUG
+    static var debugOverride: WeatherCondition?
+    #endif
+
     func fetchCurrent(for location: CLLocation) async -> WeatherSnapshot? {
+        #if DEBUG
+        if let override = Self.debugOverride {
+            try? await Task.sleep(nanoseconds: 500_000_000)
+            return WeatherSnapshot(
+                condition: override,
+                temperature: 14,
+                humidity: 0.72,
+                windSpeed: override == .wind ? 12 : 3.5
+            )
+        }
+        #endif
+
         do {
             let weather = try await service.weather(for: location, including: .current)
             let windSpeedMS = weather.wind.speed.converted(to: .metersPerSecond).value

--- a/Pilgrim/Models/Weather/WeatherVignetteView.swift
+++ b/Pilgrim/Models/Weather/WeatherVignetteView.swift
@@ -13,6 +13,8 @@ struct WeatherVignetteView: View {
                 content(for: snapshot)
             }
             .buttonStyle(.plain)
+            .accessibilityLabel("Weather: \(snapshot.condition.label), \(snapshot.formattedTemperature(imperial: imperial))")
+            .accessibilityHint("Double tap to expand weather details")
         }
     }
 
@@ -28,7 +30,7 @@ struct WeatherVignetteView: View {
                 Text("\(Int(snapshot.humidity * 100))%")
                     .font(Constants.Typography.caption)
 
-                Text(windDescription(snapshot.windSpeed))
+                Text(snapshot.windDescription)
                     .font(Constants.Typography.caption)
             }
         }
@@ -38,13 +40,4 @@ struct WeatherVignetteView: View {
         .background(.ultraThinMaterial, in: Capsule())
     }
 
-    private func windDescription(_ ms: Double) -> String {
-        switch ms {
-        case ..<2: return "calm"
-        case 2..<5: return "gentle"
-        case 5..<10: return "moderate"
-        case 10..<15: return "strong"
-        default: return "very strong"
-        }
-    }
 }

--- a/Pilgrim/Models/Weather/WeatherVignetteView.swift
+++ b/Pilgrim/Models/Weather/WeatherVignetteView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+struct WeatherVignetteView: View {
+
+    let snapshot: WeatherSnapshot?
+    let imperial: Bool
+
+    @State private var expanded = false
+
+    var body: some View {
+        if let snapshot {
+            Button { withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) { expanded.toggle() } } label: {
+                content(for: snapshot)
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private func content(for snapshot: WeatherSnapshot) -> some View {
+        HStack(spacing: 4) {
+            Image(systemName: snapshot.condition.icon)
+                .font(.caption2)
+
+            Text(snapshot.formattedTemperature(imperial: imperial))
+                .font(Constants.Typography.caption)
+
+            if expanded {
+                Text("\(Int(snapshot.humidity * 100))%")
+                    .font(Constants.Typography.caption)
+
+                Text(windDescription(snapshot.windSpeed))
+                    .font(Constants.Typography.caption)
+            }
+        }
+        .foregroundColor(.fog)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 4)
+        .background(.ultraThinMaterial, in: Capsule())
+    }
+
+    private func windDescription(_ ms: Double) -> String {
+        switch ms {
+        case ..<2: return "calm"
+        case 2..<5: return "gentle"
+        case 5..<10: return "moderate"
+        case 10..<15: return "strong"
+        default: return "very strong"
+        }
+    }
+}

--- a/Pilgrim/Models/Weather/WeatherVignetteView.swift
+++ b/Pilgrim/Models/Weather/WeatherVignetteView.swift
@@ -34,10 +34,14 @@ struct WeatherVignetteView: View {
                     .font(Constants.Typography.caption)
             }
         }
-        .foregroundColor(.fog)
-        .padding(.horizontal, 8)
-        .padding(.vertical, 4)
-        .background(.ultraThinMaterial, in: Capsule())
+        .foregroundColor(.ink)
+        .padding(.horizontal, Constants.UI.Padding.small)
+        .padding(.vertical, Constants.UI.Padding.xs)
+        .background(
+            Capsule()
+                .fill(Color.parchmentSecondary)
+                .shadow(color: .ink.opacity(0.08), radius: 4, y: 2)
+        )
     }
 
 }

--- a/Pilgrim/Pilgrim.entitlements
+++ b/Pilgrim/Pilgrim.entitlements
@@ -1,5 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.developer.weatherkit</key>
+	<true/>
+</dict>
 </plist>

--- a/Pilgrim/Protocols/DataInterfaces/WalkInterface.swift
+++ b/Pilgrim/Protocols/DataInterfaces/WalkInterface.swift
@@ -78,6 +78,10 @@ public protocol WalkInterface: DataInterface {
     var favicon: String? { get }
     /// A reference to `Waypoint`s associated with this walk.
     var waypoints: [WaypointInterface] { get }
+    var weatherCondition: String? { get }
+    var weatherTemperature: Double? { get }
+    var weatherHumidity: Double? { get }
+    var weatherWindSpeed: Double? { get }
 
 }
 
@@ -110,5 +114,9 @@ public extension WalkInterface {
     var activityIntervals: [ActivityIntervalInterface] { [] }
     var favicon: String? { nil }
     var waypoints: [WaypointInterface] { [] }
+    var weatherCondition: String? { nil }
+    var weatherTemperature: Double? { nil }
+    var weatherHumidity: Double? { nil }
+    var weatherWindSpeed: Double? { nil }
 
 }

--- a/Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift
+++ b/Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift
@@ -388,10 +388,13 @@ struct ActiveWalkView: View {
         Button(action: action) {
             Image(systemName: icon)
                 .font(.caption2)
-                .foregroundColor(.parchment.opacity(0.8))
+                .foregroundColor(.ink)
                 .frame(width: 28, height: 28)
-                .background(.ultraThinMaterial)
-                .clipShape(Circle())
+                .background(
+                    Circle()
+                        .fill(Color.parchmentSecondary)
+                        .shadow(color: .ink.opacity(0.08), radius: 4, y: 2)
+                )
         }
     }
 

--- a/Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift
+++ b/Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift
@@ -14,6 +14,7 @@ struct ActiveWalkView: View {
     @State private var showBackConfirmation = false
     @State private var showWaypointFailed = false
     @State private var hasCheckedAutoIntention = false
+    @State private var weatherGreeting: String?
 
     private var selectedSoundscapeName: String? {
         guard UserPreferences.soundsEnabled.value,
@@ -64,6 +65,15 @@ struct ActiveWalkView: View {
                         }
                         .padding(.trailing, Constants.UI.Padding.normal)
                         .padding(.bottom, 48)
+
+                        if let weatherGreeting {
+                            Text(weatherGreeting)
+                                .font(Constants.Typography.body.italic())
+                                .foregroundColor(.ink.opacity(0.5))
+                                .multilineTextAlignment(.center)
+                                .transition(.opacity)
+                                .allowsHitTesting(false)
+                        }
                     }
 
                     statsSection
@@ -76,6 +86,26 @@ struct ActiveWalkView: View {
         }
         .background(Color.parchment)
         .ignoresSafeArea(edges: .top)
+        .onChange(of: viewModel.weatherSnapshot?.condition) { _, condition in
+            guard let condition, weatherGreeting == nil else { return }
+            let greeting: String
+            switch condition {
+            case .clear: greeting = "A clear day for wandering"
+            case .partlyCloudy: greeting = "Walking under shifting skies"
+            case .overcast: greeting = "Soft light on the path"
+            case .lightRain: greeting = "Walking into the rain"
+            case .heavyRain: greeting = "The sky walks with you"
+            case .thunderstorm: greeting = "Thunder on the horizon"
+            case .snow: greeting = "Snow on the path"
+            case .fog: greeting = "Walking into the mist"
+            case .wind: greeting = "The wind at your back"
+            case .haze: greeting = "A hazy veil over the world"
+            }
+            withAnimation(.easeIn(duration: 0.8)) { weatherGreeting = greeting }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 3.5) {
+                withAnimation(.easeOut(duration: 1.0)) { weatherGreeting = nil }
+            }
+        }
         .alert("End Walk?", isPresented: $showStopConfirmation) {
             Button("End Walk", role: .destructive) { viewModel.stop() }
             Button("Cancel", role: .cancel) {}

--- a/Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift
+++ b/Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift
@@ -24,6 +24,9 @@ struct ActiveWalkView: View {
     var body: some View {
         GeometryReader { geometry in
             ZStack(alignment: .top) {
+                WeatherOverlayView(condition: viewModel.weatherSnapshot?.condition)
+                    .ignoresSafeArea()
+
                 VStack(spacing: 0) {
                     ZStack(alignment: .bottom) {
                         mapSection(height: geometry.size.height * 0.6)
@@ -36,6 +39,10 @@ struct ActiveWalkView: View {
 
                         HStack(spacing: 6) {
                             Spacer()
+                            WeatherVignetteView(
+                                snapshot: viewModel.weatherSnapshot,
+                                imperial: UserPreferences.distanceMeasurementType.safeValue == .miles
+                            )
                             if SoundscapePlayer.shared.isPlaying || SoundscapePlayer.shared.isMuted {
                                 audioIndicator(
                                     icon: SoundscapePlayer.shared.isMuted ? "speaker.slash" : "speaker.wave.2"

--- a/Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift
+++ b/Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift
@@ -15,6 +15,7 @@ struct ActiveWalkView: View {
     @State private var showWaypointFailed = false
     @State private var hasCheckedAutoIntention = false
     @State private var weatherGreeting: String?
+    @State private var greetingGeneration = 0
 
     private var selectedSoundscapeName: String? {
         guard UserPreferences.soundsEnabled.value,
@@ -101,8 +102,11 @@ struct ActiveWalkView: View {
             case .wind: greeting = "The wind at your back"
             case .haze: greeting = "A hazy veil over the world"
             }
+            greetingGeneration += 1
+            let gen = greetingGeneration
             withAnimation(.easeIn(duration: 0.8)) { weatherGreeting = greeting }
             DispatchQueue.main.asyncAfter(deadline: .now() + 3.5) {
+                guard greetingGeneration == gen else { return }
                 withAnimation(.easeOut(duration: 1.0)) { weatherGreeting = nil }
             }
         }

--- a/Pilgrim/Scenes/ActiveWalk/ActiveWalkViewModel.swift
+++ b/Pilgrim/Scenes/ActiveWalk/ActiveWalkViewModel.swift
@@ -64,14 +64,7 @@ class ActiveWalkViewModel: ObservableObject, Identifiable {
 
         builder.onSnapshotCreated = { [weak self] snapshot in
             DispatchQueue.main.async {
-                guard let self else { return }
-                if let weather = self.weatherSnapshot {
-                    snapshot.weatherCondition = weather.condition.rawValue
-                    snapshot.weatherTemperature = weather.temperature
-                    snapshot.weatherHumidity = weather.humidity
-                    snapshot.weatherWindSpeed = weather.windSpeed
-                }
-                self.onWalkCompleted?(snapshot)
+                self?.onWalkCompleted?(snapshot)
             }
         }
 
@@ -89,11 +82,11 @@ class ActiveWalkViewModel: ObservableObject, Identifiable {
         self.sessionGuard = guard_
 
         DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
-            self?.fetchWeather()
+            self?.fetchWeather(retryOnFailure: true)
         }
     }
 
-    func fetchWeather() {
+    func fetchWeather(retryOnFailure: Bool = false) {
         let clLocation: CLLocation?
         if let sample = currentLocation {
             clLocation = CLLocation(latitude: sample.latitude, longitude: sample.longitude)
@@ -102,11 +95,27 @@ class ActiveWalkViewModel: ObservableObject, Identifiable {
         } else {
             clLocation = nil
         }
-        guard let location = clLocation else { return }
+
+        guard let location = clLocation else {
+            if retryOnFailure {
+                DispatchQueue.main.asyncAfter(deadline: .now() + 10) { [weak self] in
+                    self?.fetchWeather(retryOnFailure: false)
+                }
+            }
+            return
+        }
+
         Task { [weak self] in
             let snapshot = await WeatherService.shared.fetchCurrent(for: location)
             await MainActor.run {
-                self?.weatherSnapshot = snapshot
+                if let snapshot {
+                    self?.weatherSnapshot = snapshot
+                    self?.builder.weatherSnapshot = snapshot
+                } else if retryOnFailure {
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 10) { [weak self] in
+                        self?.fetchWeather(retryOnFailure: false)
+                    }
+                }
             }
         }
     }

--- a/Pilgrim/Scenes/ActiveWalk/ActiveWalkViewModel.swift
+++ b/Pilgrim/Scenes/ActiveWalk/ActiveWalkViewModel.swift
@@ -87,19 +87,6 @@ class ActiveWalkViewModel: ObservableObject, Identifiable {
     }
 
     func fetchWeather(retryOnFailure: Bool = false) {
-        #if DEBUG
-        if WeatherService.debugOverride != nil {
-            Task { [weak self] in
-                let snapshot = await WeatherService.shared.fetchCurrent(for: CLLocation(latitude: 0, longitude: 0))
-                await MainActor.run {
-                    self?.weatherSnapshot = snapshot
-                    self?.builder.weatherSnapshot = snapshot
-                }
-            }
-            return
-        }
-        #endif
-
         let clLocation: CLLocation?
         if let sample = currentLocation {
             clLocation = CLLocation(latitude: sample.latitude, longitude: sample.longitude)

--- a/Pilgrim/Scenes/ActiveWalk/ActiveWalkViewModel.swift
+++ b/Pilgrim/Scenes/ActiveWalk/ActiveWalkViewModel.swift
@@ -103,10 +103,10 @@ class ActiveWalkViewModel: ObservableObject, Identifiable {
             clLocation = nil
         }
         guard let location = clLocation else { return }
-        Task {
+        Task { [weak self] in
             let snapshot = await WeatherService.shared.fetchCurrent(for: location)
             await MainActor.run {
-                self.weatherSnapshot = snapshot
+                self?.weatherSnapshot = snapshot
             }
         }
     }

--- a/Pilgrim/Scenes/ActiveWalk/ActiveWalkViewModel.swift
+++ b/Pilgrim/Scenes/ActiveWalk/ActiveWalkViewModel.swift
@@ -38,6 +38,7 @@ class ActiveWalkViewModel: ObservableObject, Identifiable {
     @Published var isVoiceGuidePaused = false
     @Published var intention: String?
     @Published var waypoints: [TempWaypoint] = []
+    @Published var weatherSnapshot: WeatherSnapshot?
 
     private var meditationStartDate: Date?
     private var meditationIntervals: [TempActivityInterval] = []
@@ -63,7 +64,14 @@ class ActiveWalkViewModel: ObservableObject, Identifiable {
 
         builder.onSnapshotCreated = { [weak self] snapshot in
             DispatchQueue.main.async {
-                self?.onWalkCompleted?(snapshot)
+                guard let self else { return }
+                if let weather = self.weatherSnapshot {
+                    snapshot.weatherCondition = weather.condition.rawValue
+                    snapshot.weatherTemperature = weather.temperature
+                    snapshot.weatherHumidity = weather.humidity
+                    snapshot.weatherWindSpeed = weather.windSpeed
+                }
+                self.onWalkCompleted?(snapshot)
             }
         }
 
@@ -79,6 +87,28 @@ class ActiveWalkViewModel: ObservableObject, Identifiable {
         guard_.viewModel = self
         guard_.start()
         self.sessionGuard = guard_
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) { [weak self] in
+            self?.fetchWeather()
+        }
+    }
+
+    func fetchWeather() {
+        let clLocation: CLLocation?
+        if let sample = currentLocation {
+            clLocation = CLLocation(latitude: sample.latitude, longitude: sample.longitude)
+        } else if let coord = routeCoordinates.last {
+            clLocation = CLLocation(latitude: coord.latitude, longitude: coord.longitude)
+        } else {
+            clLocation = nil
+        }
+        guard let location = clLocation else { return }
+        Task {
+            let snapshot = await WeatherService.shared.fetchCurrent(for: location)
+            await MainActor.run {
+                self.weatherSnapshot = snapshot
+            }
+        }
     }
 
     private func bindLiveStats() {

--- a/Pilgrim/Scenes/ActiveWalk/ActiveWalkViewModel.swift
+++ b/Pilgrim/Scenes/ActiveWalk/ActiveWalkViewModel.swift
@@ -87,6 +87,19 @@ class ActiveWalkViewModel: ObservableObject, Identifiable {
     }
 
     func fetchWeather(retryOnFailure: Bool = false) {
+        #if DEBUG
+        if WeatherService.debugOverride != nil {
+            Task { [weak self] in
+                let snapshot = await WeatherService.shared.fetchCurrent(for: CLLocation(latitude: 0, longitude: 0))
+                await MainActor.run {
+                    self?.weatherSnapshot = snapshot
+                    self?.builder.weatherSnapshot = snapshot
+                }
+            }
+            return
+        }
+        #endif
+
         let clLocation: CLLocation?
         if let sample = currentLocation {
             clLocation = CLLocation(latitude: sample.latitude, longitude: sample.longitude)

--- a/Pilgrim/Scenes/Home/HomeViewModel.swift
+++ b/Pilgrim/Scenes/Home/HomeViewModel.swift
@@ -13,6 +13,7 @@ struct WalkSnapshot: Identifiable {
     let meditateDuration: TimeInterval
     let favicon: String?
     let isShared: Bool
+    let weatherCondition: String?
 
     var walkOnlyDuration: TimeInterval {
         max(0, duration - talkDuration - meditateDuration)
@@ -88,7 +89,8 @@ class HomeViewModel: ObservableObject {
                 talkDuration: walk.talkDuration,
                 meditateDuration: walk.meditateDuration,
                 favicon: walk.favicon,
-                isShared: ShareService.cachedShare(for: walk.id) != nil
+                isShared: ShareService.cachedShare(for: walk.id) != nil,
+                weatherCondition: walk.weatherCondition
             ))
         }
 

--- a/Pilgrim/Scenes/Home/InkScrollView.swift
+++ b/Pilgrim/Scenes/Home/InkScrollView.swift
@@ -99,20 +99,17 @@ struct InkScrollView: View {
                 let isNewest = index == 0
                 let scenery = self.sceneryForDot(snapshot: snapshot, position: position.center, viewportHeight: viewportHeight)
 
-                if isNewest {
-                    newestDotEffects(snapshot: snapshot)
-                        .frame(width: 60, height: 60)
-                        .position(x: position.center.x, y: position.center.y)
-                        .animation(nil, value: position.center.x)
-                        .animation(nil, value: position.center.y)
-                }
-
                 self.dotContent(
                     snapshot: snapshot,
                     position: position.center,
                     opacity: opacity,
                     sceneryView: scenery
                 )
+                .background {
+                    if isNewest {
+                        newestDotEffects(snapshot: snapshot)
+                    }
+                }
                 .opacity(hasAppeared ? 1 : 0)
                 .animation(
                     .easeOut(duration: 0.5).delay(Double(index) * 0.03 + 0.3),

--- a/Pilgrim/Scenes/Home/InkScrollView.swift
+++ b/Pilgrim/Scenes/Home/InkScrollView.swift
@@ -706,7 +706,7 @@ private struct BreathingPulseView: View {
             .frame(width: 50, height: 50)
             .phaseAnimator([false, true]) { content, phase in
                 content
-                    .scaleEffect(phase ? 1.3 : 0.9)
+                    .scaleEffect(phase ? 1.3 : 1.0)
                     .opacity(phase ? 0.0 : 0.15)
             } animation: { _ in .easeInOut(duration: 2.5) }
     }
@@ -721,7 +721,7 @@ private struct SonarRingView: View {
             .frame(width: 28, height: 28)
             .phaseAnimator([false, true]) { content, phase in
                 content
-                    .scaleEffect(phase ? 2.0 : 0.8)
+                    .scaleEffect(phase ? 2.0 : 1.0)
                     .opacity(phase ? 0 : 0.5)
             } animation: { _ in .easeOut(duration: 2.0) }
     }

--- a/Pilgrim/Scenes/Home/InkScrollView.swift
+++ b/Pilgrim/Scenes/Home/InkScrollView.swift
@@ -280,6 +280,13 @@ struct InkScrollView: View {
                             .font(Constants.Typography.annotation)
                             .foregroundColor(.ink)
 
+                        if let condStr = snapshot.weatherCondition,
+                           let cond = WeatherCondition(rawValue: condStr) {
+                            Image(systemName: cond.icon)
+                                .font(Constants.Typography.caption)
+                                .foregroundColor(.fog)
+                        }
+
                         Spacer()
 
                         if snapshot.isShared {

--- a/Pilgrim/Scenes/Home/InkScrollView.swift
+++ b/Pilgrim/Scenes/Home/InkScrollView.swift
@@ -425,6 +425,54 @@ struct InkScrollView: View {
         return 1.0 - normalized * 0.5
     }
 
+    // MARK: - Weather mood
+
+    private static func weatherAdjustedColor(_ color: Color, condition: String?) -> Color {
+        guard let condStr = condition,
+              let cond = WeatherCondition(rawValue: condStr) else { return color }
+
+        let uiColor = UIColor(color)
+        var h: CGFloat = 0, s: CGFloat = 0, b: CGFloat = 0, a: CGFloat = 0
+        uiColor.getHue(&h, saturation: &s, brightness: &b, alpha: &a)
+
+        switch cond {
+        case .clear:
+            h += 0.02
+            b = min(b * 1.05, 1)
+        case .partlyCloudy:
+            break
+        case .overcast:
+            s *= 0.85
+            b *= 0.95
+        case .lightRain:
+            h -= 0.01
+            b *= 0.88
+        case .heavyRain:
+            h -= 0.02
+            b *= 0.80
+        case .thunderstorm:
+            s *= 0.7
+            b *= 0.75
+        case .snow:
+            h += 0.03
+            b = min(b * 1.05, 1)
+            s *= 0.85
+        case .fog:
+            s *= 0.6
+            b *= 0.9
+        case .wind:
+            break
+        case .haze:
+            h += 0.02
+            s *= 0.85
+        }
+
+        return Color(hue: Double((h + 1).truncatingRemainder(dividingBy: 1)),
+                      saturation: Double(max(0, min(s, 1))),
+                      brightness: Double(max(0, min(b, 1))),
+                      opacity: Double(a))
+    }
+
     // MARK: - Scenery
 
     private func sceneryForDot(snapshot: WalkSnapshot, position: CGPoint, viewportHeight: CGFloat) -> AnyView? {
@@ -432,11 +480,12 @@ struct InkScrollView: View {
             return nil
         }
 
-        let tintColor = Color(uiColor: SeasonalColorEngine.seasonalColor(
+        let baseTint = Color(uiColor: SeasonalColorEngine.seasonalColor(
             named: placement.tintColorName,
             intensity: .full,
             on: snapshot.startDate
         ))
+        let tintColor = Self.weatherAdjustedColor(baseTint, condition: snapshot.weatherCondition)
 
         let baseSize: CGFloat = 32
         var h: UInt64 = 14695981039346656037

--- a/Pilgrim/Scenes/Home/InkScrollView.swift
+++ b/Pilgrim/Scenes/Home/InkScrollView.swift
@@ -101,8 +101,10 @@ struct InkScrollView: View {
 
                 if isNewest {
                     newestDotEffects(snapshot: snapshot)
-                        .position(position.center)
-                        .transaction { $0.animation = nil }
+                        .frame(width: 60, height: 60)
+                        .position(x: position.center.x, y: position.center.y)
+                        .animation(nil, value: position.center.x)
+                        .animation(nil, value: position.center.y)
                 }
 
                 self.dotContent(

--- a/Pilgrim/Scenes/Home/InkScrollView.swift
+++ b/Pilgrim/Scenes/Home/InkScrollView.swift
@@ -103,14 +103,9 @@ struct InkScrollView: View {
                     snapshot: snapshot,
                     position: position.center,
                     opacity: opacity,
-                    sceneryView: scenery
+                    sceneryView: scenery,
+                    isNewest: isNewest
                 )
-                .overlay {
-                    if isNewest {
-                        newestDotEffects(snapshot: snapshot)
-                            .frame(width: 60, height: 60)
-                    }
-                }
                 .opacity(hasAppeared ? 1 : 0)
                 .animation(
                     .easeOut(duration: 0.5).delay(Double(index) * 0.03 + 0.3),
@@ -197,12 +192,14 @@ struct InkScrollView: View {
         snapshot: WalkSnapshot,
         position: CGPoint,
         opacity: Double,
-        sceneryView: AnyView?
+        sceneryView: AnyView?,
+        isNewest: Bool = false
     ) -> some View {
         WalkDotView(
             snapshot: snapshot,
             position: position,
             opacity: opacity,
+            isNewest: isNewest,
             onTap: { id in handleDotTap(snapshot: snapshot, position: position, id: id) },
             sceneryView: sceneryView
         )
@@ -223,17 +220,6 @@ struct InkScrollView: View {
                 expandedSnapshot = snapshot
             }
         }
-    }
-
-    // MARK: - Newest dot ring
-
-    private func newestDotEffects(snapshot: WalkSnapshot) -> some View {
-        let color = dotSeasonalColor(for: snapshot)
-        return ZStack {
-            BreathingPulseView(color: color)
-            SonarRingView(color: color)
-        }
-        .allowsHitTesting(false)
     }
 
     private func dotSeasonalColor(for snapshot: WalkSnapshot) -> Color {
@@ -685,6 +671,7 @@ struct InkScrollView: View {
                 snapshot: snap,
                 position: .zero,
                 opacity: 1,
+                isNewest: false,
                 onTap: { _ in },
                 sceneryView: nil
             )
@@ -697,7 +684,7 @@ struct InkScrollView: View {
 
 }
 
-private struct BreathingPulseView: View {
+struct BreathingPulseView: View {
     let color: Color
 
     var body: some View {
@@ -712,7 +699,7 @@ private struct BreathingPulseView: View {
     }
 }
 
-private struct SonarRingView: View {
+struct SonarRingView: View {
     let color: Color
 
     var body: some View {

--- a/Pilgrim/Scenes/Home/InkScrollView.swift
+++ b/Pilgrim/Scenes/Home/InkScrollView.swift
@@ -105,9 +105,10 @@ struct InkScrollView: View {
                     opacity: opacity,
                     sceneryView: scenery
                 )
-                .background {
+                .overlay {
                     if isNewest {
                         newestDotEffects(snapshot: snapshot)
+                            .frame(width: 60, height: 60)
                     }
                 }
                 .opacity(hasAppeared ? 1 : 0)

--- a/Pilgrim/Scenes/Home/InkScrollView.swift
+++ b/Pilgrim/Scenes/Home/InkScrollView.swift
@@ -683,33 +683,3 @@ struct InkScrollView: View {
     }
 
 }
-
-struct BreathingPulseView: View {
-    let color: Color
-
-    var body: some View {
-        Circle()
-            .fill(color.opacity(0.08))
-            .frame(width: 50, height: 50)
-            .phaseAnimator([false, true]) { content, phase in
-                content
-                    .scaleEffect(phase ? 1.3 : 1.0)
-                    .opacity(phase ? 0.0 : 0.15)
-            } animation: { _ in .easeInOut(duration: 2.5) }
-    }
-}
-
-struct SonarRingView: View {
-    let color: Color
-
-    var body: some View {
-        Circle()
-            .stroke(color, lineWidth: 1.5)
-            .frame(width: 28, height: 28)
-            .phaseAnimator([false, true]) { content, phase in
-                content
-                    .scaleEffect(phase ? 2.0 : 1.0)
-                    .opacity(phase ? 0 : 0.5)
-            } animation: { _ in .easeOut(duration: 2.0) }
-    }
-}

--- a/Pilgrim/Scenes/Home/WalkDotView.swift
+++ b/Pilgrim/Scenes/Home/WalkDotView.swift
@@ -193,7 +193,7 @@ private struct RippleEffectView: View {
                 .stroke(color.opacity(0.15), lineWidth: 1.5)
                 .frame(width: dotSize + 16, height: dotSize + 16)
         } else {
-            TimelineView(.animation(minimumInterval: 1.0 / 20)) { timeline in
+            TimelineView(.animation(minimumInterval: 1.0 / 10)) { timeline in
                 let time = timeline.date.timeIntervalSinceReferenceDate
                 Canvas { context, size in
                     let center = CGPoint(x: size.width / 2, y: size.height / 2)

--- a/Pilgrim/Scenes/Home/WalkDotView.swift
+++ b/Pilgrim/Scenes/Home/WalkDotView.swift
@@ -5,6 +5,7 @@ struct WalkDotView: View {
     let snapshot: WalkSnapshot
     let position: CGPoint
     let opacity: Double
+    let isNewest: Bool
     let onTap: (UUID) -> Void
     let sceneryView: AnyView?
 
@@ -15,6 +16,11 @@ struct WalkDotView: View {
         let size = dotSize
 
         ZStack {
+            if isNewest {
+                BreathingPulseView(color: dotColor)
+                SonarRingView(color: dotColor)
+            }
+
             if let scenery = sceneryView {
                 scenery
             }

--- a/Pilgrim/Scenes/Home/WalkDotView.swift
+++ b/Pilgrim/Scenes/Home/WalkDotView.swift
@@ -17,8 +17,7 @@ struct WalkDotView: View {
 
         ZStack {
             if isNewest {
-                BreathingPulseView(color: dotColor)
-                SonarRingView(color: dotColor)
+                RippleEffectView(color: dotColor, dotSize: size)
             }
 
             if let scenery = sceneryView {
@@ -178,5 +177,61 @@ struct WalkDotView: View {
         let m = (total % 3600) / 60
         if h > 0 { return "\(h)h \(m)m" }
         return "\(m)m"
+    }
+}
+
+// MARK: - Ripple Effect (TimelineView-based, no phaseAnimator)
+
+private struct RippleEffectView: View {
+
+    let color: Color
+    let dotSize: CGFloat
+
+    var body: some View {
+        if UIAccessibility.isReduceMotionEnabled {
+            Circle()
+                .stroke(color.opacity(0.15), lineWidth: 1.5)
+                .frame(width: dotSize + 16, height: dotSize + 16)
+        } else {
+            TimelineView(.animation(minimumInterval: 1.0 / 20)) { timeline in
+                let time = timeline.date.timeIntervalSinceReferenceDate
+                Canvas { context, size in
+                    let center = CGPoint(x: size.width / 2, y: size.height / 2)
+
+                    for i in 0..<2 {
+                        let phase = (time * 0.4 + Double(i) * 0.5)
+                            .truncatingRemainder(dividingBy: 1.0)
+                        let radius = dotSize * 0.5 + phase * dotSize * 1.2
+                        let opacity = (1.0 - phase) * 0.2
+                        let rect = CGRect(
+                            x: center.x - radius,
+                            y: center.y - radius,
+                            width: radius * 2,
+                            height: radius * 2
+                        )
+                        context.stroke(
+                            Circle().path(in: rect),
+                            with: .color(color.opacity(opacity)),
+                            lineWidth: 1.5 * (1.0 - phase * 0.5)
+                        )
+                    }
+
+                    let breathPhase = sin(time * 1.2) * 0.5 + 0.5
+                    let glowRadius = dotSize * 1.5
+                    let glowRect = CGRect(
+                        x: center.x - glowRadius,
+                        y: center.y - glowRadius,
+                        width: glowRadius * 2,
+                        height: glowRadius * 2
+                    )
+                    context.fill(
+                        Circle().path(in: glowRect),
+                        with: .color(color.opacity(0.04 + breathPhase * 0.04))
+                    )
+                }
+                .frame(width: dotSize * 4, height: dotSize * 4)
+            }
+            .allowsHitTesting(false)
+        }
     }
 }

--- a/Pilgrim/Scenes/Prompts/PromptListView.swift
+++ b/Pilgrim/Scenes/Prompts/PromptListView.swift
@@ -147,7 +147,8 @@ struct PromptListView: View {
                 routeSpeeds: routeSpeeds,
                 recentWalkSnippets: recentWalkSnippets,
                 intention: intention,
-                waypoints: waypointContexts
+                waypoints: waypointContexts,
+                weather: PromptGenerator.formatWeather(walk)
             )
             regenerateCustomPrompts()
         }
@@ -223,7 +224,8 @@ struct PromptListView: View {
                 routeSpeeds: routeSpeeds,
                 recentWalkSnippets: recentWalkSnippets,
                 intention: intention,
-                waypoints: waypointContexts
+                waypoints: waypointContexts,
+                weather: PromptGenerator.formatWeather(walk)
             )
         }
     }

--- a/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
@@ -186,7 +186,9 @@ final class WalkShareViewModel: ObservableObject {
             elevationDescent: toggleElevation ? walk.descend : nil,
             steps: toggleSteps ? walk.steps : nil,
             meditateDuration: toggleActivityBreakdown ? walk.meditateDuration : nil,
-            talkDuration: toggleActivityBreakdown ? walk.talkDuration : nil
+            talkDuration: toggleActivityBreakdown ? walk.talkDuration : nil,
+            weatherCondition: walk.weatherCondition,
+            weatherTemperature: walk.weatherTemperature
         )
 
         let formatter = ISO8601DateFormatter()

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
@@ -53,6 +53,7 @@ struct WalkSummaryView: View {
                         milestoneCallout(milestone)
                     }
                     statsRow
+                    weatherLine
                     timeBreakdown
                     FaviconSelectorView(selection: $selectedFavicon)
                         .onChange(of: selectedFavicon) { _, newValue in
@@ -400,6 +401,25 @@ struct WalkSummaryView: View {
                 .foregroundColor(.fog)
         }
         .frame(maxWidth: .infinity)
+    }
+
+    @ViewBuilder
+    private var weatherLine: some View {
+        if let condStr = walk.weatherCondition,
+           let cond = WeatherCondition(rawValue: condStr),
+           let temp = walk.weatherTemperature {
+            let imperial = UserPreferences.distanceMeasurementType.safeValue == .miles
+            let snapshot = WeatherSnapshot(condition: cond, temperature: temp, humidity: 0, windSpeed: 0)
+            HStack(spacing: Constants.UI.Padding.xs) {
+                Image(systemName: cond.icon)
+                    .font(.system(size: 12))
+                Text("\(cond.label), \(snapshot.formattedTemperature(imperial: imperial))")
+                    .font(Constants.Typography.caption)
+            }
+            .foregroundColor(.fog)
+            .opacity(revealPhase == .revealed ? 1 : 0)
+            .animation(.easeIn(duration: 0.6).delay(0.2), value: revealPhase)
+        }
     }
 
     private var timeBreakdown: some View {

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
@@ -409,11 +409,11 @@ struct WalkSummaryView: View {
            let cond = WeatherCondition(rawValue: condStr),
            let temp = walk.weatherTemperature {
             let imperial = UserPreferences.distanceMeasurementType.safeValue == .miles
-            let snapshot = WeatherSnapshot(condition: cond, temperature: temp, humidity: 0, windSpeed: 0)
+            let tempStr = imperial ? String(format: "%.0f°F", temp * 9 / 5 + 32) : String(format: "%.0f°C", temp)
             HStack(spacing: Constants.UI.Padding.xs) {
                 Image(systemName: cond.icon)
-                    .font(.system(size: 12))
-                Text("\(cond.label), \(snapshot.formattedTemperature(imperial: imperial))")
+                    .font(Constants.Typography.caption)
+                Text("\(cond.label), \(tempStr)")
                     .font(Constants.Typography.caption)
             }
             .foregroundColor(.fog)

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
@@ -160,7 +160,7 @@ struct WalkSummaryView: View {
                     .compactMap { $0.transcription }
                     .joined(separator: " ")
                 let preview = allText.truncatedAtWordBoundary()
-                return PromptGenerator.WalkSnippet(date: w.startDate, placeName: nil, transcriptionPreview: preview)
+                return PromptGenerator.WalkSnippet(date: w.startDate, placeName: nil, transcriptionPreview: preview, weatherCondition: w.weatherCondition)
             }
     }
 

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
@@ -409,11 +409,10 @@ struct WalkSummaryView: View {
            let cond = WeatherCondition(rawValue: condStr),
            let temp = walk.weatherTemperature {
             let imperial = UserPreferences.distanceMeasurementType.safeValue == .miles
-            let tempStr = imperial ? String(format: "%.0f°F", temp * 9 / 5 + 32) : String(format: "%.0f°C", temp)
             HStack(spacing: Constants.UI.Padding.xs) {
                 Image(systemName: cond.icon)
                     .font(Constants.Typography.caption)
-                Text("\(cond.label), \(tempStr)")
+                Text("\(cond.label), \(WeatherSnapshot.formatTemperature(temp, imperial: imperial))")
                     .font(Constants.Typography.caption)
             }
             .foregroundColor(.fog)

--- a/docs/superpowers/plans/2026-03-18-weatherkit-integration.md
+++ b/docs/superpowers/plans/2026-03-18-weatherkit-integration.md
@@ -1,0 +1,650 @@
+# WeatherKit Integration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fetch real-time weather at walk start via Apple WeatherKit, display it as atmospheric overlay + vignette on the active walk screen, persist it with the walk, and feed it into AI prompt context.
+
+**Architecture:** WeatherService singleton fetches current conditions → WeatherSnapshot stored on ActiveWalkViewModel → visual layer reads snapshot for overlay/vignette → snapshot persisted to existing DB weather fields (dormant since V1) via WalkInterface/TempWalk/DataManager plumbing → PromptGenerator reads weather for AI context.
+
+**Tech Stack:** WeatherKit (system framework), SwiftUI Canvas (particles), CoreStore (existing ORM), CoreLocation (existing)
+
+**Spec:** `docs/superpowers/specs/2026-03-18-weatherkit-integration-design.md`
+
+**Key discovery:** The DB already has weather fields on the Workout entity since PilgrimV1 (`_weatherCondition`, `_weatherTemperature`, `_weatherHumidity`, `_weatherWindSpeed`) — inherited from OutRun but never populated. No migration needed. We just need to wire them up.
+
+---
+
+### Task 1: WeatherService + WeatherSnapshot + WeatherCondition
+
+**Files:**
+- Create: `Pilgrim/Models/Weather/WeatherService.swift`
+
+- [ ] **Step 1: Create the Weather directory**
+
+```bash
+mkdir -p Pilgrim/Models/Weather
+```
+
+- [ ] **Step 2: Create WeatherService.swift with WeatherCondition enum, WeatherSnapshot struct, and service**
+
+```swift
+import Foundation
+import WeatherKit
+import CoreLocation
+
+enum WeatherCondition: String, Codable {
+    case clear, partlyCloudy, overcast
+    case lightRain, heavyRain, thunderstorm
+    case snow, fog, wind, haze
+
+    var icon: String {
+        switch self {
+        case .clear: return "sun.max.fill"
+        case .partlyCloudy: return "cloud.sun.fill"
+        case .overcast: return "cloud.fill"
+        case .lightRain: return "cloud.drizzle.fill"
+        case .heavyRain: return "cloud.heavyrain.fill"
+        case .thunderstorm: return "cloud.bolt.fill"
+        case .snow: return "cloud.snow.fill"
+        case .fog: return "cloud.fog.fill"
+        case .wind: return "wind"
+        case .haze: return "sun.haze.fill"
+        }
+    }
+
+    var label: String {
+        switch self {
+        case .clear: return "Clear"
+        case .partlyCloudy: return "Partly cloudy"
+        case .overcast: return "Overcast"
+        case .lightRain: return "Light rain"
+        case .heavyRain: return "Heavy rain"
+        case .thunderstorm: return "Thunderstorm"
+        case .snow: return "Snow"
+        case .fog: return "Foggy"
+        case .wind: return "Windy"
+        case .haze: return "Hazy"
+        }
+    }
+}
+
+struct WeatherSnapshot: Codable {
+    let condition: WeatherCondition
+    let temperature: Double
+    let humidity: Double
+    let windSpeed: Double
+
+    var description: String {
+        let tempStr = String(format: "%.0f", temperature)
+        return "\(condition.label), \(tempStr)°C"
+    }
+
+    func formattedTemperature(imperial: Bool) -> String {
+        if imperial {
+            return String(format: "%.0f°F", temperature * 9 / 5 + 32)
+        }
+        return String(format: "%.0f°C", temperature)
+    }
+}
+
+final class WeatherService {
+
+    static let shared = WeatherService()
+    private let service = WeatherKit.WeatherService.shared
+    private init() {}
+
+    func fetchCurrent(for location: CLLocation) async -> WeatherSnapshot? {
+        do {
+            let weather = try await service.weather(for: location, including: .current)
+            let condition = mapCondition(weather.condition, windSpeed: weather.wind.speed.converted(to: .metersPerSecond).value)
+            return WeatherSnapshot(
+                condition: condition,
+                temperature: weather.temperature.converted(to: .celsius).value,
+                humidity: weather.humidity,
+                windSpeed: weather.wind.speed.converted(to: .metersPerSecond).value
+            )
+        } catch {
+            print("[WeatherService] Failed to fetch weather: \(error.localizedDescription)")
+            return nil
+        }
+    }
+
+    private func mapCondition(_ condition: WeatherKit.WeatherCondition, windSpeed: Double) -> WeatherCondition {
+        if windSpeed > 10 { return .wind }
+
+        switch condition {
+        case .clear, .mostlyClear, .hot:
+            return .clear
+        case .partlyCloudy:
+            return .partlyCloudy
+        case .cloudy, .mostlyCloudy:
+            return .overcast
+        case .drizzle:
+            return .lightRain
+        case .rain:
+            return windSpeed > 5 ? .heavyRain : .lightRain
+        case .heavyRain:
+            return .heavyRain
+        case .thunderstorms, .tropicalStorm, .hurricane, .isolatedThunderstorms, .scatteredThunderstorms, .strongStorms:
+            return .thunderstorm
+        case .snow, .flurries, .sleet, .freezingRain, .blizzard, .heavySnow, .freezingDrizzle, .blowingSnow, .wintryMix:
+            return .snow
+        case .foggy:
+            return .fog
+        case .windy, .breezy:
+            return .wind
+        case .haze, .smoky, .blowingDust:
+            return .haze
+        @unknown default:
+            return .clear
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Add file to Xcode project and build**
+
+Add `WeatherService.swift` to the Pilgrim target in `project.pbxproj`.
+
+Run: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 4: Commit**
+
+```
+git add Pilgrim/Models/Weather/WeatherService.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat: add WeatherService with WeatherKit integration"
+```
+
+---
+
+### Task 2: Data plumbing — WalkInterface, TempWalk, DataManager, NewWalk, SessionGuard
+
+**Files:**
+- Modify: `Pilgrim/Protocols/DataInterfaces/WalkInterface.swift`
+- Modify: `Pilgrim/Models/Data/Temp/Versions/TempV4.swift`
+- Modify: `Pilgrim/Models/Data/DataManager.swift`
+- Modify: `Pilgrim/Models/Data/NewWalk.swift`
+- Modify: `Pilgrim/Models/Walk/WalkSessionGuard.swift`
+
+- [ ] **Step 1: Add weather properties to WalkInterface protocol**
+
+In `WalkInterface.swift`, add after the existing properties (near `var waypoints`):
+
+```swift
+var weatherCondition: String? { get }
+var weatherTemperature: Double? { get }
+var weatherHumidity: Double? { get }
+var weatherWindSpeed: Double? { get }
+```
+
+And add default `throwOnAccess()` implementations in the default extension at the bottom of the file.
+
+- [ ] **Step 2: Add weather fields to TempV4.Workout**
+
+In `Pilgrim/Models/Data/Temp/Versions/TempV4.swift`, add to the `Workout` class:
+
+Properties (after `favicon`):
+```swift
+public var weatherCondition: String?
+public var weatherTemperature: Double?
+public var weatherHumidity: Double?
+public var weatherWindSpeed: Double?
+```
+
+Add to the `init` parameter list:
+```swift
+weatherCondition: String? = nil, weatherTemperature: Double? = nil, weatherHumidity: Double? = nil, weatherWindSpeed: Double? = nil
+```
+
+Add to init body:
+```swift
+self.weatherCondition = weatherCondition
+self.weatherTemperature = weatherTemperature
+self.weatherHumidity = weatherHumidity
+self.weatherWindSpeed = weatherWindSpeed
+```
+
+Add to `CodingKeys`:
+```swift
+case weatherCondition, weatherTemperature, weatherHumidity, weatherWindSpeed
+```
+
+Add to `init(from decoder:)`:
+```swift
+weatherCondition = try container.decodeIfPresent(String.self, forKey: .weatherCondition)
+weatherTemperature = try container.decodeIfPresent(Double.self, forKey: .weatherTemperature)
+weatherHumidity = try container.decodeIfPresent(Double.self, forKey: .weatherHumidity)
+weatherWindSpeed = try container.decodeIfPresent(Double.self, forKey: .weatherWindSpeed)
+```
+
+- [ ] **Step 3: Write weather fields in DataManager.saveWalk**
+
+In `DataManager.swift`, inside the `for object in validatedObjects` loop (after line 212 `walk._favicon .= object.favicon`), add:
+
+```swift
+walk._weatherCondition .= object.weatherCondition
+walk._weatherTemperature .= object.weatherTemperature
+walk._weatherHumidity .= object.weatherHumidity
+walk._weatherWindSpeed .= object.weatherWindSpeed
+```
+
+- [ ] **Step 4: Add weather params to NewWalk init**
+
+In `NewWalk.swift`, add weather parameters to the `init`:
+
+```swift
+weatherCondition: String? = nil, weatherTemperature: Double? = nil, weatherHumidity: Double? = nil, weatherWindSpeed: Double? = nil
+```
+
+Pass them through to `super.init(...)` by setting them after the super.init call:
+```swift
+self.weatherCondition = weatherCondition
+self.weatherTemperature = weatherTemperature
+self.weatherHumidity = weatherHumidity
+self.weatherWindSpeed = weatherWindSpeed
+```
+
+- [ ] **Step 5: Include weather in session guard recovery**
+
+In `WalkSessionGuard.swift`, in the recovery `NewWalk(...)` constructor call, add:
+
+```swift
+weatherCondition: walk.weatherCondition,
+weatherTemperature: walk.weatherTemperature,
+weatherHumidity: walk.weatherHumidity,
+weatherWindSpeed: walk.weatherWindSpeed
+```
+
+- [ ] **Step 6: Build and commit**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build`
+
+```
+git add -A
+git commit -m "feat: wire weather fields through data layer
+
+Add weather properties to WalkInterface, TempV4.Workout, NewWalk,
+DataManager save path, and session guard recovery. DB fields existed
+since V1 but were never populated."
+```
+
+---
+
+### Task 3: ActiveWalkViewModel — fetch weather at walk start
+
+**Files:**
+- Modify: `Pilgrim/Scenes/ActiveWalk/ActiveWalkViewModel.swift`
+
+- [ ] **Step 1: Add weather state and fetch on init**
+
+Add published property:
+```swift
+@Published var weatherSnapshot: WeatherSnapshot?
+```
+
+Add a method to fetch weather:
+```swift
+func fetchWeather() {
+    guard let location = locationManagement.locationManager.location else { return }
+    Task {
+        let snapshot = await WeatherService.shared.fetchCurrent(for: location)
+        await MainActor.run {
+            self.weatherSnapshot = snapshot
+        }
+    }
+}
+```
+
+Call `fetchWeather()` at the end of the view model's `init` (or from a `.task` in the view after location is available).
+
+- [ ] **Step 2: Pass weather to snapshot on walk completion**
+
+In the `WalkBuilder.createSnapshot()` flow or wherever `NewWalk` is constructed, pass the weather fields:
+
+```swift
+weatherCondition: weatherSnapshot?.condition.rawValue,
+weatherTemperature: weatherSnapshot?.temperature,
+weatherHumidity: weatherSnapshot?.humidity,
+weatherWindSpeed: weatherSnapshot?.windSpeed
+```
+
+- [ ] **Step 3: Build and commit**
+
+```
+git add Pilgrim/Scenes/ActiveWalk/ActiveWalkViewModel.swift
+git commit -m "feat: fetch weather at walk start via WeatherService"
+```
+
+---
+
+### Task 4: Weather visual layer — overlay + vignette
+
+**Files:**
+- Create: `Pilgrim/Models/Weather/WeatherOverlayView.swift`
+- Create: `Pilgrim/Models/Weather/WeatherVignetteView.swift`
+- Modify: `Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift`
+
+- [ ] **Step 1: Create WeatherOverlayView**
+
+```swift
+import SwiftUI
+
+struct WeatherOverlayView: View {
+
+    let condition: WeatherCondition?
+
+    var body: some View {
+        ZStack {
+            switch condition {
+            case .clear:
+                Color.orange.opacity(0.01)
+            case .partlyCloudy:
+                cloudOverlay(opacity: 0.03)
+            case .overcast:
+                Color.gray.opacity(0.02)
+            case .lightRain:
+                Color(.systemBlue).opacity(0.01)
+                    .overlay { rainParticles(density: 20, speed: 1.0) }
+            case .heavyRain:
+                Color(.systemBlue).opacity(0.02)
+                    .overlay { rainParticles(density: 40, speed: 1.5) }
+            case .thunderstorm:
+                Color.ink.opacity(0.03)
+                    .overlay { lightningFlash }
+            case .snow:
+                Color(.systemCyan).opacity(0.01)
+                    .overlay { snowParticles }
+            case .fog:
+                RadialGradient(
+                    colors: [Color.white.opacity(0.04), Color.white.opacity(0.01)],
+                    center: .center, startRadius: 50, endRadius: 300
+                )
+            case .wind:
+                windStreaks
+            case .haze:
+                Color.brown.opacity(0.02)
+            case nil:
+                Color.clear
+            }
+        }
+        .allowsHitTesting(false)
+        .accessibilityHidden(true)
+    }
+
+    // Rain: diagonal falling lines using Canvas
+    private func rainParticles(density: Int, speed: Double) -> some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 20.0)) { timeline in
+            Canvas { context, size in
+                let time = timeline.date.timeIntervalSinceReferenceDate * speed
+                for i in 0..<density {
+                    let seed = Double(i) * 137.508
+                    let x = (seed.truncatingRemainder(dividingBy: size.width))
+                    let rawY = (time * 80 + seed * 3).truncatingRemainder(dividingBy: size.height + 20) - 10
+                    let y = rawY < 0 ? rawY + size.height + 20 : rawY
+                    var path = Path()
+                    path.move(to: CGPoint(x: x, y: y))
+                    path.addLine(to: CGPoint(x: x - 2, y: y + 12))
+                    context.stroke(path, with: .color(.ink.opacity(0.03)), lineWidth: 0.5)
+                }
+            }
+        }
+    }
+
+    // Snow: gentle falling dots
+    private var snowParticles: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 15.0)) { timeline in
+            Canvas { context, size in
+                let time = timeline.date.timeIntervalSinceReferenceDate
+                for i in 0..<25 {
+                    let seed = Double(i) * 97.31
+                    let x = (seed.truncatingRemainder(dividingBy: size.width)) + sin(time * 0.5 + seed) * 10
+                    let y = (time * 20 + seed * 5).truncatingRemainder(dividingBy: size.height + 10)
+                    let r = 1.0 + (seed.truncatingRemainder(dividingBy: 2))
+                    let rect = CGRect(x: x - r, y: y - r, width: r * 2, height: r * 2)
+                    context.fill(Circle().path(in: rect), with: .color(.white.opacity(0.04)))
+                }
+            }
+        }
+    }
+
+    // Cloud: drifting soft shapes
+    private func cloudOverlay(opacity: Double) -> some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 10.0)) { timeline in
+            Canvas { context, size in
+                let time = timeline.date.timeIntervalSinceReferenceDate
+                for i in 0..<3 {
+                    let seed = Double(i) * 200
+                    let x = (time * 3 + seed).truncatingRemainder(dividingBy: size.width + 200) - 100
+                    let y = 50 + seed.truncatingRemainder(dividingBy: size.height * 0.4)
+                    let w = 120 + seed.truncatingRemainder(dividingBy: 80)
+                    let rect = CGRect(x: x, y: y, width: w, height: 40)
+                    context.fill(Ellipse().path(in: rect), with: .color(.fog.opacity(opacity)))
+                }
+            }
+        }
+    }
+
+    // Lightning: brief flash every 8-15s
+    private var lightningFlash: some View {
+        TimelineView(.animation(minimumInterval: 0.1)) { timeline in
+            let time = timeline.date.timeIntervalSinceReferenceDate
+            let cycle = time.truncatingRemainder(dividingBy: 12)
+            let flash = cycle > 11.8 && cycle < 11.9
+            Color.white.opacity(flash ? 0.06 : 0)
+        }
+    }
+
+    // Wind: fast diagonal streaks
+    private var windStreaks: some View {
+        TimelineView(.animation(minimumInterval: 1.0 / 20.0)) { timeline in
+            Canvas { context, size in
+                let time = timeline.date.timeIntervalSinceReferenceDate
+                for i in 0..<12 {
+                    let seed = Double(i) * 73.7
+                    let x = (time * 120 + seed * 20).truncatingRemainder(dividingBy: size.width + 100) - 50
+                    let y = seed.truncatingRemainder(dividingBy: size.height)
+                    var path = Path()
+                    path.move(to: CGPoint(x: x, y: y))
+                    path.addLine(to: CGPoint(x: x + 30, y: y - 2))
+                    context.stroke(path, with: .color(.fog.opacity(0.03)), lineWidth: 0.5)
+                }
+            }
+        }
+    }
+}
+```
+
+For reduce motion: wrap `TimelineView` content in a check — if reduce motion, show only the static color tint.
+
+- [ ] **Step 2: Create WeatherVignetteView**
+
+```swift
+import SwiftUI
+
+struct WeatherVignetteView: View {
+
+    let snapshot: WeatherSnapshot?
+    let imperial: Bool
+    @State private var expanded = false
+
+    var body: some View {
+        if let snapshot {
+            Button {
+                withAnimation(.spring(duration: 0.3)) { expanded.toggle() }
+            } label: {
+                HStack(spacing: Constants.UI.Padding.xs) {
+                    Image(systemName: snapshot.condition.icon)
+                        .font(.system(size: 12))
+                    Text(snapshot.formattedTemperature(imperial: imperial))
+                        .font(Constants.Typography.caption)
+                    if expanded {
+                        Text("·")
+                            .foregroundColor(.fog.opacity(0.3))
+                        Text("\(Int(snapshot.humidity * 100))%")
+                            .font(Constants.Typography.caption)
+                        Text("·")
+                            .foregroundColor(.fog.opacity(0.3))
+                        Text(formatWind(snapshot.windSpeed))
+                            .font(Constants.Typography.caption)
+                    }
+                }
+                .foregroundColor(.fog)
+                .padding(.horizontal, Constants.UI.Padding.small)
+                .padding(.vertical, Constants.UI.Padding.xs)
+                .background(
+                    Capsule().fill(.ultraThinMaterial)
+                )
+            }
+            .buttonStyle(.plain)
+        }
+    }
+
+    private func formatWind(_ speed: Double) -> String {
+        switch speed {
+        case ..<2: return "calm"
+        case 2..<5: return "gentle"
+        case 5..<10: return "moderate"
+        case 10..<15: return "strong"
+        default: return "very strong"
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Add overlay + vignette to ActiveWalkView**
+
+In `ActiveWalkView.swift`, add the overlay behind the content (inside the main ZStack) and the vignette near the map/stats area. The overlay goes at the back of the ZStack, the vignette near the audio indicators.
+
+- [ ] **Step 4: Add new files to Xcode project, build and commit**
+
+```
+git add -A
+git commit -m "feat: weather overlay and vignette on active walk screen
+
+Atmospheric overlay renders rain/snow/fog/wind particles via Canvas.
+Compact vignette shows condition icon + temperature, tappable to
+expand with humidity and wind."
+```
+
+---
+
+### Task 5: Prompt integration
+
+**Files:**
+- Modify: `Pilgrim/Models/PromptGenerator.swift`
+
+- [ ] **Step 1: Add formatWeather method**
+
+Add a new static method to `PromptGenerator`:
+
+```swift
+private static func formatWeather(_ walk: WalkInterface) -> String? {
+    guard let conditionStr = walk.weatherCondition,
+          let condition = WeatherCondition(rawValue: conditionStr),
+          let temp = walk.weatherTemperature else { return nil }
+
+    var parts = ["\(condition.label)", String(format: "%.0f°C", temp)]
+
+    if let humidity = walk.weatherHumidity {
+        parts.append("humidity \(Int(humidity * 100))%")
+    }
+
+    if let wind = walk.weatherWindSpeed {
+        let desc: String
+        switch wind {
+        case ..<2: desc = "calm"
+        case 2..<5: desc = "gentle breeze"
+        case 5..<10: desc = "moderate wind"
+        case 10..<15: desc = "strong wind"
+        default: desc = "very strong wind"
+        }
+        parts.append(desc)
+    }
+
+    return "Weather: \(parts.joined(separator: ", "))"
+}
+```
+
+- [ ] **Step 2: Add weather to buildPrompt**
+
+In `buildPrompt()` or `formatMetadata()`, add after the lunar phase line:
+
+```swift
+if let weather = formatWeather(walk) {
+    sections.append(weather)
+}
+```
+
+- [ ] **Step 3: Build and commit**
+
+```
+git add Pilgrim/Models/PromptGenerator.swift
+git commit -m "feat: add weather context to AI prompt generation"
+```
+
+---
+
+### Task 6: Walk summary weather display
+
+**Files:**
+- Modify: `Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift`
+
+- [ ] **Step 1: Add weather line to summary stats**
+
+Find the stats section in WalkSummaryView and add a weather line (condition icon + description) when weather data exists:
+
+```swift
+if let condStr = walk.weatherCondition,
+   let cond = WeatherCondition(rawValue: condStr),
+   let temp = walk.weatherTemperature {
+    let imperial = UserPreferences.distanceMeasurementType.safeValue == .miles
+    HStack(spacing: Constants.UI.Padding.xs) {
+        Image(systemName: cond.icon)
+            .font(.system(size: 12))
+        Text(WeatherSnapshot(condition: cond, temperature: temp, humidity: walk.weatherHumidity ?? 0, windSpeed: walk.weatherWindSpeed ?? 0).formattedTemperature(imperial: imperial))
+            .font(Constants.Typography.caption)
+        Text(cond.label)
+            .font(Constants.Typography.caption)
+    }
+    .foregroundColor(.fog)
+}
+```
+
+- [ ] **Step 2: Build and commit**
+
+```
+git add Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+git commit -m "feat: display weather in walk summary stats"
+```
+
+---
+
+### Task 7: Verification
+
+- [ ] **Step 1: Build full project**
+
+Run: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build`
+
+- [ ] **Step 2: Test on physical device** (requires WeatherKit provisioning)
+
+1. Start a walk → weather overlay should appear, vignette shows temp + icon
+2. Tap vignette → expands to show humidity + wind
+3. End walk → summary shows weather line
+4. Generate prompts → weather section present in prompt text
+
+- [ ] **Step 3: Test offline**
+
+1. Enable airplane mode → start walk → no weather visuals, no crash
+2. Walk completes normally, summary has no weather line
+
+- [ ] **Step 4: Test reduce motion**
+
+1. Enable Accessibility → Reduce Motion
+2. Start walk → overlay shows static tint only (no particles)
+3. Vignette still functional
+
+- [ ] **Step 5: Test session guard**
+
+1. Start walk with weather → force-quit app → relaunch
+2. Recovered walk should include weather data

--- a/docs/superpowers/specs/2026-03-18-weatherkit-integration-design.md
+++ b/docs/superpowers/specs/2026-03-18-weatherkit-integration-design.md
@@ -1,0 +1,194 @@
+# WeatherKit Integration Design
+
+## Context
+
+Pilgrim already responds to time-of-day (background tinting) and season (scenery colors, animations). Weather is the missing third dimension. With the Apple Developer Program now enrolled and WeatherKit capability enabled, we can fetch real-time weather and weave it into the active walk experience, post-walk summary, and AI prompt context.
+
+Weather appears on the **active walk screen** (not the path/home screen) because GPS is already active there, giving us location for free. No extra permission needed.
+
+## Architecture Overview
+
+Three layers, all additive:
+
+1. **WeatherService** — fetches current conditions via WeatherKit, returns a lightweight snapshot
+2. **Visual layer** — atmospheric overlay + weather vignette on the active walk screen
+3. **Data layer** — weather persisted with each walk, fed to prompt generator
+
+## 1. WeatherService
+
+**New file:** `Pilgrim/Models/Weather/WeatherService.swift`
+
+Singleton wrapping Apple's `WeatherKit` framework.
+
+```
+WeatherService.shared.fetchCurrent(for: CLLocation) async → WeatherSnapshot?
+```
+
+**WeatherSnapshot** — lightweight Codable struct:
+- `condition`: `WeatherCondition` enum (clear, partlyCloudy, overcast, lightRain, heavyRain, thunderstorm, snow, fog, wind, haze)
+- `temperature`: Double (Celsius)
+- `humidity`: Double (0–1)
+- `windSpeed`: Double (m/s)
+- `windDirection`: Double (degrees, 0–360)
+- `uvIndex`: Int
+- `visibility`: Double (meters)
+- `cloudCover`: Double (0–1)
+- `precipitationIntensity`: Double (mm/hr)
+- `description`: String (human-readable, e.g. "Light rain, 14°C")
+
+**WeatherCondition** enum maps from Apple's `WeatherKit.WeatherCondition`:
+- `.clear` ← clear, mostlyClear, hot
+- `.partlyCloudy` ← partlyCloudy
+- `.overcast` ← cloudy, mostlyCloudy
+- `.lightRain` ← drizzle, rain (low intensity)
+- `.heavyRain` ← heavyRain, rain (high intensity)
+- `.thunderstorm` ← thunderstorms, tropicalStorm, hurricane
+- `.snow` ← snow, flurries, sleet, freezingRain, blizzard, heavySnow
+- `.fog` ← foggy
+- `.wind` ← windy, breezy (or wind speed > 10 m/s regardless of condition)
+- `.haze` ← haze, smoky, blowingDust
+
+**Error handling:** Returns nil on any failure (no network, WeatherKit unavailable, location unavailable). Never blocks walk start. Fire-and-forget async call.
+
+**Caching:** Result cached for the session. One fetch per walk, at walk start.
+
+## 2. Data Persistence
+
+**New migration:** PilgrimV7 extending the Walk entity with optional weather fields.
+
+New fields on Workout entity (all optional):
+- `_weatherCondition`: String? (raw value of WeatherCondition enum)
+- `_weatherTemperature`: Double? (Celsius)
+- `_weatherHumidity`: Double?
+- `_weatherWindSpeed`: Double?
+- `_weatherWindDirection`: Double?
+- `_weatherUVIndex`: Int16?
+- `_weatherVisibility`: Double?
+- `_weatherCloudCover`: Double?
+
+All optional — walks without weather (offline, pre-update, pre-V7) simply have nil. No separate entity needed; weather is a property of the walk, not a standalone object.
+
+**Save flow:**
+1. Walk starts → `ActiveWalkViewModel` calls `WeatherService.fetchCurrent(for: location)`
+2. Result stored as `@Published var weatherSnapshot: WeatherSnapshot?` on the view model
+3. At walk completion, snapshot fields written into `NewWalk` and saved to DB
+4. Session guard checkpoint includes weather fields (so crash recovery preserves weather)
+
+**TempWalk extension:** Add weather fields to `TempV4.Workout` for checkpoint serialization. Codable — encoded into existing checkpoint JSON.
+
+## 3. Active Walk Screen — Visual Layer
+
+Weather manifests as two visual layers on the active walk screen (Option C — Layered):
+
+### Atmospheric Overlay (mood layer)
+
+A subtle full-screen overlay behind the walk content. Very quiet — wabi-sabi, not a weather app.
+
+| Condition | Visual Treatment |
+|-----------|-----------------|
+| Clear | Warm golden tint intensified (+0.01 opacity on time-of-day gradient) |
+| Partly cloudy | Gentle drifting cloud shapes, opacity 0.03–0.05, slow lateral movement |
+| Overcast | Flat, desaturated tint, reduced contrast (subtle grey veil at 0.02 opacity) |
+| Light rain | Subtle falling particle lines (thin, 0.03 opacity, diagonal), cool blue-grey tint |
+| Heavy rain | Denser particles, darker tint (+0.02), very slight blur on edges |
+| Thunderstorm | Dark overlay (0.03), occasional brief opacity flash (lightning, every 8–15s random) |
+| Snow | Gentle falling dots (white, 0.04 opacity), cool blue-white tint |
+| Fog | Soft radial gradient overlay (white, 0.04 center → 0.01 edges), dreamy |
+| Wind | Diagonal particle streaks (fast, subtle), existing scenery sway amplified if present |
+| Haze | Warm golden-brown veil (0.02 opacity), slightly washed out |
+
+**Implementation:** New `WeatherOverlayView` — a SwiftUI view that takes `WeatherCondition?` and renders the appropriate overlay. Uses `Canvas` for particles (rain, snow) to avoid per-particle view overhead. Respects reduce-motion (static tint only, no particles).
+
+**Resource safety:** Particle animations use `TimelineView` at 20fps max. The overlay is removed when the walk ends. No accumulating state.
+
+### Weather Vignette (fact layer)
+
+A compact indicator showing current conditions. Positioned near the walk stats (map area or stats bar).
+
+- Condition SF Symbol icon (sun.max, cloud, cloud.rain, cloud.bolt, cloud.snow, cloud.fog, wind, sun.haze)
+- Temperature in user's preferred unit
+- Tappable to expand: shows humidity, wind, UV index
+- Uses app typography: `statValue` for temperature, `caption` for labels
+- Color: `fog` for icon/text, matching the understated aesthetic
+
+**Expand/collapse:** Tap toggles between compact (icon + temp) and expanded (icon + temp + humidity + wind + UV). Uses `.spring(duration: 0.3)` animation.
+
+## 4. Post-Walk Summary
+
+Weather displayed in the walk summary stats section:
+
+- One line: condition icon + "Light rain, 14°C" (or "57°F" for imperial users)
+- Positioned alongside distance, duration, pace
+- Only shown if weather data exists (nil = hidden, graceful for pre-update walks)
+- Uses `Constants.Typography.caption` and `Color.fog`
+
+Temperature unit follows `UserPreferences.distanceMeasurementType` — if imperial (miles), show Fahrenheit; if metric (km), show Celsius.
+
+## 5. Prompt Integration
+
+**New section in PromptGenerator:** `formatWeather(_ snapshot: WeatherSnapshot?) → String?`
+
+Output format:
+```
+Weather: Light rain, 14°C, humidity 82%, gentle breeze from the west (12 km/h)
+Visibility: 5.2 km, cloud cover 75%, UV index 2
+```
+
+Wind description uses cardinal directions and qualitative terms:
+- < 2 m/s: "calm"
+- 2–5 m/s: "gentle breeze"
+- 5–10 m/s: "moderate wind"
+- 10–15 m/s: "strong wind"
+- > 15 m/s: "very strong wind"
+
+Direction converted to cardinal: "from the north", "from the southwest", etc.
+
+Added to the existing metadata section in `buildPrompt()`, after time-of-day and lunar phase. Returns nil if no weather data — prompt continues without it.
+
+## 6. Offline / Error Handling
+
+- WeatherKit fetch fails → `weatherSnapshot` stays nil
+- No weather → no overlay, no vignette, no prompt section, no summary line
+- Walk continues normally — weather is enhancement, never requirement
+- No error shown to user
+- Session guard checkpoint handles nil weather fields gracefully
+
+## Files to Create/Modify
+
+| File | Action |
+|------|--------|
+| `Pilgrim/Models/Weather/WeatherService.swift` | **Create** — WeatherKit wrapper + WeatherSnapshot + WeatherCondition |
+| `Pilgrim/Models/Weather/WeatherOverlayView.swift` | **Create** — atmospheric overlay for active walk |
+| `Pilgrim/Models/Weather/WeatherVignetteView.swift` | **Create** — compact weather indicator |
+| `Pilgrim/Models/Data/DataModels/Versions/PilgrimV7.swift` | **Create** — DB migration adding weather fields |
+| `Pilgrim/Models/Data/DataModels/Versions/PilgrimV6.swift` | **Modify** — update migration chain reference |
+| `Pilgrim/Models/Data/NewWalk.swift` | **Modify** — add weather fields |
+| `Pilgrim/Models/Data/Temp/Versions/TempWaypoint.swift` (TempV4) | **Modify** — add weather fields to checkpoint serialization |
+| `Pilgrim/Scenes/ActiveWalk/ActiveWalkViewModel.swift` | **Modify** — fetch weather on walk start, expose to views |
+| `Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift` | **Modify** — add overlay + vignette |
+| `Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift` | **Modify** — add weather line to stats |
+| `Pilgrim/Models/PromptGenerator.swift` | **Modify** — add formatWeather() section |
+| `Pilgrim/Models/Walk/WalkSessionGuard.swift` | **Modify** — include weather in checkpoint/recovery |
+| `Pilgrim.xcodeproj/project.pbxproj` | **Modify** — add new files |
+
+## Reused Components
+
+- `Constants.Typography.*` — all text styling
+- `Constants.UI.Padding.*` — spacing
+- `Color.fog/stone/ink/parchment` — weather UI colors
+- `SeasonalColorEngine` — overlay tinting could use seasonal modulation
+- `UserPreferences.distanceMeasurementType` — imperial/metric for temperature unit
+- Generation counter pattern — for overlay animations
+
+## Verification
+
+1. **Build**: `xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build`
+2. **Simulator**: WeatherKit returns data in simulator with a developer account (may need physical device for real data)
+3. **Active walk**: Start a walk — atmospheric overlay matches current conditions, vignette shows temp + icon
+4. **Vignette tap**: Expand/collapse shows additional weather details
+5. **Walk summary**: After ending walk, weather line appears in summary stats
+6. **Prompts**: Generate prompts after a walk — weather section present in prompt text
+7. **Offline**: Disable network → start walk → no weather visuals, no crash, walk works normally
+8. **Reduce motion**: Overlay shows static tint only (no particles), vignette still functional
+9. **Session guard**: Kill app during walk → relaunch → recovered walk includes weather data
+10. **Imperial/Metric**: Switch units → temperature displays in correct unit (°F/°C)


### PR DESCRIPTION
## Summary

- **WeatherService** singleton wrapping Apple WeatherKit — fetches current conditions at walk start, maps to 10 weather conditions (clear, partly cloudy, overcast, light/heavy rain, thunderstorm, snow, fog, wind, haze)
- **Atmospheric overlay** on active walk screen — subtle Canvas particle effects (rain lines, snow dots, fog gradient, wind streaks, lightning flash) with reduce-motion fallback to static tints
- **Weather vignette** badge — compact condition icon + temperature, tappable to expand with humidity and wind
- **Data persistence** — wires up dormant DB weather fields (existed since V1, never populated) through WalkInterface, TempWalk, DataManager save path, and session guard recovery
- **AI prompt context** — weather fed to PromptGenerator alongside lunar phase and time-of-day
- **Walk summary** — weather line shown in post-walk stats

## Setup required

WeatherKit capability must be enabled:
1. Apple Developer Portal → Identifiers → App ID → WeatherKit checked
2. Xcode → Signing & Capabilities → WeatherKit added (already done, in entitlements)
3. Provisioning profile regenerated with capability

## Test plan

- [ ] Start walk on physical device → weather overlay appears after ~2s, vignette shows temp + icon
- [ ] Tap vignette → expands with humidity + wind
- [ ] End walk → summary shows weather line
- [ ] Generate prompts → weather section in prompt text
- [ ] Airplane mode → start walk → no weather visuals, no crash, walk works normally
- [ ] Reduce Motion enabled → static tints only, no particles
- [ ] Force-quit during walk → recovered walk includes weather data
- [ ] Imperial units → temperature shows °F

🤖 Generated with [Claude Code](https://claude.com/claude-code)