### PR TITLE
feat(share): walk share preview ritual — auto-reveal modal scroll

### DIFF
--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 		LR00000200000000LRWVLD01 /* WebViewLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVLD01 /* WebViewLoader.swift */; };
 		LR00000200000000LRWVLDT1 /* WebViewLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVLDT1 /* WebViewLoaderTests.swift */; };
 		LR00000200000000LRWVRP01 /* WebViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVRP01 /* WebViewRepresentable.swift */; };
+		LR00000200000000LRWVPV01 /* WalkSharePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVPV01 /* WalkSharePreviewView.swift */; };
 		73E33F8FCA5B429A65D78EE0 /* PromptContextTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E6ADC967A625A65E935F52 /* PromptContextTypes.swift */; };
 		758B907703CD5A6120536B37 /* ProximityDetectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C415FCDCD38A1DE0212C8451 /* ProximityDetectionService.swift */; };
 		764C2FC0EBC04F779B97EA92 /* WalkCheckpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74490DBCE024418B78E73B2 /* WalkCheckpoint.swift */; };
@@ -528,6 +529,7 @@
 		LR00000100000000LRWVLD01 /* WebViewLoader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewLoader.swift; sourceTree = "<group>"; };
 		LR00000100000000LRWVLDT1 /* WebViewLoaderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewLoaderTests.swift; sourceTree = "<group>"; };
 		LR00000100000000LRWVRP01 /* WebViewRepresentable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewRepresentable.swift; sourceTree = "<group>"; };
+		LR00000100000000LRWVPV01 /* WalkSharePreviewView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkSharePreviewView.swift; sourceTree = "<group>"; };
 		0F5581F46A4FFE9ED1D2DCEB /* SoundSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundSettingsView.swift; sourceTree = "<group>"; };
 		12245A2A15EE8E64818B6D3F /* ActivityContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActivityContext.swift; sourceTree = "<group>"; };
 		123512C2E2D2088520214836 /* CairnVisualGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CairnVisualGenerator.swift; sourceTree = "<group>"; };
@@ -1794,6 +1796,7 @@
 				4B95E4FB1DF743CEF3AC77C2 /* RouteShapeView.swift */,
 				LR00000100000000LRWVLD01 /* WebViewLoader.swift */,
 				LR00000100000000LRWVRP01 /* WebViewRepresentable.swift */,
+				LR00000100000000LRWVPV01 /* WalkSharePreviewView.swift */,
 			);
 			path = WalkShare;
 			sourceTree = "<group>";
@@ -2729,6 +2732,7 @@
 				9C3309EA59D57A4224524F68 /* WhisperManifestService.swift in Sources */,
 				LR00000200000000LRWVLD01 /* WebViewLoader.swift in Sources */,
 				LR00000200000000LRWVRP01 /* WebViewRepresentable.swift in Sources */,
+				LR00000200000000LRWVPV01 /* WalkSharePreviewView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -229,6 +229,8 @@
 		LR00000200000000LRGENR02 /* LightReadingGeneratorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRGENR02 /* LightReadingGeneratorTests.swift */; };
 		LR00000200000000LRSHTR01 /* WalkSharingTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRSHTR01 /* WalkSharingTracker.swift */; };
 		LR00000200000000LRSHTR02 /* WalkSharingTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRSHTR02 /* WalkSharingTrackerTests.swift */; };
+		LR00000200000000LRWVLD01 /* WebViewLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVLD01 /* WebViewLoader.swift */; };
+		LR00000200000000LRWVLDT1 /* WebViewLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVLDT1 /* WebViewLoaderTests.swift */; };
 		73E33F8FCA5B429A65D78EE0 /* PromptContextTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E6ADC967A625A65E935F52 /* PromptContextTypes.swift */; };
 		758B907703CD5A6120536B37 /* ProximityDetectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C415FCDCD38A1DE0212C8451 /* ProximityDetectionService.swift */; };
 		764C2FC0EBC04F779B97EA92 /* WalkCheckpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74490DBCE024418B78E73B2 /* WalkCheckpoint.swift */; };
@@ -522,6 +524,8 @@
 		LR00000100000000LRGENR02 /* LightReadingGeneratorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LightReadingGeneratorTests.swift; sourceTree = "<group>"; };
 		LR00000100000000LRSHTR01 /* WalkSharingTracker.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkSharingTracker.swift; sourceTree = "<group>"; };
 		LR00000100000000LRSHTR02 /* WalkSharingTrackerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkSharingTrackerTests.swift; sourceTree = "<group>"; };
+		LR00000100000000LRWVLD01 /* WebViewLoader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewLoader.swift; sourceTree = "<group>"; };
+		LR00000100000000LRWVLDT1 /* WebViewLoaderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewLoaderTests.swift; sourceTree = "<group>"; };
 		0F5581F46A4FFE9ED1D2DCEB /* SoundSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundSettingsView.swift; sourceTree = "<group>"; };
 		12245A2A15EE8E64818B6D3F /* ActivityContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActivityContext.swift; sourceTree = "<group>"; };
 		123512C2E2D2088520214836 /* CairnVisualGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CairnVisualGenerator.swift; sourceTree = "<group>"; };
@@ -1631,6 +1635,7 @@
 				LR00000100000000LRTMPL02 /* LightReadingTemplatesTests.swift */,
 				LR00000100000000LRGENR02 /* LightReadingGeneratorTests.swift */,
 				LR00000100000000LRSHTR02 /* WalkSharingTrackerTests.swift */,
+				LR00000100000000LRWVLDT1 /* WebViewLoaderTests.swift */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -1785,6 +1790,7 @@
 				16BE9557700152F043C359DC /* WalkShareView.swift */,
 				8E0BF1B23139F428720EB2CF /* WalkShareViewModel.swift */,
 				4B95E4FB1DF743CEF3AC77C2 /* RouteShapeView.swift */,
+				LR00000100000000LRWVLD01 /* WebViewLoader.swift */,
 			);
 			path = WalkShare;
 			sourceTree = "<group>";
@@ -2718,6 +2724,7 @@
 				7978824143C5D5E81A6A3E06 /* StonePlacementSheet.swift in Sources */,
 				DA6DDA89F11F4728B6B553A1 /* WhisperManifest.swift in Sources */,
 				9C3309EA59D57A4224524F68 /* WhisperManifestService.swift in Sources */,
+				LR00000200000000LRWVLD01 /* WebViewLoader.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2774,6 +2781,7 @@
 				LR00000200000000LRTMPL02 /* LightReadingTemplatesTests.swift in Sources */,
 				LR00000200000000LRGENR02 /* LightReadingGeneratorTests.swift in Sources */,
 				LR00000200000000LRSHTR02 /* WalkSharingTrackerTests.swift in Sources */,
+				LR00000200000000LRWVLDT1 /* WebViewLoaderTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -231,6 +231,7 @@
 		LR00000200000000LRSHTR02 /* WalkSharingTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRSHTR02 /* WalkSharingTrackerTests.swift */; };
 		LR00000200000000LRWVLD01 /* WebViewLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVLD01 /* WebViewLoader.swift */; };
 		LR00000200000000LRWVLDT1 /* WebViewLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVLDT1 /* WebViewLoaderTests.swift */; };
+		LR00000200000000LRWVRP01 /* WebViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVRP01 /* WebViewRepresentable.swift */; };
 		73E33F8FCA5B429A65D78EE0 /* PromptContextTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E6ADC967A625A65E935F52 /* PromptContextTypes.swift */; };
 		758B907703CD5A6120536B37 /* ProximityDetectionService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C415FCDCD38A1DE0212C8451 /* ProximityDetectionService.swift */; };
 		764C2FC0EBC04F779B97EA92 /* WalkCheckpoint.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74490DBCE024418B78E73B2 /* WalkCheckpoint.swift */; };
@@ -526,6 +527,7 @@
 		LR00000100000000LRSHTR02 /* WalkSharingTrackerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkSharingTrackerTests.swift; sourceTree = "<group>"; };
 		LR00000100000000LRWVLD01 /* WebViewLoader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewLoader.swift; sourceTree = "<group>"; };
 		LR00000100000000LRWVLDT1 /* WebViewLoaderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewLoaderTests.swift; sourceTree = "<group>"; };
+		LR00000100000000LRWVRP01 /* WebViewRepresentable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewRepresentable.swift; sourceTree = "<group>"; };
 		0F5581F46A4FFE9ED1D2DCEB /* SoundSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundSettingsView.swift; sourceTree = "<group>"; };
 		12245A2A15EE8E64818B6D3F /* ActivityContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActivityContext.swift; sourceTree = "<group>"; };
 		123512C2E2D2088520214836 /* CairnVisualGenerator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CairnVisualGenerator.swift; sourceTree = "<group>"; };
@@ -1791,6 +1793,7 @@
 				8E0BF1B23139F428720EB2CF /* WalkShareViewModel.swift */,
 				4B95E4FB1DF743CEF3AC77C2 /* RouteShapeView.swift */,
 				LR00000100000000LRWVLD01 /* WebViewLoader.swift */,
+				LR00000100000000LRWVRP01 /* WebViewRepresentable.swift */,
 			);
 			path = WalkShare;
 			sourceTree = "<group>";
@@ -2725,6 +2728,7 @@
 				DA6DDA89F11F4728B6B553A1 /* WhisperManifest.swift in Sources */,
 				9C3309EA59D57A4224524F68 /* WhisperManifestService.swift in Sources */,
 				LR00000200000000LRWVLD01 /* WebViewLoader.swift in Sources */,
