### PR TITLE
chore: migrate NavigationView to NavigationStack

### DIFF
--- a/Pilgrim/Scenes/Prompts/CustomPromptEditorView.swift
+++ b/Pilgrim/Scenes/Prompts/CustomPromptEditorView.swift
@@ -19,7 +19,7 @@ struct CustomPromptEditorView: View {
     ]
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: Constants.UI.Padding.big) {
                     titleSection

--- a/Pilgrim/Scenes/Prompts/PromptDetailView.swift
+++ b/Pilgrim/Scenes/Prompts/PromptDetailView.swift
@@ -11,7 +11,7 @@ struct PromptDetailView: View {
     @State private var copyResetWorkItem: DispatchWorkItem?
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             VStack(spacing: 0) {
                 ScrollView {
                     VStack(alignment: .leading, spacing: Constants.UI.Padding.big) {

--- a/Pilgrim/Scenes/WalkShare/WalkShareView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareView.swift
@@ -27,7 +27,7 @@ struct WalkShareView: View {
     }
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ScrollView {
                 VStack(spacing: Constants.UI.Padding.big) {
                     if isShared {

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
@@ -50,7 +50,7 @@ struct WalkSummaryView: View {
     @State private var animatedDistance: Double = 0
 
     var body: some View {
-        NavigationView {
+        NavigationStack {
             ScrollView {
                 VStack(spacing: Constants.UI.Padding.normal) {
                     mapSection
@@ -144,7 +144,7 @@ struct WalkSummaryView: View {
                 }
             }
             .sheet(isPresented: $showPrompts) {
-                NavigationView {
+                NavigationStack {
                     PromptListView(walk: walk, transcriptions: transcriptions, recentWalkSnippets: recentWalkSnippets, intention: walk.comment, photoCandidates: photoCandidates)
                 }
             }


### PR DESCRIPTION
## Summary

`NavigationView` has been deprecated since iOS 16. This replaces all 5 occurrences with `NavigationStack`.

Every occurrence was a direct swap with zero API-migration work:
- No `NavigationLink` push/pop usage
- No `navigationBarItems` (deprecated) — all already use `.toolbar { ToolbarItem(...) }`
- No `navigationViewStyle` customization (no iPad split-view expectations)
- All sites are sheet/modal roots using the navigation container purely for their title bar + Cancel/Done toolbar

5 sites in 4 files, 5 lines changed.

## Test plan

- [x] 447/447 unit tests pass
- [x] Clean build on iOS 18 simulator
- [ ] Manual smoke test on device — each affected sheet/modal renders correctly:
  - [ ] Share sheet for a walk (WalkShareView)
  - [ ] Walk summary view (WalkSummaryView, both the main view and the Prompts sheet opened from it)
  - [ ] Prompt detail view (PromptDetailView)
  - [ ] Custom prompt editor (CustomPromptEditorView)

No iPad-specific behavior changes because none of these sites relied on `NavigationView`'s iPad split-view rendering (they all present as sheets, which use form-sheet/full-screen presentation on iPad regardless of navigation container).

🤖 Generated with [Claude Code](https://claude.com/claude-code)