### PR TITLE
fix: proximity haptics don't fire + cairn timestamps don't update

### DIFF
--- a/Pilgrim/Models/Haptics/HapticManager.swift
+++ b/Pilgrim/Models/Haptics/HapticManager.swift
@@ -1,6 +1,87 @@
 import UIKit
 import CoreHaptics
 
+/// Shared Core Haptics engine for the app. Must live as a long-lived
+/// instance — the previous implementation created a fresh `CHHapticEngine`
+/// inside each pattern-firing function, and the engine was deallocated
+/// before the pattern finished playing, so proximity haptics for whispers
+/// and cairns silently never fired on device. Apple's own docs: "Keep
+/// the engine as a property so it remains in memory during playback."
+///
+/// The engine is created lazily on first access, started once, and kept
+/// alive for the lifetime of the app. `stoppedHandler` + `resetHandler`
+/// handle system interruptions (phone calls, Siri, audio route changes)
+/// by restarting the engine automatically.
+final class HapticEngineHost {
+
+    static let shared = HapticEngineHost()
+
+    private(set) var engine: CHHapticEngine?
+    private var isStarted = false
+
+    private init() {
+        guard CHHapticEngine.capabilitiesForHardware().supportsHaptics else { return }
+        do {
+            let engine = try CHHapticEngine()
+            // Keep running even when idle — we fire frequent short patterns
+            // and restart latency would be audible/feelable.
+            engine.isAutoShutdownEnabled = false
+            engine.playsHapticsOnly = true
+            engine.stoppedHandler = { [weak self] reason in
+                print("[HapticEngine] stopped: \(reason.rawValue)")
+                self?.isStarted = false
+            }
+            engine.resetHandler = { [weak self] in
+                print("[HapticEngine] reset — restarting")
+                self?.isStarted = false
+                self?.startIfNeeded()
+            }
+            self.engine = engine
+            startIfNeeded()
+        } catch {
+            print("[HapticEngine] init failed: \(error)")
+        }
+    }
+
+    /// Starts the engine if it isn't already running. Safe to call
+    /// repeatedly — a no-op when already started.
+    func startIfNeeded() {
+        guard let engine, !isStarted else { return }
+        do {
+            try engine.start()
+            isStarted = true
+        } catch {
+            print("[HapticEngine] start failed: \(error)")
+        }
+    }
+
+    /// Plays a Core Haptics pattern through the shared engine. Returns
+    /// `true` on success, `false` if the engine is unavailable or the
+    /// pattern failed to play. Callers should fall back to a simpler
+    /// UIKit feedback generator when this returns `false`.
+    ///
+    /// Calls `engine.start()` unconditionally before playing. This is
+    /// documented as idempotent on an already-running engine, and it
+    /// makes the path self-healing if the engine was stopped by the
+    /// system (background transition, audio session change) without
+    /// our `stoppedHandler` being invoked in time to clear `isStarted`.
+    @discardableResult
+    func play(_ events: [CHHapticEvent]) -> Bool {
+        guard let engine else { return false }
+        do {
+            try engine.start()
+            isStarted = true
+            let pattern = try CHHapticPattern(events: events, parameters: [])
+            let player = try engine.makePlayer(with: pattern)
+            try player.start(atTime: 0)
+            return true
+        } catch {
+            print("[HapticEngine] play failed: \(error)")
+            return false
+        }
+    }
+}
+
 enum HapticPattern {
     case waypointDropped
     case whisperProximity
@@ -16,9 +97,7 @@ enum HapticPattern {
             generator.impactOccurred()
 
         case .whisperProximity:
-            if CHHapticEngine.capabilitiesForHardware().supportsHaptics {
-                Self.fireWhisperProximityHaptic()
-            } else {
+            if !Self.playWhisperProximity() {
                 let generator = UINotificationFeedbackGenerator()
                 generator.prepare()
                 generator.notificationOccurred(.success)
@@ -30,17 +109,15 @@ enum HapticPattern {
             generator.impactOccurred()
 
         case .cairnProximity:
-            if CHHapticEngine.capabilitiesForHardware().supportsHaptics {
-                Self.fireCairnProximityHaptic()
-            } else {
+            if !Self.playCairnProximity() {
                 let generator = UIImpactFeedbackGenerator(style: .heavy)
                 generator.prepare()
                 generator.impactOccurred()
             }
 
         case .stonePlaced(let tier):
-            if tier >= 5, CHHapticEngine.capabilitiesForHardware().supportsHaptics {
-                Self.fireDeepStoneHaptic(tier: tier)
+            if tier >= 5, Self.playDeepStone(tier: tier) {
+                // Played via Core Haptics.
             } else {
                 let generator = UIImpactFeedbackGenerator(style: .heavy)
                 generator.prepare()
@@ -49,78 +126,46 @@ enum HapticPattern {
         }
     }
 
-    private static func fireWhisperProximityHaptic() {
-        guard let engine = try? CHHapticEngine() else { return }
-        do {
-            try engine.start()
-            let soft = CHHapticEventParameter(parameterID: .hapticIntensity, value: 0.4)
-            let round = CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.2)
-            let events = [
-                CHHapticEvent(eventType: .hapticTransient, parameters: [soft, round], relativeTime: 0),
-                CHHapticEvent(eventType: .hapticTransient, parameters: [soft, round], relativeTime: 0.12),
-                CHHapticEvent(eventType: .hapticTransient, parameters: [soft, round], relativeTime: 0.24)
-            ]
-            let pattern = try CHHapticPattern(events: events, parameters: [])
-            let player = try engine.makePlayer(with: pattern)
-            try player.start(atTime: 0)
-            engine.notifyWhenPlayersFinished { _ in .stopEngine }
-        } catch {
-            let generator = UINotificationFeedbackGenerator()
-            generator.prepare()
-            generator.notificationOccurred(.success)
-        }
+    private static func playWhisperProximity() -> Bool {
+        let soft = CHHapticEventParameter(parameterID: .hapticIntensity, value: 0.4)
+        let round = CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.2)
+        let events = [
+            CHHapticEvent(eventType: .hapticTransient, parameters: [soft, round], relativeTime: 0),
+            CHHapticEvent(eventType: .hapticTransient, parameters: [soft, round], relativeTime: 0.12),
+            CHHapticEvent(eventType: .hapticTransient, parameters: [soft, round], relativeTime: 0.24)
+        ]
+        return HapticEngineHost.shared.play(events)
     }
 
-    private static func fireCairnProximityHaptic() {
-        guard let engine = try? CHHapticEngine() else { return }
-        do {
-            try engine.start()
-            let firm = CHHapticEventParameter(parameterID: .hapticIntensity, value: 0.7)
-            let sharp = CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.6)
-            let events = [
-                CHHapticEvent(eventType: .hapticTransient, parameters: [firm, sharp], relativeTime: 0),
-                CHHapticEvent(eventType: .hapticTransient, parameters: [firm, sharp], relativeTime: 0.15)
-            ]
-            let pattern = try CHHapticPattern(events: events, parameters: [])
-            let player = try engine.makePlayer(with: pattern)
-            try player.start(atTime: 0)
-            engine.notifyWhenPlayersFinished { _ in .stopEngine }
-        } catch {
-            let generator = UIImpactFeedbackGenerator(style: .heavy)
-            generator.prepare()
-            generator.impactOccurred()
-        }
+    private static func playCairnProximity() -> Bool {
+        let firm = CHHapticEventParameter(parameterID: .hapticIntensity, value: 0.7)
+        let sharp = CHHapticEventParameter(parameterID: .hapticSharpness, value: 0.6)
+        let events = [
+            CHHapticEvent(eventType: .hapticTransient, parameters: [firm, sharp], relativeTime: 0),
+            CHHapticEvent(eventType: .hapticTransient, parameters: [firm, sharp], relativeTime: 0.15)
+        ]
+        return HapticEngineHost.shared.play(events)
     }
 
-    private static func fireDeepStoneHaptic(tier: Int) {
-        guard let engine = try? CHHapticEngine() else { return }
-        do {
-            try engine.start()
-
-            let intensity = CHHapticEventParameter(
-                parameterID: .hapticIntensity,
-                value: min(1.0, 0.6 + Float(tier) * 0.06)
+    private static func playDeepStone(tier: Int) -> Bool {
+        let intensity = CHHapticEventParameter(
+            parameterID: .hapticIntensity,
+            value: min(1.0, 0.6 + Float(tier) * 0.06)
+        )
+        let sharpness = CHHapticEventParameter(
+            parameterID: .hapticSharpness,
+            value: max(0.2, 0.8 - Float(tier) * 0.1)
+        )
+        let events = [
+            CHHapticEvent(eventType: .hapticTransient, parameters: [intensity, sharpness], relativeTime: 0),
+            CHHapticEvent(eventType: .hapticTransient, parameters: [intensity, sharpness], relativeTime: 0.08),
+            CHHapticEvent(
+                eventType: .hapticContinuous,
+                parameters: [intensity, sharpness],
+                relativeTime: 0.15,
+                duration: 0.2
             )
-            let sharpness = CHHapticEventParameter(
-                parameterID: .hapticSharpness,
-                value: max(0.2, 0.8 - Float(tier) * 0.1)
-            )
-
-            let events = [
-                CHHapticEvent(eventType: .hapticTransient, parameters: [intensity, sharpness], relativeTime: 0),
-                CHHapticEvent(eventType: .hapticTransient, parameters: [intensity, sharpness], relativeTime: 0.08),
-                CHHapticEvent(eventType: .hapticContinuous, parameters: [intensity, sharpness], relativeTime: 0.15, duration: 0.2)
-            ]
-
-            let pattern = try CHHapticPattern(events: events, parameters: [])
-            let player = try engine.makePlayer(with: pattern)
-            try player.start(atTime: 0)
-
-            engine.notifyWhenPlayersFinished { _ in .stopEngine }
-        } catch {
-            let generator = UIImpactFeedbackGenerator(style: .heavy)
-            generator.prepare()
-            generator.impactOccurred()
-        }
+        ]
+        return HapticEngineHost.shared.play(events)
     }
 }

--- a/Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift
+++ b/Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift
@@ -853,14 +853,21 @@ extension ActiveWalkView {
                 await MainActor.run {
                     viewModel.stonePlacedThisWalk = true
                     StonePlayer.shared.playForCount(result.stoneCount)
+                    let nowISO = Self.isoFormatter.string(from: Date())
                     if let idx = GeoCacheService.shared.cachedCairns.firstIndex(where: { $0.id == result.id }) {
                         let old = GeoCacheService.shared.cachedCairns[idx]
+                        // Refresh lastPlacedAt to NOW (the stone was just placed)
+                        // and preserve the original createdAt so "first stone"
+                        // continues to show the cairn's true creation date.
+                        // Previously both fields drifted to the same stale
+                        // value on every placement.
                         GeoCacheService.shared.cachedCairns[idx] = CachedCairn(
                             id: old.id,
                             latitude: old.latitude,
                             longitude: old.longitude,
                             stoneCount: result.stoneCount,
-                            lastPlacedAt: old.lastPlacedAt
+                            lastPlacedAt: nowISO,
+                            createdAt: old.createdAt
                         )
                     } else {
                         GeoCacheService.shared.cachedCairns.append(CachedCairn(
@@ -868,7 +875,8 @@ extension ActiveWalkView {
                             latitude: location.latitude,
                             longitude: location.longitude,
                             stoneCount: result.stoneCount,
-                            lastPlacedAt: Self.isoFormatter.string(from: Date())
+                            lastPlacedAt: nowISO,
+                            createdAt: nowISO
                         ))
                     }
                     viewModel.proximityService.suppressTarget(id: "cairn-\(result.id)")


### PR DESCRIPTION
## Summary

Two small "stale state after placement" bugs reported together during a real walk test.

### 1. Proximity haptics silently never fired on device

`HapticPattern.fire{Whisper,Cairn}ProximityHaptic()` was creating a fresh `CHHapticEngine` as a **local variable** inside the function. When the function returned, the engine was deallocated before the pattern finished playing — so no haptic was ever felt. The text notification and audio playback worked (those are separate systems), but haptics were silently dead.

Apple's docs explicitly say: *"Keep the engine as a property so it remains in memory during playback."*

**Fix:** new `HapticEngineHost` singleton holding one long-lived engine, lazy-initialized, `isAutoShutdownEnabled = false`, with `stoppedHandler` + `resetHandler` to recover from system interruptions (phone calls, Siri, audio routing, background/foreground). The `play()` path calls `engine.start()` unconditionally before each pattern, making it self-healing if the engine was stopped without the handler firing in time. Falls back to UIKit `UIImpactFeedbackGenerator` if Core Haptics is unavailable.

### 2. Cairn detail timestamps stuck after placing a stone

In `ActiveWalkView.placeStone`, the cairn cache update passed `lastPlacedAt: old.lastPlacedAt` — keeping the stale timestamp instead of refreshing to now. It also didn't pass `createdAt` at all, so the `CachedCairn` initializer defaulted it to `lastPlacedAt`, destroying the original creation date on every update.

Result: "First stone placed" and "Last stone placed" in the cairn detail view collapsed to the same timestamp, and "Last stone" never updated after placing a new one.

**Fix:** pass `lastPlacedAt: nowISO` (refreshes to current time) and `createdAt: old.createdAt` (preserves the original). New-cairn path now explicitly passes `createdAt: nowISO` so both branches are consistent.

## Proximity ranges (for reference)

Unchanged, documented in `ProximityDetectionService`:
- Whisper: 42 m
- Cairn: 108 m
- Hysteresis exit: 1.2 × radius
- Location updates throttled to 5 s
- One-shot per target per walk session

## Test plan

- [x] Build passes
- [x] SwiftLint clean on changed files (0 violations on `HapticManager.swift`)
- [x] `xcodebuild test` — 5/5 AppStoreScreenshots passed
- [ ] **Real device walk test** — walk within 42m of a whisper, confirm you FEEL three soft taps
- [ ] Real device walk test — walk within 108m of a cairn, confirm you feel two firm taps
- [ ] Real device walk test — place a stone on an existing cairn, open detail view, confirm "Last stone" reads "a few seconds ago" and "First stone" still shows the original date

## Not for 1.2.0

This is a fast-follow fix on `main` but explicitly NOT going into 1.2.0 (already uploaded, awaiting Apple review). Targets the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)