+				LR00000200000000LRWVRP01 /* WebViewRepresentable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pilgrim/Scenes/WalkShare/WalkSharePreviewView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkSharePreviewView.swift
@@ -58,7 +58,6 @@ struct WalkSharePreviewView: View {
         ZStack {
             WebViewRepresentable(webView: loader.webView)
                 .opacity(loader.loadState == .loaded ? 1 : 0)
-                .animation(.easeInOut(duration: 0.3), value: loader.loadState)
 
             if loader.loadState == .loading {
                 skeleton
@@ -68,6 +67,7 @@ struct WalkSharePreviewView: View {
                 failureView
             }
         }
+        .animation(.easeInOut(duration: 0.3), value: loader.loadState)
     }
 
     private var skeleton: some View {

--- a/Pilgrim/Scenes/WalkShare/WalkSharePreviewView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkSharePreviewView.swift
@@ -1,0 +1,176 @@
+import SwiftUI
+
+struct WalkSharePreviewView: View {
+
+    @ObservedObject var loader: WebViewLoader
+    let shareURL: String
+    let onDismiss: () -> Void
+
+    @State private var captionOpacity: Double = 0
+    @State private var showCopiedToast = false
+    @State private var toastGeneration = 0
+
+    var body: some View {
+        ZStack {
+            Color.parchment.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                topBar
+                contentArea
+                Spacer(minLength: 0)
+            }
+
+            VStack {
+                Spacer()
+                floatingActionBar
+            }
+        }
+        .onAppear {
+            withAnimation(.easeInOut(duration: 0.3).delay(0.2)) {
+                captionOpacity = 1
+            }
+        }
+    }
+
+    // MARK: - Top bar
+
+    private var topBar: some View {
+        HStack {
+            Text("Your walk.")
+                .font(Constants.Typography.heading)
+                .foregroundColor(.ink)
+                .opacity(captionOpacity)
+
+            Spacer()
+
+            Button("Done", action: onDismiss)
+                .font(Constants.Typography.button)
+                .foregroundColor(.stone)
+        }
+        .padding(.horizontal, Constants.UI.Padding.normal)
+        .padding(.vertical, Constants.UI.Padding.small)
+        .background(Color.parchment)
+    }
+
+    // MARK: - Content area
+
+    private var contentArea: some View {
+        ZStack {
+            WebViewRepresentable(webView: loader.webView)
+                .opacity(loader.loadState == .loaded ? 1 : 0)
+                .animation(.easeInOut(duration: 0.3), value: loader.loadState)
+
+            if loader.loadState == .loading {
+                skeleton
+            }
+
+            if loader.loadState == .failed {
+                failureView
+            }
+        }
+    }
+
+    private var skeleton: some View {
+        VStack(alignment: .leading, spacing: Constants.UI.Padding.normal) {
+            Rectangle()
+                .fill(Color.fog.opacity(0.2))
+                .frame(height: 28)
+                .frame(maxWidth: .infinity)
+
+            ForEach(0..<5, id: \.self) { _ in
+                Rectangle()
+                    .fill(Color.fog.opacity(0.15))
+                    .frame(height: 12)
+                    .frame(maxWidth: .infinity)
+            }
+
+            Rectangle()
+                .fill(Color.fog.opacity(0.1))
+                .frame(height: 140)
+                .frame(maxWidth: .infinity)
+        }
+        .padding(Constants.UI.Padding.big)
+        .transition(.opacity)
+    }
+
+    private var failureView: some View {
+        VStack(spacing: Constants.UI.Padding.normal) {
+            Text("The scroll will appear when your connection returns.")
+                .font(Constants.Typography.body)
+                .foregroundColor(.fog)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Constants.UI.Padding.big)
+
+            Button("Retry", action: { loader.retry() })
+                .font(Constants.Typography.button)
+                .foregroundColor(.stone)
+                .padding(.horizontal, Constants.UI.Padding.big)
+                .padding(.vertical, 12)
+                .overlay(
+                    Capsule()
+                        .stroke(Color.stone.opacity(0.3), lineWidth: 1)
+                )
+        }
+    }
+
+    // MARK: - Floating action bar
+
+    private var floatingActionBar: some View {
+        HStack(spacing: Constants.UI.Padding.small) {
+            copyButton
+            shareButton
+        }
+        .padding(.horizontal, Constants.UI.Padding.normal)
+        .padding(.vertical, Constants.UI.Padding.small)
+        .background(
+            Color.parchment
+                .shadow(color: Color.black.opacity(0.08), radius: 8, x: 0, y: -2)
+        )
+    }
+
+    private var copyButton: some View {
+        Button {
+            UIPasteboard.general.string = shareURL
+            toastGeneration += 1
+            let gen = toastGeneration
+            showCopiedToast = true
+            Task {
+                try? await Task.sleep(for: .seconds(2))
+                if toastGeneration == gen { showCopiedToast = false }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: showCopiedToast ? "checkmark" : "doc.on.doc")
+                Text(showCopiedToast ? "Copied" : "Copy")
+                    .font(Constants.Typography.button)
+                    .minimumScaleFactor(0.8)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(Color.parchmentSecondary)
+            .foregroundColor(.stone)
+            .cornerRadius(Constants.UI.CornerRadius.small)
+        }
+    }
+
+    @ViewBuilder
+    private var shareButton: some View {
+        if let url = URL(string: shareURL) {
+            ShareLink(item: url) {
+                HStack(spacing: 4) {
+                    Image(systemName: "square.and.arrow.up")
+                    Text("Share")
+                        .font(Constants.Typography.button)
+                        .minimumScaleFactor(0.8)
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(Color.stone)
+                .foregroundColor(.parchment)
+                .cornerRadius(Constants.UI.CornerRadius.small)
+            }
+        }
+    }
+}

--- a/Pilgrim/Scenes/WalkShare/WalkSharePreviewView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkSharePreviewView.swift
@@ -72,6 +72,7 @@ struct WalkSharePreviewView: View {
                 failureView
             }
         }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
         .animation(.easeInOut(duration: 0.3), value: loader.loadState)
         .accessibilitySortPriority(2)
     }

--- a/Pilgrim/Scenes/WalkShare/WalkSharePreviewView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkSharePreviewView.swift
@@ -54,6 +54,7 @@ struct WalkSharePreviewView: View {
         .padding(.horizontal, Constants.UI.Padding.normal)
         .padding(.vertical, Constants.UI.Padding.small)
         .background(Color.parchment)
+        .accessibilitySortPriority(3)
     }
 
     // MARK: - Content area
@@ -72,6 +73,7 @@ struct WalkSharePreviewView: View {
             }
         }
         .animation(.easeInOut(duration: 0.3), value: loader.loadState)
+        .accessibilitySortPriority(2)
     }
 
     private var skeleton: some View {
@@ -130,6 +132,7 @@ struct WalkSharePreviewView: View {
             Color.parchment
                 .shadow(color: Color.black.opacity(0.08), radius: 8, x: 0, y: -2)
         )
+        .accessibilitySortPriority(1)
     }
 
     private var copyButton: some View {

--- a/Pilgrim/Scenes/WalkShare/WalkSharePreviewView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkSharePreviewView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UIKit
 
 struct WalkSharePreviewView: View {
 
@@ -26,7 +27,10 @@ struct WalkSharePreviewView: View {
             }
         }
         .onAppear {
-            withAnimation(.easeInOut(duration: 0.3).delay(0.2)) {
+            let reduceMotion = UIAccessibility.isReduceMotionEnabled
+            let delay = reduceMotion ? 0.0 : 0.2
+            let duration = reduceMotion ? 0.2 : 0.3
+            withAnimation(.easeInOut(duration: duration).delay(delay)) {
                 captionOpacity = 1
             }
         }

--- a/Pilgrim/Scenes/WalkShare/WalkShareView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareView.swift
@@ -7,6 +7,10 @@ struct WalkShareView: View {
     @State private var showCopiedToast = false
     @State private var toastGeneration = 0
     @State private var showPodcastCard = false
+    @State private var showPreview = false
+    @State private var revealTask: Task<Void, Never>?
+    @StateObject private var webViewLoaderHolder = WebViewLoaderHolder()
+    @State private var previewURL: String?
 
     let walk: WalkInterface
     let pinnedPhotos: [PhotoCandidate]
@@ -266,61 +270,44 @@ struct WalkShareView: View {
 
         case .success(let url):
             VStack(spacing: Constants.UI.Padding.normal) {
-                routePreview
+                Button {
+                    openPreview(url: url)
+                } label: {
+                    ZStack(alignment: .topTrailing) {
+                        routePreview
+                        Image(systemName: "chevron.right")
+                            .font(.caption)
+                            .foregroundColor(.fog.opacity(0.4))
+                            .padding(8)
+                    }
+                }
+                .buttonStyle(.plain)
 
-                Text(url)
-                    .font(Constants.Typography.caption)
-                    .foregroundColor(.stone)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
+                HStack(spacing: 6) {
+                    Text("Shared")
+                        .font(Constants.Typography.body)
+                        .foregroundColor(.stone)
+                    Image(systemName: "checkmark")
+                        .font(.caption)
+                        .foregroundColor(.moss)
+                }
 
                 Text("Returns to the trail on \(expiryDateFormatted)")
                     .font(Constants.Typography.caption)
                     .foregroundColor(.fog)
                     .italic()
 
-                HStack(spacing: Constants.UI.Padding.small) {
-                    Button {
-                        UIPasteboard.general.string = url
-                        toastGeneration += 1
-                        let gen = toastGeneration
-                        showCopiedToast = true
-                        Task {
-                            try? await Task.sleep(for: .seconds(2))
-                            if toastGeneration == gen { showCopiedToast = false }
-                        }
-                    } label: {
-                        HStack(spacing: 4) {
-                            Image(systemName: showCopiedToast ? "checkmark" : "doc.on.doc")
-                            Text(showCopiedToast ? "Copied" : "Copy")
-                                .font(Constants.Typography.button)
-                                .minimumScaleFactor(0.8)
-                                .lineLimit(1)
-                        }
+                Button {
+                    openPreview(url: url)
+                } label: {
+                    Text("View scroll")
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.fog)
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 12)
-                        .background(Color.parchmentSecondary)
-                        .foregroundColor(.stone)
-                        .cornerRadius(Constants.UI.CornerRadius.small)
-                    }
-
-                    if let shareURL = URL(string: url) {
-                        ShareLink(item: shareURL) {
-                            HStack(spacing: 4) {
-                                Image(systemName: "square.and.arrow.up")
-                                Text("Share")
-                                    .font(Constants.Typography.button)
-                                    .minimumScaleFactor(0.8)
-                                    .lineLimit(1)
-                            }
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 12)
-                            .background(Color.stone)
-                            .foregroundColor(.parchment)
-                            .cornerRadius(Constants.UI.CornerRadius.small)
-                        }
-                    }
+                        .contentShape(Rectangle())
                 }
+                .buttonStyle(.plain)
             }
             .padding(Constants.UI.Padding.normal)
             .background(Color.parchmentSecondary)
@@ -359,6 +346,30 @@ struct WalkShareView: View {
             .font(Constants.Typography.micro)
             .foregroundColor(.fog)
             .tracking(1.5)
+    }
+
+    private func openPreview(url: String) {
+        guard let parsedURL = URL(string: url) else { return }
+        if webViewLoaderHolder.loader == nil {
+            webViewLoaderHolder.create(url: parsedURL)
+        }
+        previewURL = url
+        showPreview = true
+    }
+}
+
+// MARK: - WebViewLoaderHolder
+
+@MainActor
+private final class WebViewLoaderHolder: ObservableObject {
+    @Published var loader: WebViewLoader?
+
+    func create(url: URL) {
+        loader = WebViewLoader(url: url)
+    }
+
+    func clear() {
+        loader = nil
     }
 }
 

--- a/Pilgrim/Scenes/WalkShare/WalkShareView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareView.swift
@@ -106,7 +106,13 @@ struct WalkShareView: View {
         .onDisappear {
             revealTask?.cancel()
             revealTask = nil
-            webViewLoaderHolder.clear()
+            // Guard against iOS versions / scene configs where onDisappear
+            // fires on the parent while the cover is still presented (e.g.,
+            // app backgrounded with modal open). Clearing the loader mid-
+            // presentation would leave the cover rendering an empty view.
+            if !showPreview {
+                webViewLoaderHolder.clear()
+            }
         }
     }
 

--- a/Pilgrim/Scenes/WalkShare/WalkShareView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareView.swift
@@ -8,6 +8,7 @@ struct WalkShareView: View {
     @State private var showPreview = false
     @State private var revealTask: Task<Void, Never>?
     @State private var podcastRevealTask: Task<Void, Never>?
+    @State private var ritualDidFire = false
     @StateObject private var webViewLoaderHolder = WebViewLoaderHolder()
     @State private var previewURL: String?
 
@@ -76,10 +77,17 @@ struct WalkShareView: View {
         // ritual's. Tying the reveal to `showPreview` going true → false
         // gives the card a visible fade-in and separates the two haptics.
         .onChange(of: showPreview) { wasShowing, isShowing in
+            // Only reveal after a FRESH-share modal dismiss (ritualDidFire).
+            // Cache-hit re-entry via the walk summary's tappable URL also
+            // dismisses the modal via showPreview true → false, and without
+            // this gate the podcast card would spuriously appear on every
+            // re-view of a walk that was shared weeks ago.
             guard wasShowing, !isShowing,
+                  ritualDidFire,
                   !showPodcastCard,
                   isShared,
                   PodcastSubmissionService.shared.isEligible(walk: walk) else { return }
+            ritualDidFire = false
             podcastRevealTask?.cancel()
             podcastRevealTask = Task {
                 try? await Task.sleep(for: .milliseconds(500))
@@ -424,6 +432,7 @@ struct WalkShareView: View {
 
         webViewLoaderHolder.create(url: parsedURL)
         previewURL = url
+        ritualDidFire = true
 
         revealTask?.cancel()
         revealTask = Task {

--- a/Pilgrim/Scenes/WalkShare/WalkShareView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareView.swift
@@ -378,6 +378,11 @@ struct WalkShareView: View {
 
     private func openPreview(url: String) {
         guard let parsedURL = URL(string: url) else { return }
+        // If the user taps to open during the 800ms ritual beat, cancel the
+        // pending reveal so its haptic + redundant showPreview assignment
+        // don't fire on an already-open modal.
+        revealTask?.cancel()
+        revealTask = nil
         if webViewLoaderHolder.loader == nil {
             webViewLoaderHolder.create(url: parsedURL)
         }

--- a/Pilgrim/Scenes/WalkShare/WalkShareView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareView.swift
@@ -78,6 +78,36 @@ struct WalkShareView: View {
                 }
             }
         }
+        .fullScreenCover(isPresented: $showPreview, onDismiss: {
+            webViewLoaderHolder.clear()
+            previewURL = nil
+        }) {
+            if let loader = webViewLoaderHolder.loader, let url = previewURL {
+                WalkSharePreviewView(
+                    loader: loader,
+                    shareURL: url,
+                    onDismiss: { showPreview = false }
+                )
+            }
+        }
+        .background(
+            Group {
+                if let loader = webViewLoaderHolder.loader, !showPreview {
+                    WebViewRepresentable(webView: loader.webView)
+                        .frame(width: 0, height: 0)
+                        .opacity(0)
+                        .allowsHitTesting(false)
+                }
+            }
+        )
+        .onChange(of: viewModel.shareState) { oldValue, newValue in
+            triggerRitualIfNeeded(old: oldValue, new: newValue)
+        }
+        .onDisappear {
+            revealTask?.cancel()
+            revealTask = nil
+            webViewLoaderHolder.clear()
+        }
     }
 
     // MARK: - Route Preview
@@ -353,6 +383,27 @@ struct WalkShareView: View {
         }
         previewURL = url
         showPreview = true
+    }
+
+    private func triggerRitualIfNeeded(
+        old: WalkShareViewModel.ShareState,
+        new: WalkShareViewModel.ShareState
+    ) {
+        guard case .uploading = old, case .success(let url) = new else { return }
+        guard let parsedURL = URL(string: url) else { return }
+
+        webViewLoaderHolder.create(url: parsedURL)
+        previewURL = url
+
+        revealTask?.cancel()
+        revealTask = Task {
+            try? await Task.sleep(for: .milliseconds(800))
+            guard !Task.isCancelled else { return }
+            await MainActor.run {
+                UIImpactFeedbackGenerator(style: .soft).impactOccurred()
+                showPreview = true
+            }
+        }
     }
 }
 

--- a/Pilgrim/Scenes/WalkShare/WalkShareView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareView.swift
@@ -313,9 +313,12 @@ struct WalkShareView: View {
                             .font(.caption)
                             .foregroundColor(.fog.opacity(0.4))
                             .padding(8)
+                            .accessibilityHidden(true)
                     }
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("View shared walk page")
+                .accessibilityHint("Opens the scroll of your shared walk")
 
                 HStack(spacing: 6) {
                     Text("Shared")

--- a/Pilgrim/Scenes/WalkShare/WalkShareView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareView.swift
@@ -4,8 +4,6 @@ struct WalkShareView: View {
 
     @StateObject private var viewModel: WalkShareViewModel
     @Environment(\.dismiss) private var dismiss
-    @State private var showCopiedToast = false
-    @State private var toastGeneration = 0
     @State private var showPodcastCard = false
     @State private var showPreview = false
     @State private var revealTask: Task<Void, Never>?

--- a/Pilgrim/Scenes/WalkShare/WalkShareView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareView.swift
@@ -7,6 +7,7 @@ struct WalkShareView: View {
     @State private var showPodcastCard = false
     @State private var showPreview = false
     @State private var revealTask: Task<Void, Never>?
+    @State private var podcastRevealTask: Task<Void, Never>?
     @StateObject private var webViewLoaderHolder = WebViewLoaderHolder()
     @State private var previewURL: String?
 
@@ -67,10 +68,23 @@ struct WalkShareView: View {
                     }
                 }
             }
-            .onChange(of: isShared) { _, shared in
-                guard shared, !showPodcastCard,
-                      PodcastSubmissionService.shared.isEligible(walk: walk) else { return }
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) {
+        }
+        // Reveal the podcast card after the ritual modal dismisses, not at
+        // the moment of share success. The previous 800ms-after-success
+        // trigger collided with the ritual's own reveal — the card animated
+        // invisibly behind the modal, and its haptic doubled up with the
+        // ritual's. Tying the reveal to `showPreview` going true → false
+        // gives the card a visible fade-in and separates the two haptics.
+        .onChange(of: showPreview) { wasShowing, isShowing in
+            guard wasShowing, !isShowing,
+                  !showPodcastCard,
+                  isShared,
+                  PodcastSubmissionService.shared.isEligible(walk: walk) else { return }
+            podcastRevealTask?.cancel()
+            podcastRevealTask = Task {
+                try? await Task.sleep(for: .milliseconds(500))
+                guard !Task.isCancelled else { return }
+                await MainActor.run {
                     withAnimation(.easeOut(duration: 0.5)) {
                         showPodcastCard = true
                     }
@@ -106,6 +120,8 @@ struct WalkShareView: View {
         .onDisappear {
             revealTask?.cancel()
             revealTask = nil
+            podcastRevealTask?.cancel()
+            podcastRevealTask = nil
             // Guard against iOS versions / scene configs where onDisappear
             // fires on the parent while the cover is still presented (e.g.,
             // app backgrounded with modal open). Clearing the loader mid-

--- a/Pilgrim/Scenes/WalkShare/WebViewLoader.swift
+++ b/Pilgrim/Scenes/WalkShare/WebViewLoader.swift
@@ -56,7 +56,7 @@ final class WebViewLoader: ObservableObject {
     }
 
     func shouldAllowNavigation(to url: URL) -> Bool {
-        return url == initialURL
+        return url.host == initialURL.host
     }
 }
 

--- a/Pilgrim/Scenes/WalkShare/WebViewLoader.swift
+++ b/Pilgrim/Scenes/WalkShare/WebViewLoader.swift
@@ -1,0 +1,96 @@
+import Foundation
+import WebKit
+import Combine
+
+final class WebViewLoader: ObservableObject {
+
+    enum LoadState: Equatable {
+        case loading
+        case loaded
+        case failed
+    }
+
+    @Published private(set) var loadState: LoadState = .loading
+
+    let webView: WKWebView
+    let initialURL: URL
+
+    private let navigationDelegate: NavigationDelegate
+
+    init(url: URL) {
+        self.initialURL = url
+
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = .nonPersistent()
+        self.webView = WKWebView(frame: .zero, configuration: config)
+        self.webView.isOpaque = false
+        self.webView.backgroundColor = .clear
+        self.webView.scrollView.backgroundColor = .clear
+
+        self.navigationDelegate = NavigationDelegate()
+        self.webView.navigationDelegate = self.navigationDelegate
+        self.navigationDelegate.loader = self
+
+        self.webView.load(URLRequest(url: url))
+    }
+
+    deinit {
+        webView.navigationDelegate = nil
+        webView.stopLoading()
+    }
+
+    func retry() {
+        loadState = .loading
+        webView.load(URLRequest(url: initialURL))
+    }
+
+    func handleDidFinish() {
+        loadState = .loaded
+    }
+
+    func handleDidFail() {
+        loadState = .failed
+    }
+
+    func shouldAllowNavigation(to url: URL) -> Bool {
+        return url == initialURL
+    }
+}
+
+private final class NavigationDelegate: NSObject, WKNavigationDelegate {
+
+    weak var loader: WebViewLoader?
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        guard let url = navigationAction.request.url,
+              let loader = loader else {
+            decisionHandler(.cancel)
+            return
+        }
+
+        if loader.shouldAllowNavigation(to: url) {
+            decisionHandler(.allow)
+        } else {
+            decisionHandler(.cancel)
+            DispatchQueue.main.async {
+                UIApplication.shared.open(url)
+            }
+        }
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        loader?.handleDidFinish()
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        loader?.handleDidFail()
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        loader?.handleDidFail()
+    }
+}

--- a/Pilgrim/Scenes/WalkShare/WebViewLoader.swift
+++ b/Pilgrim/Scenes/WalkShare/WebViewLoader.swift
@@ -2,6 +2,7 @@ import Foundation
 import WebKit
 import Combine
 
+@MainActor
 final class WebViewLoader: ObservableObject {
 
     enum LoadState: Equatable {
@@ -35,8 +36,10 @@ final class WebViewLoader: ObservableObject {
     }
 
     deinit {
-        webView.navigationDelegate = nil
-        webView.stopLoading()
+        MainActor.assumeIsolated {
+            webView.navigationDelegate = nil
+            webView.stopLoading()
+        }
     }
 
     func retry() {
@@ -66,31 +69,43 @@ private final class NavigationDelegate: NSObject, WKNavigationDelegate {
         decidePolicyFor navigationAction: WKNavigationAction,
         decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
     ) {
-        guard let url = navigationAction.request.url,
-              let loader = loader else {
+        guard let url = navigationAction.request.url else {
             decisionHandler(.cancel)
             return
         }
 
-        if loader.shouldAllowNavigation(to: url) {
-            decisionHandler(.allow)
-        } else {
-            decisionHandler(.cancel)
-            DispatchQueue.main.async {
+        // WKNavigationDelegate callbacks are documented to arrive on the main thread.
+        // MainActor.assumeIsolated lets us call into the @MainActor-isolated loader
+        // synchronously (required because decisionHandler must be invoked before returning).
+        MainActor.assumeIsolated {
+            guard let loader = loader else {
+                decisionHandler(.cancel)
+                return
+            }
+            if loader.shouldAllowNavigation(to: url) {
+                decisionHandler(.allow)
+            } else {
+                decisionHandler(.cancel)
                 UIApplication.shared.open(url)
             }
         }
     }
 
     func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        loader?.handleDidFinish()
+        MainActor.assumeIsolated {
+            loader?.handleDidFinish()
+        }
     }
 
     func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
-        loader?.handleDidFail()
+        MainActor.assumeIsolated {
+            loader?.handleDidFail()
+        }
     }
 
     func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
-        loader?.handleDidFail()
+        MainActor.assumeIsolated {
+            loader?.handleDidFail()
+        }
     }
 }

--- a/Pilgrim/Scenes/WalkShare/WebViewRepresentable.swift
+++ b/Pilgrim/Scenes/WalkShare/WebViewRepresentable.swift
@@ -1,0 +1,15 @@
+import SwiftUI
+import WebKit
+
+struct WebViewRepresentable: UIViewRepresentable {
+
+    let webView: WKWebView
+
+    func makeUIView(context: Context) -> WKWebView {
+        webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        // WebView state is managed by WebViewLoader; nothing to update here.
+    }
+}

--- a/Pilgrim/Views/WalkSharingButtons.swift
+++ b/Pilgrim/Views/WalkSharingButtons.swift
@@ -201,11 +201,25 @@ struct WalkSharingButtons: View {
                         .tracking(1.5)
                 }
 
-                Text(cached.url)
-                    .font(Constants.Typography.caption)
-                    .foregroundColor(.stone)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
+                Button {
+                    showJourneySheet = true
+                } label: {
+                    HStack(spacing: 4) {
+                        Text(cached.url)
+                            .font(Constants.Typography.caption)
+                            .foregroundColor(.stone)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                        Image(systemName: "chevron.right")
+                            .font(.caption2)
+                            .foregroundColor(.stone.opacity(0.4))
+                            .accessibilityHidden(true)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("View shared walk page")
+                .accessibilityHint("Opens the walk share details to re-view the scroll")
 
                 Text("Returns to the trail on \(Self.expiryFormatter.string(from: cached.expiry))")
                     .font(Constants.Typography.caption)

--- a/UnitTests/WebViewLoaderTests.swift
+++ b/UnitTests/WebViewLoaderTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Pilgrim
 
+@MainActor
 final class WebViewLoaderTests: XCTestCase {
 
     private let shareURL = URL(string: "https://walk.pilgrimapp.org/abc123")!

--- a/UnitTests/WebViewLoaderTests.swift
+++ b/UnitTests/WebViewLoaderTests.swift
@@ -1,0 +1,48 @@
+import XCTest
+@testable import Pilgrim
+
+final class WebViewLoaderTests: XCTestCase {
+
+    private let shareURL = URL(string: "https://walk.pilgrimapp.org/abc123")!
+
+    func testInitialState_isLoading() {
+        let loader = WebViewLoader(url: shareURL)
+        XCTAssertEqual(loader.loadState, .loading)
+    }
+
+    func testDidFinish_transitionsToLoaded() {
+        let loader = WebViewLoader(url: shareURL)
+        loader.handleDidFinish()
+        XCTAssertEqual(loader.loadState, .loaded)
+    }
+
+    func testDidFail_transitionsToFailed() {
+        let loader = WebViewLoader(url: shareURL)
+        loader.handleDidFail()
+        XCTAssertEqual(loader.loadState, .failed)
+    }
+
+    func testRetry_afterFailure_returnsToLoading() {
+        let loader = WebViewLoader(url: shareURL)
+        loader.handleDidFail()
+        loader.retry()
+        XCTAssertEqual(loader.loadState, .loading)
+    }
+
+    func testShouldAllowNavigation_initialURL_returnsTrue() {
+        let loader = WebViewLoader(url: shareURL)
+        XCTAssertTrue(loader.shouldAllowNavigation(to: shareURL))
+    }
+
+    func testShouldAllowNavigation_differentURL_returnsFalse() {
+        let loader = WebViewLoader(url: shareURL)
+        let external = URL(string: "https://apple.com/")!
+        XCTAssertFalse(loader.shouldAllowNavigation(to: external))
+    }
+
+    func testShouldAllowNavigation_differentPathSameHost_returnsFalse() {
+        let loader = WebViewLoader(url: shareURL)
+        let other = URL(string: "https://walk.pilgrimapp.org/xyz999")!
+        XCTAssertFalse(loader.shouldAllowNavigation(to: other))
+    }
+}

--- a/UnitTests/WebViewLoaderTests.swift
+++ b/UnitTests/WebViewLoaderTests.swift
@@ -41,9 +41,15 @@ final class WebViewLoaderTests: XCTestCase {
         XCTAssertFalse(loader.shouldAllowNavigation(to: external))
     }
 
-    func testShouldAllowNavigation_differentPathSameHost_returnsFalse() {
+    func testShouldAllowNavigation_differentPathSameHost_returnsTrue() {
         let loader = WebViewLoader(url: shareURL)
         let other = URL(string: "https://walk.pilgrimapp.org/xyz999")!
-        XCTAssertFalse(loader.shouldAllowNavigation(to: other))
+        XCTAssertTrue(loader.shouldAllowNavigation(to: other))
+    }
+
+    func testShouldAllowNavigation_trailingSlashVariant_returnsTrue() {
+        let loader = WebViewLoader(url: shareURL)
+        let redirected = URL(string: "https://walk.pilgrimapp.org/abc123/")!
+        XCTAssertTrue(loader.shouldAllowNavigation(to: redirected))
     }
 }

--- a/docs/superpowers/plans/2026-04-22-walk-share-preview-ritual.md
+++ b/docs/superpowers/plans/2026-04-22-walk-share-preview-ritual.md
@@ -1,0 +1,961 @@
+# Walk Share Preview Ritual — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Auto-reveal the hosted walk page as a full-screen WKWebView modal after a successful share, with a contemplative 800 ms beat, soft haptic, slide-up animation, skeleton loading state, and a condensed post-ritual success card.
+
+**Architecture:** A new `WebViewLoader` ObservableObject owns a single `WKWebView` and publishes load state. `WebViewRepresentable` (a `UIViewRepresentable`) binds the webview into SwiftUI, with a navigation delegate that locks to the initial share URL and hands off external links to Safari. A new `WalkSharePreviewView` is the modal presentation (top bar + webview + skeleton overlay + floating Copy/Share). `WalkShareView` is modified to own the loader, trigger the ritual on `shareState` transitioning `.uploading → .success`, and present the modal via `.fullScreenCover`.
+
+**Tech Stack:** SwiftUI, WebKit (WKWebView), Combine, CocoaPods, XCTest.
+
+**Reference:** Design spec at `docs/superpowers/specs/2026-04-22-walk-share-preview-ritual-design.md`.
+
+---
+
+## File Structure
+
+**New files:**
+- `Pilgrim/Scenes/WalkShare/WebViewLoader.swift` — ObservableObject owning the `WKWebView`, publishing `LoadState` (loading / loaded / failed), with a pure `shouldAllowNavigation(to:)` policy method.
+- `Pilgrim/Scenes/WalkShare/WebViewRepresentable.swift` — `UIViewRepresentable` that embeds `WebViewLoader.webView` into SwiftUI.
+- `Pilgrim/Scenes/WalkShare/WalkSharePreviewView.swift` — the modal (top bar, webview middle, skeleton overlay, floating action bar).
+- `UnitTests/WebViewLoaderTests.swift` — unit tests for the loader's state machine and navigation policy.
+
+**Modified:**
+- `Pilgrim/Scenes/WalkShare/WalkShareView.swift` — condensed success card, `.fullScreenCover` wiring, `onChange` ritual trigger, hidden prefetch webview.
+
+**Unchanged:** `Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift` (state machine already distinguishes fresh vs cached via `.uploading`).
+
+---
+
+## Task 1: WebViewLoader state machine — failing test
+
+**Files:**
+- Create: `UnitTests/WebViewLoaderTests.swift`
+
+- [ ] **Step 1: Write the failing test file**
+
+Create `UnitTests/WebViewLoaderTests.swift` with this content:
+
+```swift
+import XCTest
+@testable import Pilgrim
+
+final class WebViewLoaderTests: XCTestCase {
+
+    private let shareURL = URL(string: "https://walk.pilgrimapp.org/abc123")!
+
+    func testInitialState_isLoading() {
+        let loader = WebViewLoader(url: shareURL)
+        XCTAssertEqual(loader.loadState, .loading)
+    }
+
+    func testDidFinish_transitionsToLoaded() {
+        let loader = WebViewLoader(url: shareURL)
+        loader.handleDidFinish()
+        XCTAssertEqual(loader.loadState, .loaded)
+    }
+
+    func testDidFail_transitionsToFailed() {
+        let loader = WebViewLoader(url: shareURL)
+        loader.handleDidFail()
+        XCTAssertEqual(loader.loadState, .failed)
+    }
+
+    func testRetry_afterFailure_returnsToLoading() {
+        let loader = WebViewLoader(url: shareURL)
+        loader.handleDidFail()
+        loader.retry()
+        XCTAssertEqual(loader.loadState, .loading)
+    }
+
+    func testShouldAllowNavigation_initialURL_returnsTrue() {
+        let loader = WebViewLoader(url: shareURL)
+        XCTAssertTrue(loader.shouldAllowNavigation(to: shareURL))
+    }
+
+    func testShouldAllowNavigation_differentURL_returnsFalse() {
+        let loader = WebViewLoader(url: shareURL)
+        let external = URL(string: "https://apple.com/")!
+        XCTAssertFalse(loader.shouldAllowNavigation(to: external))
+    }
+
+    func testShouldAllowNavigation_differentPathSameHost_returnsFalse() {
+        let loader = WebViewLoader(url: shareURL)
+        let other = URL(string: "https://walk.pilgrimapp.org/xyz999")!
+        XCTAssertFalse(loader.shouldAllowNavigation(to: other))
+    }
+}
+```
+
+- [ ] **Step 2: Run test — expect compile failure**
+
+Run:
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/WebViewLoaderTests 2>&1 | tail -20
+```
+
+Expected: compile error — `WebViewLoader` not defined.
+
+---
+
+## Task 2: Implement WebViewLoader
+
+**Files:**
+- Create: `Pilgrim/Scenes/WalkShare/WebViewLoader.swift`
+
+- [ ] **Step 1: Create the loader**
+
+Create `Pilgrim/Scenes/WalkShare/WebViewLoader.swift`:
+
+```swift
+import Foundation
+import WebKit
+import Combine
+
+final class WebViewLoader: ObservableObject {
+
+    enum LoadState: Equatable {
+        case loading
+        case loaded
+        case failed
+    }
+
+    @Published private(set) var loadState: LoadState = .loading
+
+    let webView: WKWebView
+    let initialURL: URL
+
+    private let navigationDelegate: NavigationDelegate
+
+    init(url: URL) {
+        self.initialURL = url
+
+        let config = WKWebViewConfiguration()
+        config.websiteDataStore = .nonPersistent()
+        self.webView = WKWebView(frame: .zero, configuration: config)
+        self.webView.isOpaque = false
+        self.webView.backgroundColor = .clear
+        self.webView.scrollView.backgroundColor = .clear
+
+        self.navigationDelegate = NavigationDelegate()
+        self.webView.navigationDelegate = self.navigationDelegate
+        self.navigationDelegate.loader = self
+
+        self.webView.load(URLRequest(url: url))
+    }
+
+    deinit {
+        webView.navigationDelegate = nil
+        webView.stopLoading()
+    }
+
+    func retry() {
+        loadState = .loading
+        webView.load(URLRequest(url: initialURL))
+    }
+
+    func handleDidFinish() {
+        loadState = .loaded
+    }
+
+    func handleDidFail() {
+        loadState = .failed
+    }
+
+    func shouldAllowNavigation(to url: URL) -> Bool {
+        return url == initialURL
+    }
+}
+
+private final class NavigationDelegate: NSObject, WKNavigationDelegate {
+
+    weak var loader: WebViewLoader?
+
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        guard let url = navigationAction.request.url,
+              let loader = loader else {
+            decisionHandler(.cancel)
+            return
+        }
+
+        if loader.shouldAllowNavigation(to: url) {
+            decisionHandler(.allow)
+        } else {
+            decisionHandler(.cancel)
+            DispatchQueue.main.async {
+                UIApplication.shared.open(url)
+            }
+        }
+    }
+
+    func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        loader?.handleDidFinish()
+    }
+
+    func webView(_ webView: WKWebView, didFail navigation: WKNavigation!, withError error: Error) {
+        loader?.handleDidFail()
+    }
+
+    func webView(_ webView: WKWebView, didFailProvisionalNavigation navigation: WKNavigation!, withError error: Error) {
+        loader?.handleDidFail()
+    }
+}
+```
+
+- [ ] **Step 2: Add the new file to the Xcode target**
+
+The file needs to be added to the `Pilgrim` target. Since this project uses an Xcode workspace, use this Ruby script to register the file via `xcodeproj`:
+
+```bash
+cd /Users/rubberduck/GitHub/momentmaker/pilgrim-ios
+# Check for xcodeproj gem; add the file by opening the workspace in Xcode and letting it be picked up by the file-system-synchronized group, or use a helper script.
+# Simplest: Xcode detects new files under Pilgrim/ automatically in sync'd groups. Verify membership in project.pbxproj.
+grep -c "WebViewLoader.swift" Pilgrim.xcodeproj/project.pbxproj
+```
+
+Expected: `>= 2` (file reference + build phase entry). If `0`, open Xcode, right-click `Pilgrim/Scenes/WalkShare/`, "Add Files to 'Pilgrim'", select `WebViewLoader.swift`, ensure `Pilgrim` target is checked.
+
+- [ ] **Step 3: Run tests — expect pass**
+
+Run:
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/WebViewLoaderTests 2>&1 | tail -20
+```
+
+Expected: `** TEST SUCCEEDED **` with all 7 tests passing.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Pilgrim/Scenes/WalkShare/WebViewLoader.swift UnitTests/WebViewLoaderTests.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat(share): add WebViewLoader state machine for preview modal"
+```
+
+---
+
+## Task 3: WebViewRepresentable (SwiftUI bridge)
+
+**Files:**
+- Create: `Pilgrim/Scenes/WalkShare/WebViewRepresentable.swift`
+
+- [ ] **Step 1: Create the representable**
+
+Create `Pilgrim/Scenes/WalkShare/WebViewRepresentable.swift`:
+
+```swift
+import SwiftUI
+import WebKit
+
+struct WebViewRepresentable: UIViewRepresentable {
+
+    let webView: WKWebView
+
+    func makeUIView(context: Context) -> WKWebView {
+        webView
+    }
+
+    func updateUIView(_ uiView: WKWebView, context: Context) {
+        // WebView state is managed by WebViewLoader; nothing to update here.
+    }
+}
+```
+
+- [ ] **Step 2: Add to Xcode target**
+
+Run:
+```bash
+grep -c "WebViewRepresentable.swift" Pilgrim.xcodeproj/project.pbxproj
+```
+
+Expected `>= 2` (see Task 2 step 2 guidance if not).
+
+- [ ] **Step 3: Build to verify it compiles**
+
+Run:
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Pilgrim/Scenes/WalkShare/WebViewRepresentable.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat(share): add WebViewRepresentable SwiftUI bridge"
+```
+
+---
+
+## Task 4: WalkSharePreviewView skeleton + chrome
+
+Build the modal UI in stages. This task creates the static structure; subsequent tasks wire in real webview content and animation.
+
+**Files:**
+- Create: `Pilgrim/Scenes/WalkShare/WalkSharePreviewView.swift`
+
+- [ ] **Step 1: Create the preview view**
+
+Create `Pilgrim/Scenes/WalkShare/WalkSharePreviewView.swift`:
+
+```swift
+import SwiftUI
+
+struct WalkSharePreviewView: View {
+
+    @ObservedObject var loader: WebViewLoader
+    let shareURL: String
+    let onDismiss: () -> Void
+
+    @State private var captionOpacity: Double = 0
+    @State private var showCopiedToast = false
+    @State private var toastGeneration = 0
+
+    var body: some View {
+        ZStack {
+            Color.parchment.ignoresSafeArea()
+
+            VStack(spacing: 0) {
+                topBar
+                contentArea
+                Spacer(minLength: 0)
+            }
+
+            VStack {
+                Spacer()
+                floatingActionBar
+            }
+        }
+        .onAppear {
+            withAnimation(.easeInOut(duration: 0.3).delay(0.2)) {
+                captionOpacity = 1
+            }
+        }
+    }
+
+    // MARK: - Top bar
+
+    private var topBar: some View {
+        HStack {
+            Text("Your walk.")
+                .font(Constants.Typography.heading)
+                .foregroundColor(.ink)
+                .opacity(captionOpacity)
+
+            Spacer()
+
+            Button("Done", action: onDismiss)
+                .font(Constants.Typography.button)
+                .foregroundColor(.stone)
+        }
+        .padding(.horizontal, Constants.UI.Padding.normal)
+        .padding(.vertical, Constants.UI.Padding.small)
+        .background(Color.parchment)
+    }
+
+    // MARK: - Content area
+
+    private var contentArea: some View {
+        ZStack {
+            WebViewRepresentable(webView: loader.webView)
+                .opacity(loader.loadState == .loaded ? 1 : 0)
+                .animation(.easeInOut(duration: 0.3), value: loader.loadState)
+
+            if loader.loadState == .loading {
+                skeleton
+            }
+
+            if loader.loadState == .failed {
+                failureView
+            }
+        }
+    }
+
+    private var skeleton: some View {
+        VStack(alignment: .leading, spacing: Constants.UI.Padding.normal) {
+            Rectangle()
+                .fill(Color.fog.opacity(0.2))
+                .frame(height: 28)
+                .frame(maxWidth: .infinity)
+
+            ForEach(0..<5, id: \.self) { _ in
+                Rectangle()
+                    .fill(Color.fog.opacity(0.15))
+                    .frame(height: 12)
+                    .frame(maxWidth: .infinity)
+            }
+
+            Rectangle()
+                .fill(Color.fog.opacity(0.1))
+                .frame(height: 140)
+                .frame(maxWidth: .infinity)
+        }
+        .padding(Constants.UI.Padding.big)
+        .transition(.opacity)
+    }
+
+    private var failureView: some View {
+        VStack(spacing: Constants.UI.Padding.normal) {
+            Text("The scroll will appear when your connection returns.")
+                .font(Constants.Typography.body)
+                .foregroundColor(.fog)
+                .multilineTextAlignment(.center)
+                .padding(.horizontal, Constants.UI.Padding.big)
+
+            Button("Retry", action: { loader.retry() })
+                .font(Constants.Typography.button)
+                .foregroundColor(.stone)
+                .padding(.horizontal, Constants.UI.Padding.big)
+                .padding(.vertical, 12)
+                .overlay(
+                    Capsule()
+                        .stroke(Color.stone.opacity(0.3), lineWidth: 1)
+                )
+        }
+    }
+
+    // MARK: - Floating action bar
+
+    private var floatingActionBar: some View {
+        HStack(spacing: Constants.UI.Padding.small) {
+            copyButton
+            shareButton
+        }
+        .padding(.horizontal, Constants.UI.Padding.normal)
+        .padding(.vertical, Constants.UI.Padding.small)
+        .background(
+            Color.parchment
+                .shadow(color: Color.black.opacity(0.08), radius: 8, x: 0, y: -2)
+        )
+    }
+
+    private var copyButton: some View {
+        Button {
+            UIPasteboard.general.string = shareURL
+            toastGeneration += 1
+            let gen = toastGeneration
+            showCopiedToast = true
+            Task {
+                try? await Task.sleep(for: .seconds(2))
+                if toastGeneration == gen { showCopiedToast = false }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Image(systemName: showCopiedToast ? "checkmark" : "doc.on.doc")
+                Text(showCopiedToast ? "Copied" : "Copy")
+                    .font(Constants.Typography.button)
+                    .minimumScaleFactor(0.8)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .background(Color.parchmentSecondary)
+            .foregroundColor(.stone)
+            .cornerRadius(Constants.UI.CornerRadius.small)
+        }
+    }
+
+    @ViewBuilder
+    private var shareButton: some View {
+        if let url = URL(string: shareURL) {
+            ShareLink(item: url) {
+                HStack(spacing: 4) {
+                    Image(systemName: "square.and.arrow.up")
+                    Text("Share")
+                        .font(Constants.Typography.button)
+                        .minimumScaleFactor(0.8)
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .background(Color.stone)
+                .foregroundColor(.parchment)
+                .cornerRadius(Constants.UI.CornerRadius.small)
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Add to Xcode target**
+
+Run:
+```bash
+grep -c "WalkSharePreviewView.swift" Pilgrim.xcodeproj/project.pbxproj
+```
+
+Expected `>= 2`.
+
+- [ ] **Step 3: Build**
+
+Run:
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Pilgrim/Scenes/WalkShare/WalkSharePreviewView.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat(share): add WalkSharePreviewView modal UI with skeleton and failure states"
+```
+
+---
+
+## Task 5: Condensed success card in WalkShareView
+
+Replace the existing `.success` case with the condensed card (no Copy/Share buttons on the card, tappable route preview, "View scroll" affordance, *"Shared ✓"* label).
+
+**Files:**
+- Modify: `Pilgrim/Scenes/WalkShare/WalkShareView.swift`
+
+- [ ] **Step 1: Read the current `.success` case**
+
+Run:
+```bash
+sed -n '267,330p' /Users/rubberduck/GitHub/momentmaker/pilgrim-ios/Pilgrim/Scenes/WalkShare/WalkShareView.swift
+```
+
+Confirm the current `.success` case is an `HStack` containing the route preview, URL text, expiry label, and Copy+Share buttons (lines 267–327).
+
+- [ ] **Step 2: Add state variables to WalkShareView**
+
+Find the `@State` declarations near the top of `WalkShareView` (around the existing `@State private var showCopiedToast`) and add:
+
+```swift
+@State private var showPreview = false
+@State private var revealTask: Task<Void, Never>?
+@StateObject private var webViewLoaderHolder = WebViewLoaderHolder()
+@State private var previewURL: String?
+```
+
+Where `WebViewLoaderHolder` is a small class that lazily creates the loader (needed because `@StateObject` requires eager init and we don't have the URL yet). Add this private class at the bottom of the file, outside the `WalkShareView` struct:
+
+```swift
+private final class WebViewLoaderHolder: ObservableObject {
+    @Published var loader: WebViewLoader?
+
+    func create(url: URL) {
+        loader = WebViewLoader(url: url)
+    }
+
+    func clear() {
+        loader = nil
+    }
+}
+```
+
+- [ ] **Step 3: Replace the `.success` case with the condensed card**
+
+Find `case .success(let url):` in the view body and replace its block (the entire `VStack` from the opening brace through the matching closing brace and modifiers, roughly lines 267–327) with:
+
+```swift
+case .success(let url):
+    VStack(spacing: Constants.UI.Padding.normal) {
+        Button {
+            openPreview(url: url)
+        } label: {
+            ZStack(alignment: .topTrailing) {
+                routePreview
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundColor(.fog.opacity(0.4))
+                    .padding(8)
+            }
+        }
+        .buttonStyle(.plain)
+
+        HStack(spacing: 6) {
+            Text("Shared")
+                .font(Constants.Typography.body)
+                .foregroundColor(.stone)
+            Image(systemName: "checkmark")
+                .font(.caption)
+                .foregroundColor(.moss)
+        }
+
+        Text("Returns to the trail on \(expiryDateFormatted)")
+            .font(Constants.Typography.caption)
+            .foregroundColor(.fog)
+            .italic()
+
+        Button {
+            openPreview(url: url)
+        } label: {
+            Text("View scroll")
+                .font(Constants.Typography.caption)
+                .foregroundColor(.fog)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 12)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+    .padding(Constants.UI.Padding.normal)
+    .background(Color.parchmentSecondary)
+    .cornerRadius(Constants.UI.CornerRadius.normal)
+```
+
+- [ ] **Step 4: Add the `openPreview` helper**
+
+Add this private function inside the `WalkShareView` struct (near other private helpers):
+
+```swift
+private func openPreview(url: String) {
+    guard let parsedURL = URL(string: url) else { return }
+    if webViewLoaderHolder.loader == nil {
+        webViewLoaderHolder.create(url: parsedURL)
+    }
+    previewURL = url
+    showPreview = true
+}
+```
+
+- [ ] **Step 5: Build**
+
+Run:
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **`. The preview modal is not yet wired in (that's Task 6).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Pilgrim/Scenes/WalkShare/WalkShareView.swift
+git commit -m "feat(share): condense success card, remove redundant copy/share buttons"
+```
+
+---
+
+## Task 6: Wire `.fullScreenCover` + ritual trigger
+
+Add the modal presentation, the hidden prefetch webview (0×0 frame), and the `onChange` handler that fires the ritual when `shareState` transitions `.uploading → .success`.
+
+**Files:**
+- Modify: `Pilgrim/Scenes/WalkShare/WalkShareView.swift`
+
+- [ ] **Step 1: Attach `.fullScreenCover` + hidden prefetch to the view body**
+
+Find the end of the main `body` (after the outermost view's closing brace but before `.onDisappear` if present, otherwise just before the final `}` of `var body: some View {`). Append these modifiers:
+
+```swift
+.fullScreenCover(isPresented: $showPreview, onDismiss: {
+    webViewLoaderHolder.clear()
+    previewURL = nil
+}) {
+    if let loader = webViewLoaderHolder.loader, let url = previewURL {
+        WalkSharePreviewView(
+            loader: loader,
+            shareURL: url,
+            onDismiss: { showPreview = false }
+        )
+    }
+}
+.background(
+    Group {
+        if let loader = webViewLoaderHolder.loader, !showPreview {
+            WebViewRepresentable(webView: loader.webView)
+                .frame(width: 0, height: 0)
+                .opacity(0)
+                .allowsHitTesting(false)
+        }
+    }
+)
+.onChange(of: viewModel.shareState) { oldValue, newValue in
+    triggerRitualIfNeeded(old: oldValue, new: newValue)
+}
+.onDisappear {
+    revealTask?.cancel()
+    revealTask = nil
+    webViewLoaderHolder.clear()
+}
+```
+
+- [ ] **Step 2: Add the `triggerRitualIfNeeded` helper**
+
+Add inside `WalkShareView`:
+
+```swift
+private func triggerRitualIfNeeded(
+    old: WalkShareViewModel.ShareState,
+    new: WalkShareViewModel.ShareState
+) {
+    guard case .uploading = old, case .success(let url) = new else { return }
+    guard let parsedURL = URL(string: url) else { return }
+
+    webViewLoaderHolder.create(url: parsedURL)
+    previewURL = url
+
+    revealTask?.cancel()
+    revealTask = Task {
+        try? await Task.sleep(for: .milliseconds(800))
+        guard !Task.isCancelled else { return }
+        await MainActor.run {
+            UIImpactFeedbackGenerator(style: .soft).impactOccurred()
+            showPreview = true
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Build**
+
+Run:
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 4: Manual smoke test — ritual fires on fresh share**
+
+1. Open simulator, launch app.
+2. Complete a walk or use demo mode (`--demo-mode`) to access a walk summary with Share enabled.
+3. Tap Share, wait.
+4. Expected: after Worker returns the URL, ~800 ms later a full-screen modal slides up showing the hosted page. Soft haptic at reveal. Caption *"Your walk."* fades in at top.
+5. Tap Done — modal dismisses, success card is in condensed form underneath.
+
+If the ritual does not fire, check: `onChange` fires correctly (add a temporary `print` inside `triggerRitualIfNeeded`), `Task.isCancelled` is false, `showPreview` is being set on the main actor.
+
+- [ ] **Step 5: Manual smoke test — cached share does NOT fire ritual**
+
+1. With a walk that was just shared, quit the app.
+2. Reopen the app, navigate to the same walk summary.
+3. Expected: condensed success card appears immediately, no modal, no haptic.
+4. Tap the route preview on the condensed card. Expected: modal opens (no 800 ms beat this time — deliberate tap).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Pilgrim/Scenes/WalkShare/WalkShareView.swift
+git commit -m "feat(share): trigger preview ritual on fresh share, tap-to-reopen from card"
+```
+
+---
+
+## Task 7: Reduce Motion honoring
+
+**Files:**
+- Modify: `Pilgrim/Scenes/WalkShare/WalkSharePreviewView.swift`
+
+- [ ] **Step 1: Honor Reduce Motion for caption fade**
+
+In `WalkSharePreviewView.swift`, at the top of the file (after `import SwiftUI`), add:
+
+```swift
+import UIKit
+```
+
+In the `body`, replace the `.onAppear` block with:
+
+```swift
+.onAppear {
+    let reduceMotion = UIAccessibility.isReduceMotionEnabled
+    let delay = reduceMotion ? 0.0 : 0.2
+    let duration = reduceMotion ? 0.2 : 0.3
+    withAnimation(.easeInOut(duration: duration).delay(delay)) {
+        captionOpacity = 1
+    }
+}
+```
+
+- [ ] **Step 2: Honor Reduce Motion for `.fullScreenCover` slide**
+
+`.fullScreenCover` uses iOS's default slide-up transition. Under Reduce Motion, iOS already swaps it to a crossfade automatically. No additional code needed. Verify this during manual testing.
+
+- [ ] **Step 3: Build**
+
+Run:
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 4: Manual smoke test — Reduce Motion**
+
+1. In simulator: Features → Accessibility → Motion → Reduce Motion (On).
+2. Share a walk.
+3. Expected: modal appears via crossfade rather than slide-up. Haptic still fires. Caption fade-in is shorter (0.2 s).
+4. Toggle Reduce Motion off, confirm slide-up returns.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Scenes/WalkShare/WalkSharePreviewView.swift
+git commit -m "feat(share): honor Reduce Motion for preview modal caption"
+```
+
+---
+
+## Task 8: VoiceOver focus order
+
+**Files:**
+- Modify: `Pilgrim/Scenes/WalkShare/WalkSharePreviewView.swift`
+
+- [ ] **Step 1: Add `.accessibilitySortPriority` to top bar, webview, and action bar**
+
+In `topBar`, add:
+```swift
+.accessibilitySortPriority(3)
+```
+immediately after the outer `.background(Color.parchment)`.
+
+In `contentArea`, after the closing `}` of the `ZStack`, add:
+```swift
+.accessibilitySortPriority(2)
+```
+
+In `floatingActionBar`, at the end of the view chain (after the `.background` modifier), add:
+```swift
+.accessibilitySortPriority(1)
+```
+
+- [ ] **Step 2: Build**
+
+Run:
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 3: Manual smoke test — VoiceOver**
+
+1. In simulator: triple-click Home button shortcut → enable VoiceOver (or Accessibility Inspector).
+2. Share a walk.
+3. Swipe right through modal elements.
+4. Expected order: *"Your walk."* caption → Done button → webview content → Copy → Share.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Pilgrim/Scenes/WalkShare/WalkSharePreviewView.swift
+git commit -m "feat(share): set VoiceOver focus order in preview modal"
+```
+
+---
+
+## Task 9: Full test suite pass + leak probe
+
+- [ ] **Step 1: Run all unit tests**
+
+Run:
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests 2>&1 | tail -10
+```
+
+Expected: `** TEST SUCCEEDED **`. All previously passing tests + the 7 new `WebViewLoaderTests` pass.
+
+- [ ] **Step 2: Manual leak probe with Instruments**
+
+1. In Xcode: Product → Profile → Allocations template.
+2. Launch app in simulator, start a walk, complete it.
+3. Share the walk (ritual fires, modal appears).
+4. Tap Done to dismiss.
+5. Repeat open-via-route-preview + Done 20 times.
+6. In Instruments' allocation view, filter by `WKWebView`. Expected: count returns to baseline after each dismiss; no unbounded growth.
+7. Also filter by `WebViewLoader` — same expectation.
+
+If `WKWebView` allocations accumulate:
+- Check `webViewLoaderHolder.clear()` is being called (add temporary `print`).
+- Check `WebViewLoader.deinit` is being called (add temporary `print`).
+- If neither fires on dismiss, there's a retain cycle — inspect for closures capturing `self` strongly.
+
+- [ ] **Step 3: Manual test — failure state**
+
+1. Disable network (Airplane mode on simulator's host, or block `walk.pilgrimapp.org` in `/etc/hosts`).
+2. Complete a walk, tap Share.
+3. If `.error` fires in the viewmodel: existing error UI shows. Preview does NOT auto-fire. ✓
+4. If the share succeeds (cached response) but webview can't reach the URL: the modal opens on skeleton, eventually transitions to failure state with Retry button.
+5. Tap Retry — confirm the state returns to `loading` and the skeleton reappears.
+
+- [ ] **Step 3b: Manual test — slow network / skeleton crossfade**
+
+1. In simulator: Features → Network Link Conditioner → select "3G" (or similar low-bandwidth profile).
+2. Complete a walk, tap Share.
+3. Expected: modal opens on skeleton at ~800 ms after share success. Skeleton visible for 1–3 seconds while the page paints. Skeleton crossfades (~0.3 s) to real content once `WKNavigationDelegate.webView(_:didFinish:)` fires.
+4. No judder or layout pop during crossfade.
+5. Reset network conditioner after testing.
+
+- [ ] **Step 4: Manual test — external link interception**
+
+Temporarily edit the `pilgrim-worker` (in `../pilgrim-worker`) to add an `<a href="https://apple.com">Apple</a>` link to the hosted page. Redeploy to dev. Share a walk. In the preview modal, tap the Apple link. Expected: Safari opens with apple.com; modal stays mounted on the original page. Revert the worker change after testing.
+
+- [ ] **Step 5: Manual test — ritual cancellation**
+
+To reproduce reliably, temporarily bump the delay in `triggerRitualIfNeeded` from 800 ms to 5 seconds. Share a walk, then before the modal appears, swipe back to the walk list (or background the app). Expected: the modal does NOT spuriously appear when you return. Revert the delay bump after testing.
+
+- [ ] **Step 6: Manual test — dark mode**
+
+1. Settings → Developer → Dark Appearance (or the app's appearance setting if available).
+2. Share a walk, observe modal in dark mode.
+3. Expected: parchment and stone colors render correctly; floating bar's drop shadow (`Color.black.opacity(0.08)`) remains visible against the page content; no bright halo inversions.
+
+- [ ] **Step 7: Manual test — iPad**
+
+1. Run app on iPad simulator (e.g., iPad Air 11-inch).
+2. Share a walk.
+3. Expected: modal is full-screen (not form-sheet). Copy/Share bar stretches across iPad width without awkward gaps. Haptic may not fire on iPad (no taptic engine) — that's fine.
+
+- [ ] **Step 8: Final commit (no code changes; verification only)**
+
+If all tests pass and manual checks succeed, no further commits are required. If any test reveals an issue, fix it as a Task 10 ad-hoc entry.
+
+---
+
+## Task 10: Final code review
+
+- [ ] **Step 1: Run the build + test suite one more time**
+
+Run:
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -10
+```
+
+Expected: `** BUILD SUCCEEDED **` + `** TEST SUCCEEDED **`.
+
+- [ ] **Step 2: Diff review**
+
+Run:
+```
+git diff main...HEAD --stat
+git log main..HEAD --oneline
+```
+
+Expected: 4 new files, 1 modified file, 8 commits.
+
+- [ ] **Step 3: Check for stale debug prints**
+
+Run:
+```
+git diff main...HEAD -- '*.swift' | grep -E '^\+.*print\('
+```
+
+Expected: no output. If any debug `print` statements remain from testing, remove them in a follow-up commit.
+
+- [ ] **Step 4: Open PR or merge to main (per user preference)**
+
+If this was worked in a worktree, merge back. If straight on main, push.
+
+```bash
+git push origin HEAD
+```
+
+---
+
+## Notes for the engineer
+
+- **Why a holder class for `WebViewLoader`?** `@StateObject` requires eager initialization in the view's init — but we don't have the URL until `shareState` fires `.success`. A lightweight `@StateObject WebViewLoaderHolder` that lazily instantiates the real loader lets us avoid constructing a webview we may never need (e.g., if the user never shares).
+- **Why `.background` instead of `.overlay` for the prefetch webview?** Both work. `.background` is slightly more idiomatic for invisible helpers. The `frame(width: 0, height: 0)` + `opacity(0)` + `allowsHitTesting(false)` combination ensures it doesn't affect layout or interaction.
+- **Why not use `@StateObject` on `WebViewLoader` directly?** Because its lifetime must span the hidden-prefetch + modal phases but also be torn down on dismiss. A holder gives us explicit control via `clear()`.
+- **SwiftUI `.fullScreenCover` transition customization**: if the default slide-up timing feels off (too fast, too slow), it's not easy to override directly. Open question in the spec flags a fall-back to a custom presentation controller if needed. Don't attempt this in v1 unless visual verification shows the default transition is off-vibe.
+- **CocoaPods/SPM**: no new dependencies. Everything uses Foundation, UIKit, WebKit, SwiftUI, Combine — all system frameworks.

--- a/docs/superpowers/specs/2026-04-22-walk-share-preview-ritual-design.md
+++ b/docs/superpowers/specs/2026-04-22-walk-share-preview-ritual-design.md
@@ -1,0 +1,181 @@
+# Walk Share Preview Ritual — Design Spec
+
+## Summary
+
+After a user successfully shares a walk, auto-reveal the actual hosted page as a full-screen scroll inside the app — a contemplative modal that lets them witness what they've made before (or instead of) sharing it. Replaces the current utility card where the URL is shown but unseen until copied elsewhere.
+
+## Motivation
+
+Share Your Walk's whole thesis is *the page quality should make people ask "what app is this?"* Today, after a successful share, the user sees a truncated URL and two buttons (Copy, Share) — they cannot see the artifact they just generated without round-tripping through the clipboard or a share sheet. For a pillar feature whose entire argument is aesthetic, hiding the artifact from its creator is an own goal.
+
+This spec re-frames the moment of successful share as a small ritual: *this is yours, witness it, share only if you choose.*
+
+## Non-Goals (for v1)
+
+- Auto-scroll-through-the-narrative on reveal (deferred; potential v1.1 polish)
+- Replacing the URL text with a goshuin-style seal/glyph (deferred)
+- "Recent Scrolls" history of past shared walks (deferred)
+- Edit-before-publish flow (separate feature, much larger scope)
+- Changes to the hosted HTML itself in `pilgrim-worker` (Dynamic Type caveat noted below but not fixed here)
+
+## Design
+
+### User Flow — Fresh Share (Ritual Fires)
+
+1. User taps Share. `shareState` transitions `.idle → .uploading` (unchanged).
+2. Worker returns URL. `shareState` transitions `.uploading → .success(url)`. This transition is the signal that fires the ritual.
+3. The moment `.success` fires, kick off a hidden `WKWebView` and begin loading the URL (prefetch).
+4. Success card appears (briefly — it's about to be replaced).
+5. After a contemplative beat (~800 ms), a full-screen modal slides up from the bottom over the success card.
+6. Modal slide-in: 0.6 s `easeOut`, paired with one `UIImpactFeedbackGenerator(style: .soft)` at the start of the reveal.
+7. 200 ms after the modal reaches its final position, a serif caption *"Your walk."* fades in at the top.
+8. User reads, scrolls, and taps Copy / Share / Done at their own pace.
+9. On dismiss, the modal slides down. The success card underneath transitions to its **condensed** post-ritual form.
+
+### User Flow — Cached Share (No Ritual)
+
+1. User opens a walk summary they've previously shared. `shareState` goes `.idle → .success(url)` directly from the existing cache hit at `WalkShareViewModel.swift:129`.
+2. **No modal appears.** Condensed card shown immediately.
+3. Tapping the route preview on the condensed card opens the same modal — without the 800 ms beat. A deliberate tap is not a ritual moment; it's an intentional action.
+
+This distinction is the entire persistence story: the `.uploading → .success` transition is the "fresh" signal. `.idle → .success` (or rebuilding the view with an already-successful state) is the "cached" signal. No flag, no stored "has been seen" state.
+
+### User Flow — Failure
+
+- Worker returns error → existing `.error` state, unchanged.
+- Worker succeeded (`.success(url)` fired) but webview fails to load (network drop, Worker degraded, R2 hiccup) → modal still opens on the skeleton state, with an inline retry affordance ("The scroll will appear when your connection returns" + Retry button). The modal does **not** auto-dismiss on timeout. The user taps Done when ready — preserving agency even in the failure case.
+
+### Modal Visual Design
+
+- Full-screen presentation (`.fullScreenCover`).
+- Parchment background behind the webview, visible briefly during load and between content if the page doesn't fill the screen.
+- **Top bar** (parchment, non-opaque, soft bottom shadow only when content scrolls beneath):
+  - Left: serif caption *"Your walk."* using `Constants.Typography.body` or `.heading` (to be decided in implementation against the surrounding type scale). Fades in 200 ms after modal settles; does not slide in with the modal.
+  - Right: `Done` button, `Constants.Typography.button`, stone color.
+- **Middle**: `WKWebView` wrapped in `UIViewRepresentable`. `isOpaque = false`, `backgroundColor = .clear` so parchment shows through during initial paint.
+- **Bottom floating action bar** (safe-area-inset aware):
+  - Parchment background with soft top shadow so page content reads through as it scrolls past.
+  - Copy button (left) + Share button (right), same visual weight and sizing as today's success card buttons.
+  - `Copy` mirrors existing clipboard + toast behavior from `WalkShareView.swift:283–291`.
+  - `Share` uses the existing `ShareLink` from `WalkShareView.swift:307–322`.
+
+### Skeleton (Loading State)
+
+Shown inside the modal when the webview has not yet painted by the time the modal opens. Aesthetic: "the page being drawn."
+
+- Parchment background (matches the real page's background).
+- Faint Cormorant-styled ghost lines for heading and body text, using `Color.fog.opacity(~0.2)`.
+- Soft ink outline sketch where the route will render.
+- Crossfades out (~0.3 s) when `WKNavigationDelegate.webView(_:didFinish:)` fires for the share URL's navigation.
+
+### Reveal Animation
+
+| State | Motion | Haptic |
+|---|---|---|
+| Default | Slide up from bottom, 0.6 s `easeOut` | `UIImpactFeedbackGenerator(style: .soft)` at reveal start |
+| Reduce Motion (`UIAccessibility.isReduceMotionEnabled`) | Parchment crossfade, 0.4 s | Same soft haptic |
+
+### Condensed Success Card (Post-Ritual or Cache Hit)
+
+Replaces the current `.success` card structure at `WalkShareView.swift:267–327`.
+
+- **Route preview**: the existing route preview component, reused. **Tappable** — tap re-opens the modal.
+- Small chevron-right glyph in the corner of the route preview as a discoverability hint.
+- Below the route preview: serif *"Shared"* label + existing expiry line *"Returns to the trail on X"*.
+- **Copy and Share buttons are removed from the card.** They live in the modal.
+- Card footer: a quiet tap affordance reading *"View scroll"* in `Constants.Typography.caption`, fog color, centered below the expiry line.
+
+### Re-Opening the Modal Later
+
+From the condensed card, tapping the route preview or the "View scroll" caption re-opens the modal. This path:
+
+- Does **not** use the 800 ms beat (deliberate action, not ritual).
+- Does not play a haptic on reveal (no need — the user initiated it themselves).
+- Uses the same `WKWebView` prefetch behavior: if the webview isn't already loaded in memory, it loads fresh. (We do not persist the webview across dismissals — see memory safety below.)
+
+## Technical Architecture
+
+### New Components
+
+- **`WalkSharePreviewView`** — SwiftUI view containing the `WKWebView` + top bar + floating action bar + skeleton overlay. Presented as a `.fullScreenCover` from `WalkShareView`.
+- **`WebViewRepresentable`** — `UIViewRepresentable` wrapping `WKWebView` with the navigation delegate and first-paint signaling. Could be placed alongside `WalkSharePreviewView` or, if general-purpose, under `Pilgrim/Views/`.
+
+### Prefetch
+
+- Start loading the share URL in a hidden `WKWebView` the moment `shareState` becomes `.success`.
+- When the modal opens, reuse the same webview instance (wired through `@StateObject` or a coordinator).
+- In the cached-share path (no modal auto-fires), prefetch is deferred until the user taps to open the modal.
+
+### Navigation Policy
+
+`WKNavigationDelegate.webView(_:decidePolicyFor:decisionHandler:)`:
+
+- Allow the initial load of the share URL itself.
+- Any subsequent navigation action to a different URL → cancel the navigation and hand the URL off to `UIApplication.shared.open(...)` so it opens in Safari.
+
+This protects against future iterations of the hosted page adding links (e.g., to the App Store or landing page) turning the in-app preview into a general-purpose browser.
+
+### Memory & Lifecycle Safety
+
+Consistent with the project's resource-safety discipline (`.claude/CLAUDE.md`):
+
+- The `WKWebView` is torn down when the modal is dismissed. We do **not** keep it alive across the whole walk session.
+- Accept a small cost (~hundreds of ms of re-load) on re-opening the same scroll later in favor of eliminating the risk of cumulative webview leaks during a 30+ minute walk.
+- All `WKNavigationDelegate` closures use `[weak self]` and the delegate is explicitly nulled on dismiss.
+- Use `WKWebsiteDataStore.nonPersistent()` so no cookies, cache, or storage persists across preview sessions. Aligned with both the per-dismiss teardown discipline and the privacy posture of the rest of the app.
+- Leak probe (manual + Instruments) is part of the test plan below.
+
+### State Signal for Ritual
+
+`WalkShareView` observes `shareState` via `.onChange(of:)`. Ritual fires if and only if the previous value was `.uploading` and the new value is `.success`. The two paths in `WalkShareViewModel` reach `.success` differently:
+
+- Fresh share: `.idle → .uploading → .success` (the `.uploading` assignment is at `WalkShareViewModel.swift:135`, the success assignment at line 145).
+- Cache hit: `.idle → .success` (single assignment at line 129, no `.uploading` in between).
+
+`.onChange` sees the pre/post values directly, so the `.uploading → .success` filter distinguishes cleanly. No persistence flag, no "has been seen" state. If the view is rebuilt or torn down mid-flow, the ritual simply does not fire — and the condensed card appears directly on next open, which is the correct behavior.
+
+### File Touch List (Estimated)
+
+- `Pilgrim/Scenes/WalkShare/WalkShareView.swift` — modify success case to use condensed card + `.fullScreenCover` wiring + `.onChange(of: shareState)` for ritual trigger.
+- `Pilgrim/Scenes/WalkShare/WalkSharePreviewView.swift` — new file, modal + webview + skeleton + floating action bar.
+- `Pilgrim/Scenes/WalkShare/WebViewRepresentable.swift` — new file, `UIViewRepresentable` wrapping `WKWebView` with navigation delegate.
+- `Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift` — no changes expected; the state machine already distinguishes fresh vs cached cleanly (see State Signal above).
+
+## Accessibility
+
+- **Reduce Motion**: handled via the crossfade fallback specified in the reveal animation table above.
+- **VoiceOver**: focus order on modal reveal is (1) *"Your walk."* caption, (2) webview content, (3) Copy / Share / Done bar. Implement via `.accessibilitySortPriority` or an explicit focus trap.
+- **Dynamic Type**: the webview text is governed by the hosted page's CSS in `pilgrim-worker`, not `Constants.Typography`. The existing page needs to respect the iOS system font size. **Known gap** — filed as a follow-up to address in `pilgrim-worker`; not blocking this iOS change.
+- **Haptics**: a single soft impact on reveal. No haptic on any other interaction (Copy already has toast feedback; Share hands off to the system sheet).
+
+## Test Plan
+
+Manual and automated checks to add:
+
+1. **Happy path (fresh share, WiFi)** — share completes, modal reveals after ~800 ms with fully painted content, haptic fires, caption fades in 200 ms later.
+2. **Fresh share on slow network** — throttle to 3G in simulator, confirm skeleton appears and crossfades into real content without judder.
+3. **Worker-down failure** — block `walk.pilgrimapp.org` in charles proxy / `/etc/hosts`, confirm inline retry appears, user can dismiss, share URL on condensed card is still functional.
+4. **Cached share** — share walk, kill app, reopen, navigate to same walk summary, confirm **no modal auto-fires** and condensed card appears directly.
+5. **Re-open via tap** — from condensed card, tap route preview, confirm modal opens without the 800 ms beat and without haptic.
+6. **Reduce Motion** — enable in iOS Settings → Accessibility → Motion, confirm crossfade path (no slide-up) and haptic still fires.
+7. **VoiceOver navigation** — enable VoiceOver, confirm focus order.
+8. **Leak probe** — open/dismiss modal 20× during a simulated walk, verify `WKWebView` instance count returns to zero in Instruments' allocation tracker. Run during a 30+ minute simulated walk to check for cumulative drift.
+9. **External link interception** — temporarily add a link to the hosted page (pilgrim-worker dev), confirm tapping it opens Safari rather than navigating inside the modal.
+
+## Decisions & Tradeoffs
+
+Choices made during brainstorming that future iterations should know about:
+
+- **Ritual over utility**: the modal auto-reveals rather than requiring a tap. Rationale: for a feature whose whole thesis is aesthetic, hiding the artifact behind a tap is the wrong default.
+- **WKWebView over SFSafariViewController**: chosen for full control over chrome and vibe. Costs: more implementation work, no built-in Safari affordances. Benefit: no URL bar or reader-mode button intruding on the moment.
+- **No persistence of "has seen" state**: ritual fires only on a live `.uploading → .success` transition. Simpler than a flag; handles backgrounding/force-quit naturally (just shows the condensed card on next open).
+- **Copy/Share floating, always visible** (vs embedded at the bottom of the scroll): respects user autonomy. The modal is not a gated experience.
+- **Condensed card after dismiss** (vs keeping full success card): once the ritual has happened, repeating Copy/Share on the outer card is bureaucratic. Users can re-open the modal to act.
+- **Navigation locked to the share URL**: future-proofing. If the hosted page ever needs outbound links, we relax this.
+- **Webview torn down per dismiss**: safety over caching. A 30+ minute walk session cannot tolerate a compounding webview leak.
+
+## Open Questions (for implementation)
+
+- Exact typography scale for the *"Your walk."* caption — `.heading` feels right for weight, `.body` for size restraint. Decide against the rendered mock.
+- Chevron glyph color/opacity on the condensed route preview — pick against the existing `routePreview` component to avoid overpowering it.
+- Whether to use `.fullScreenCover` or a custom `UIViewControllerRepresentable` presentation. `.fullScreenCover` should work; if its transition can't be customized enough for the 0.6 s slide, fall back to custom presentation.

--- a/docs/superpowers/specs/2026-04-22-walk-share-preview-ritual-design.md
+++ b/docs/superpowers/specs/2026-04-22-walk-share-preview-ritual-design.md
@@ -64,7 +64,7 @@ This distinction is the entire persistence story: the `.uploading → .success` 
 Shown inside the modal when the webview has not yet painted by the time the modal opens. Aesthetic: "the page being drawn."
 
 - Parchment background (matches the real page's background).
-- Faint Cormorant-styled ghost lines for heading and body text, using `Color.fog.opacity(~0.2)`.
+- Faint Cormorant Garamond ghost lines for heading and body text, using `Color.fog.opacity(~0.2)` (tune against the rendered page during implementation).
 - Soft ink outline sketch where the route will render.
 - Crossfades out (~0.3 s) when `WKNavigationDelegate.webView(_:didFinish:)` fires for the share URL's navigation.
 
@@ -81,17 +81,18 @@ Replaces the current `.success` card structure at `WalkShareView.swift:267–327
 
 - **Route preview**: the existing route preview component, reused. **Tappable** — tap re-opens the modal.
 - Small chevron-right glyph in the corner of the route preview as a discoverability hint.
-- Below the route preview: serif *"Shared"* label + existing expiry line *"Returns to the trail on X"*.
+- Below the route preview: serif *"Shared ✓"* label (checkmark glyph) + existing expiry line *"Returns to the trail on X"*.
 - **Copy and Share buttons are removed from the card.** They live in the modal.
-- Card footer: a quiet tap affordance reading *"View scroll"* in `Constants.Typography.caption`, fog color, centered below the expiry line.
+- Card footer: a quiet tap affordance reading *"View scroll"* in `Constants.Typography.caption`, fog color, centered below the expiry line. The tap target extends via `.contentShape(Rectangle())` and vertical padding so the hit region meets the 44×44 pt HIG minimum even though the glyph is small.
 
 ### Re-Opening the Modal Later
 
 From the condensed card, tapping the route preview or the "View scroll" caption re-opens the modal. This path:
 
 - Does **not** use the 800 ms beat (deliberate action, not ritual).
-- Does not play a haptic on reveal (no need — the user initiated it themselves).
-- Uses the same `WKWebView` prefetch behavior: if the webview isn't already loaded in memory, it loads fresh. (We do not persist the webview across dismissals — see memory safety below.)
+- Does **not** play a haptic on reveal (no need — the user initiated it themselves).
+- **Uses the same slide-up animation** (0.6 s `easeOut`, or crossfade under Reduce Motion). The visual vocabulary stays constant; what differs between ritual and re-open is only the pre-roll beat and haptic.
+- Webview loads from scratch each time. We do not persist the `WKWebView` across dismissals (see memory safety below). The skeleton appears during first paint on every re-open.
 
 ## Technical Architecture
 
@@ -102,9 +103,32 @@ From the condensed card, tapping the route preview or the "View scroll" caption 
 
 ### Prefetch
 
-- Start loading the share URL in a hidden `WKWebView` the moment `shareState` becomes `.success`.
+- Start loading the share URL in a hidden `WKWebView` the moment `shareState` becomes `.success` via a fresh-share transition. The hidden webview is mounted in the view hierarchy with `.frame(width: 0, height: 0)` (not `.hidden()` — `WKWebView` needs to be in the hierarchy to actually load) and sits behind the success card until the modal opens.
 - When the modal opens, reuse the same webview instance (wired through `@StateObject` or a coordinator).
-- In the cached-share path (no modal auto-fires), prefetch is deferred until the user taps to open the modal.
+- In the cached-share path, prefetch does not fire. The webview loads from scratch the first time the user taps to open the modal. Skeleton handles the perceived-latency gap.
+
+### Ritual Cancellation Safety
+
+The 800 ms contemplative beat is implemented as a Swift `Task` with a sleep + cancellation guard, not `DispatchQueue.asyncAfter` — so that if the view disappears (user dismisses the walk summary, app backgrounds, etc.) during the beat, the delayed modal reveal cancels cleanly. Pattern (iOS 17+ `onChange` with both old and new values):
+
+```swift
+@State private var revealTask: Task<Void, Never>?
+
+...
+
+.onChange(of: viewModel.shareState) { oldValue, newValue in
+    guard case .uploading = oldValue, case .success = newValue else { return }
+    revealTask?.cancel()
+    revealTask = Task {
+        try? await Task.sleep(for: .milliseconds(800))
+        guard !Task.isCancelled else { return }
+        showPreview = true
+    }
+}
+.onDisappear { revealTask?.cancel() }
+```
+
+This follows the resource-safety discipline in `.claude/CLAUDE.md` for timer/async cancellation. It also doubles as the State Signal for the ritual — see below.
 
 ### Navigation Policy
 
@@ -141,10 +165,15 @@ Consistent with the project's resource-safety discipline (`.claude/CLAUDE.md`):
 - `Pilgrim/Scenes/WalkShare/WebViewRepresentable.swift` — new file, `UIViewRepresentable` wrapping `WKWebView` with navigation delegate.
 - `Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift` — no changes expected; the state machine already distinguishes fresh vs cached cleanly (see State Signal above).
 
+## Device & Appearance Considerations
+
+- **iPad**: the project targets iPhone + iPad (`TARGETED_DEVICE_FAMILY = "1,2"`). `.fullScreenCover` on iPad presents as an iPad-sized full-screen modal, not a floating form sheet — which is correct for the ritual framing (we want immersion, not a windowed preview). No iPad-specific layout code needed for v1; rely on standard SwiftUI adaptive layout. Verify Copy/Share bar renders correctly at iPad widths during testing.
+- **Dark mode**: colors used in the modal (parchment, stone, fog) must be chosen deliberately. Per `feedback_shadow_color_not_adaptive`, adaptive `ink`/`fog` colors can invert and become bright halos in dark mode. For the floating action bar's top shadow, use a **fixed** dark color (e.g., `Color.black.opacity(0.08)`), not `Color.ink.opacity(...)`. Verify modal in both appearances during testing.
+
 ## Accessibility
 
 - **Reduce Motion**: handled via the crossfade fallback specified in the reveal animation table above.
-- **VoiceOver**: focus order on modal reveal is (1) *"Your walk."* caption, (2) webview content, (3) Copy / Share / Done bar. Implement via `.accessibilitySortPriority` or an explicit focus trap.
+- **VoiceOver**: focus order on modal reveal is (1) *"Your walk."* caption, (2) webview content, (3) Copy / Share / Done bar. Implement via `.accessibilitySortPriority` (higher number = earlier in focus order), not a custom focus trap — the native SwiftUI approach composes more cleanly with `.fullScreenCover`.
 - **Dynamic Type**: the webview text is governed by the hosted page's CSS in `pilgrim-worker`, not `Constants.Typography`. The existing page needs to respect the iOS system font size. **Known gap** — filed as a follow-up to address in `pilgrim-worker`; not blocking this iOS change.
 - **Haptics**: a single soft impact on reveal. No haptic on any other interaction (Copy already has toast feedback; Share hands off to the system sheet).
 
@@ -161,6 +190,9 @@ Manual and automated checks to add:
 7. **VoiceOver navigation** — enable VoiceOver, confirm focus order.
 8. **Leak probe** — open/dismiss modal 20× during a simulated walk, verify `WKWebView` instance count returns to zero in Instruments' allocation tracker. Run during a 30+ minute simulated walk to check for cumulative drift.
 9. **External link interception** — temporarily add a link to the hosted page (pilgrim-worker dev), confirm tapping it opens Safari rather than navigating inside the modal.
+10. **Ritual cancellation** — initiate share, then during the 800 ms beat (introduce a larger delay temporarily if needed to reproduce reliably), navigate away from the walk summary or background the app. Confirm the modal does not appear spuriously on return.
+11. **Dark mode** — switch appearance mid-preview, confirm floating action bar's shadow and background remain legible, no adaptive-color inversions.
+12. **iPad layout** — run preview on iPad simulator, confirm modal is full-screen (not form-sheet) and Copy/Share bar renders at the wider width without awkward gaps.
 
 ## Decisions & Tradeoffs
 


### PR DESCRIPTION
## Summary

After a successful share, auto-reveal the hosted walk page as a full-screen `WKWebView` modal inside the app — the user finally sees what they just made before (or instead of) sharing it. Replaces the old URL-plus-two-buttons success card that hid the artifact behind a clipboard round-trip.

**Three UX pillars:**
- **Ritual reveal** on fresh share only: 800 ms contemplative beat, soft haptic, slide-up modal with a serif *"Your walk."* caption that fades in 200 ms after the modal settles
- **Condensed success card** after dismiss: tappable route preview + *"Shared ✓"* + expiry + *"View scroll"* affordance. Copy/Share move into the modal's floating bar
- **Re-entry from walk summary**: the URL in the existing `WalkSharingButtons` activeShareSection becomes tappable with a chevron hint — re-opens the sheet, two taps to re-view the scroll

**Supporting work:**
- New `WebViewLoader` (`@MainActor` ObservableObject) owning a `WKWebView` with `WKWebsiteDataStore.nonPersistent()`, publishing a `.loading / .loaded / .failed` state machine
- `WebViewRepresentable` bridging the webview into SwiftUI
- Navigation delegate locks to the initial URL's host (same-host match tolerates redirects); external links hand off to Safari
- Hidden prefetch webview at `frame(0,0)` starts loading the moment `.success` fires so the modal usually opens on painted content; skeleton fallback crossfades when it doesn't
- Cancellable `Task` pattern for both the 800 ms ritual beat and the podcast-card reveal, cancelled in `onDisappear` to respect the 30+ min walk resource-safety rules

**Behavior-change worth noting:** the pre-existing podcast-submission card's reveal is moved from *"800 ms after share success"* to *"after the ritual modal dismisses"*. The old timing collided with the new ritual — double haptic, card animating invisibly behind the modal. Now the podcast card fades in visibly with a clean haptic separation once the user dismisses the preview. Cache-hit re-entry is gated by a `ritualDidFire` flag so re-viewing an old walk doesn't re-pitch the podcast.

Full design spec: `docs/superpowers/specs/2026-04-22-walk-share-preview-ritual-design.md`.
Implementation plan: `docs/superpowers/plans/2026-04-22-walk-share-preview-ritual.md`.

### Decisions made

- **WKWebView over SFSafariViewController** — Safari chrome (URL bar, reader mode) fights the wabi-sabi frame; WKWebView gives full control over the ritual
- **Auto-reveal over tap-to-reveal** — for a feature whose whole thesis is aesthetic, hiding the artifact behind a tap is the wrong default
- **No persistence of "has seen" state** — the `.uploading → .success` state transition is a natural filter for fresh vs cached
- **Per-dismiss webview teardown** — safety over caching; a compounding webview leak across a 30 min walk is unacceptable
- **Same-host navigation policy** — robust to Worker URL redirects/normalization; strict equality would have silently broken the initial load

## Test plan

Unit tests already cover the `WebViewLoader` state machine (8 tests, all pass). Manual QA (on simulator or device) for the SwiftUI layer:

- [ ] **Happy path (fresh share, WiFi)** — share a walk → ~800 ms later modal slides up with soft haptic → caption *"Your walk."* fades in → Done dismisses to condensed card
- [ ] **Cached share — no ritual** — kill app, reopen, navigate to previously-shared walk → condensed card appears directly, NO modal, NO haptic
- [ ] **Re-open via condensed card** — tap route preview or *"View scroll"* → modal opens immediately (no 800 ms beat, no haptic)
- [ ] **Re-open via walk summary URL** — on walk summary for a shared walk, tap the URL row → sheet opens → tap *"View scroll"* → modal opens
- [ ] **Slow network** — Network Link Conditioner → 3G → share → skeleton appears, crossfades to real content when first-paint fires
- [ ] **Worker-down / offline** — turn off WiFi after share success, re-open modal → skeleton → failure view with Retry; Retry returns to loading
- [ ] **Reduce Motion** — enable in Settings → modal appears via crossfade (not slide-up), caption fades shorter, haptic still fires
- [ ] **VoiceOver** — order should be: *"View shared walk page"* button on condensed card → *"Your walk."* caption → Done → webview content → Copy → Share
- [ ] **Dark mode** — floating bar's shadow (`Color.black.opacity(0.08)`) renders correctly, no bright-halo inversion
- [ ] **iPad** — modal is full-screen, Copy/Share bar stretches cleanly
- [ ] **Ritual cancellation** — bump beat to 5 s temporarily, share, swipe back to walk list mid-beat → modal does NOT spuriously appear on return
- [ ] **Podcast card timing** — for a podcast-eligible walk: share → ritual modal (one haptic) → user reads/dismisses → ~500 ms later podcast card fades in with its own haptic (cleanly separated)
- [ ] **Podcast card gated on cache-hit** — re-view a previously-shared podcast-eligible walk via walk summary URL → dismiss modal → podcast card does NOT appear (it's a fresh-share-only pitch)
- [ ] **Leak probe (Instruments → Allocations)** — open/dismiss modal 20× during a simulated walk, verify `WKWebView` count returns to baseline

## Follow-ups (not in this PR)

- Pre-existing `DispatchQueue.asyncAfter` at `WalkShareView.swift:73` (podcast-card trigger) — now removed in this PR's refactor, but the broader project still has similar patterns worth auditing
- `NavigationView` at `WalkShareView.swift:28` — deprecated since iOS 16; migrate to `NavigationStack`
- Dynamic Type on the hosted HTML — responsibility of `pilgrim-worker`, not iOS
- Auto-scroll-through-the-narrative on first reveal — deferred to v1.1 per spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)