### PR TITLE
fix(walk): crash resilience for locked walk+talk sessions

### DIFF
--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 		LR00000200000000LRWVLD01 /* WebViewLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVLD01 /* WebViewLoader.swift */; };
 		LR00000200000000LRWVLDT1 /* WebViewLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVLDT1 /* WebViewLoaderTests.swift */; };
 		LR00000200000000LRVRCPT1 /* VoiceRecordingCheckpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRVRCPT1 /* VoiceRecordingCheckpointTests.swift */; };
+		LR00000200000000LRVRCIT1 /* VoiceRecordingCallInterruptionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRVRCIT1 /* VoiceRecordingCallInterruptionTests.swift */; };
 		LR00000200000000LRWSGRT1 /* WalkSessionGuardRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWSGRT1 /* WalkSessionGuardRecoveryTests.swift */; };
 		LR00000200000000LRWVRP01 /* WebViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVRP01 /* WebViewRepresentable.swift */; };
 		LR00000200000000LRWVPV01 /* WalkSharePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVPV01 /* WalkSharePreviewView.swift */; };
@@ -531,6 +532,7 @@
 		LR00000100000000LRWVLD01 /* WebViewLoader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewLoader.swift; sourceTree = "<group>"; };
 		LR00000100000000LRWVLDT1 /* WebViewLoaderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewLoaderTests.swift; sourceTree = "<group>"; };
 		LR00000100000000LRVRCPT1 /* VoiceRecordingCheckpointTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceRecordingCheckpointTests.swift; sourceTree = "<group>"; };
+		LR00000100000000LRVRCIT1 /* VoiceRecordingCallInterruptionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceRecordingCallInterruptionTests.swift; sourceTree = "<group>"; };
 		LR00000100000000LRWSGRT1 /* WalkSessionGuardRecoveryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkSessionGuardRecoveryTests.swift; sourceTree = "<group>"; };
 		LR00000100000000LRWVRP01 /* WebViewRepresentable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewRepresentable.swift; sourceTree = "<group>"; };
 		LR00000100000000LRWVPV01 /* WalkSharePreviewView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkSharePreviewView.swift; sourceTree = "<group>"; };
@@ -1645,6 +1647,7 @@
 				LR00000100000000LRSHTR02 /* WalkSharingTrackerTests.swift */,
 				LR00000100000000LRWVLDT1 /* WebViewLoaderTests.swift */,
 				LR00000100000000LRVRCPT1 /* VoiceRecordingCheckpointTests.swift */,
+				LR00000100000000LRVRCIT1 /* VoiceRecordingCallInterruptionTests.swift */,
 				LR00000100000000LRWSGRT1 /* WalkSessionGuardRecoveryTests.swift */,
 			);
 			path = UnitTests;
@@ -2797,6 +2800,7 @@
 				LR00000200000000LRSHTR02 /* WalkSharingTrackerTests.swift in Sources */,
 				LR00000200000000LRWVLDT1 /* WebViewLoaderTests.swift in Sources */,
 				LR00000200000000LRVRCPT1 /* VoiceRecordingCheckpointTests.swift in Sources */,
+				LR00000200000000LRVRCIT1 /* VoiceRecordingCallInterruptionTests.swift in Sources */,
 				LR00000200000000LRWSGRT1 /* WalkSessionGuardRecoveryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -232,6 +232,7 @@
 		LR00000200000000LRWVLD01 /* WebViewLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVLD01 /* WebViewLoader.swift */; };
 		LR00000200000000LRWVLDT1 /* WebViewLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVLDT1 /* WebViewLoaderTests.swift */; };
 		LR00000200000000LRVRCPT1 /* VoiceRecordingCheckpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRVRCPT1 /* VoiceRecordingCheckpointTests.swift */; };
+		LR00000200000000LRWSGRT1 /* WalkSessionGuardRecoveryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWSGRT1 /* WalkSessionGuardRecoveryTests.swift */; };
 		LR00000200000000LRWVRP01 /* WebViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVRP01 /* WebViewRepresentable.swift */; };
 		LR00000200000000LRWVPV01 /* WalkSharePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVPV01 /* WalkSharePreviewView.swift */; };
 		73E33F8FCA5B429A65D78EE0 /* PromptContextTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E6ADC967A625A65E935F52 /* PromptContextTypes.swift */; };
@@ -530,6 +531,7 @@
 		LR00000100000000LRWVLD01 /* WebViewLoader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewLoader.swift; sourceTree = "<group>"; };
 		LR00000100000000LRWVLDT1 /* WebViewLoaderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewLoaderTests.swift; sourceTree = "<group>"; };
 		LR00000100000000LRVRCPT1 /* VoiceRecordingCheckpointTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceRecordingCheckpointTests.swift; sourceTree = "<group>"; };
+		LR00000100000000LRWSGRT1 /* WalkSessionGuardRecoveryTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkSessionGuardRecoveryTests.swift; sourceTree = "<group>"; };
 		LR00000100000000LRWVRP01 /* WebViewRepresentable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewRepresentable.swift; sourceTree = "<group>"; };
 		LR00000100000000LRWVPV01 /* WalkSharePreviewView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkSharePreviewView.swift; sourceTree = "<group>"; };
 		0F5581F46A4FFE9ED1D2DCEB /* SoundSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundSettingsView.swift; sourceTree = "<group>"; };
@@ -1643,6 +1645,7 @@
 				LR00000100000000LRSHTR02 /* WalkSharingTrackerTests.swift */,
 				LR00000100000000LRWVLDT1 /* WebViewLoaderTests.swift */,
 				LR00000100000000LRVRCPT1 /* VoiceRecordingCheckpointTests.swift */,
+				LR00000100000000LRWSGRT1 /* WalkSessionGuardRecoveryTests.swift */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -2794,6 +2797,7 @@
 				LR00000200000000LRSHTR02 /* WalkSharingTrackerTests.swift in Sources */,
 				LR00000200000000LRWVLDT1 /* WebViewLoaderTests.swift in Sources */,
 				LR00000200000000LRVRCPT1 /* VoiceRecordingCheckpointTests.swift in Sources */,
+				LR00000200000000LRWSGRT1 /* WalkSessionGuardRecoveryTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -231,6 +231,7 @@
 		LR00000200000000LRSHTR02 /* WalkSharingTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRSHTR02 /* WalkSharingTrackerTests.swift */; };
 		LR00000200000000LRWVLD01 /* WebViewLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVLD01 /* WebViewLoader.swift */; };
 		LR00000200000000LRWVLDT1 /* WebViewLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVLDT1 /* WebViewLoaderTests.swift */; };
+		LR00000200000000LRVRCPT1 /* VoiceRecordingCheckpointTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRVRCPT1 /* VoiceRecordingCheckpointTests.swift */; };
 		LR00000200000000LRWVRP01 /* WebViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVRP01 /* WebViewRepresentable.swift */; };
 		LR00000200000000LRWVPV01 /* WalkSharePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVPV01 /* WalkSharePreviewView.swift */; };
 		73E33F8FCA5B429A65D78EE0 /* PromptContextTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3E6ADC967A625A65E935F52 /* PromptContextTypes.swift */; };
@@ -528,6 +529,7 @@
 		LR00000100000000LRSHTR02 /* WalkSharingTrackerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkSharingTrackerTests.swift; sourceTree = "<group>"; };
 		LR00000100000000LRWVLD01 /* WebViewLoader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewLoader.swift; sourceTree = "<group>"; };
 		LR00000100000000LRWVLDT1 /* WebViewLoaderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewLoaderTests.swift; sourceTree = "<group>"; };
+		LR00000100000000LRVRCPT1 /* VoiceRecordingCheckpointTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VoiceRecordingCheckpointTests.swift; sourceTree = "<group>"; };
 		LR00000100000000LRWVRP01 /* WebViewRepresentable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewRepresentable.swift; sourceTree = "<group>"; };
 		LR00000100000000LRWVPV01 /* WalkSharePreviewView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkSharePreviewView.swift; sourceTree = "<group>"; };
 		0F5581F46A4FFE9ED1D2DCEB /* SoundSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundSettingsView.swift; sourceTree = "<group>"; };
@@ -1640,6 +1642,7 @@
 				LR00000100000000LRGENR02 /* LightReadingGeneratorTests.swift */,
 				LR00000100000000LRSHTR02 /* WalkSharingTrackerTests.swift */,
 				LR00000100000000LRWVLDT1 /* WebViewLoaderTests.swift */,
+				LR00000100000000LRVRCPT1 /* VoiceRecordingCheckpointTests.swift */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -2790,6 +2793,7 @@
 				LR00000200000000LRGENR02 /* LightReadingGeneratorTests.swift in Sources */,
 				LR00000200000000LRSHTR02 /* WalkSharingTrackerTests.swift in Sources */,
 				LR00000200000000LRWVLDT1 /* WebViewLoaderTests.swift in Sources */,
+				LR00000200000000LRVRCPT1 /* VoiceRecordingCheckpointTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pilgrim/Models/Data/Temp/Versions/TempV4.swift
+++ b/Pilgrim/Models/Data/Temp/Versions/TempV4.swift
@@ -156,6 +156,10 @@ public enum TempV4 {
             _activityIntervals = intervals
         }
 
+        public func replaceVoiceRecordings(_ recordings: [TempV4.VoiceRecording]) {
+            self._voiceRecordings = recordings
+        }
+
         public func appendVoiceRecordings(_ recordings: [TempV4.VoiceRecording]) {
             _voiceRecordings.append(contentsOf: recordings)
         }

--- a/Pilgrim/Models/Podcast/PodcastSubmissionService.swift
+++ b/Pilgrim/Models/Podcast/PodcastSubmissionService.swift
@@ -58,6 +58,7 @@ final class PodcastSubmissionService {
         }
 
         for (index, recording) in freshRecordings.enumerated() {
+            guard !recording.fileRelativePath.isEmpty else { continue }
             let audioURL = docs.appendingPathComponent(recording.fileRelativePath)
             guard FileManager.default.fileExists(atPath: audioURL.path) else { continue }
 

--- a/Pilgrim/Models/TranscriptionService.swift
+++ b/Pilgrim/Models/TranscriptionService.swift
@@ -114,6 +114,7 @@ final class TranscriptionService: ObservableObject {
 
         for (index, recording) in recordings.enumerated() {
             guard let uuid = recording.uuid else { continue }
+            guard !recording.fileRelativePath.isEmpty else { continue }
 
             await MainActor.run { state = .transcribing(current: index + 1, total: total) }
 
@@ -143,6 +144,7 @@ final class TranscriptionService: ObservableObject {
 
     func transcribeSingle(_ recording: VoiceRecordingInterface) async -> String? {
         guard let uuid = recording.uuid else { return nil }
+        guard !recording.fileRelativePath.isEmpty else { return nil }
         let started = await MainActor.run { () -> Bool in
             guard !isTranscribing else { return false }
             isTranscribing = true

--- a/Pilgrim/Models/Walk/WalkBuilder/Components/VoiceRecordingManagement.swift
+++ b/Pilgrim/Models/Walk/WalkBuilder/Components/VoiceRecordingManagement.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AVFoundation
+import CallKit
 import Combine
 import CombineExt
 
@@ -21,6 +22,7 @@ public class VoiceRecordingManagement: NSObject, WalkBuilderComponent {
     @Published public private(set) var audioLevel: Float = 0
 
     private var meteringTimer: Timer?
+    private let callObserver: CXCallObserver = CXCallObserver()
 
     public required init(builder: WalkBuilder) {
         super.init()
@@ -30,6 +32,8 @@ public class VoiceRecordingManagement: NSObject, WalkBuilderComponent {
         builder.registerPreSnapshotFlush { [weak self] in
             self?.flushCurrentRecording()
         }
+
+        callObserver.setDelegate(self, queue: .main)
     }
 
     public func bind(builder: WalkBuilder) {
@@ -116,9 +120,14 @@ public class VoiceRecordingManagement: NSObject, WalkBuilderComponent {
     }
 
     public func stopRecording() {
-        guard isRecording, let recorder = audioRecorder else { return }
+        // Relaxed from `guard isRecording, let recorder = audioRecorder` to
+        // tolerate the #if DEBUG _test_setActiveRecording path, which sets
+        // isRecording=true without a real AVAudioRecorder. In production
+        // these flags always move together — see startRecording /
+        // flushCurrentRecording / commitRecording.
+        guard isRecording else { return }
         stopMetering()
-        recorder.stop()
+        audioRecorder?.stop()
         isRecording = false
         recordingStartDate = nil
         audioRecorder = nil
@@ -244,4 +253,22 @@ extension VoiceRecordingManagement: AVAudioRecorderDelegate {
     public func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
         commitRecording(successfully: flag)
     }
+}
+
+extension VoiceRecordingManagement: CXCallObserverDelegate {
+
+    public func callObserver(_ observer: CXCallObserver, callChanged call: CXCall) {
+        handleCallStateChange(hasConnected: call.hasConnected, hasEnded: call.hasEnded)
+    }
+
+    private func handleCallStateChange(hasConnected: Bool, hasEnded: Bool) {
+        guard hasConnected, !hasEnded, isRecording else { return }
+        stopRecording()
+    }
+
+    #if DEBUG
+    func _test_simulateCallChanged(hasConnected: Bool, hasEnded: Bool) {
+        handleCallStateChange(hasConnected: hasConnected, hasEnded: hasEnded)
+    }
+    #endif
 }

--- a/Pilgrim/Models/Walk/WalkBuilder/Components/VoiceRecordingManagement.swift
+++ b/Pilgrim/Models/Walk/WalkBuilder/Components/VoiceRecordingManagement.swift
@@ -202,6 +202,41 @@ public class VoiceRecordingManagement: NSObject, WalkBuilderComponent {
             startRecording()
         }
     }
+
+    /// Returns a provisional `TempVoiceRecording` capturing the currently-active
+    /// recording's start + elapsed duration so far, or `nil` if no recording is
+    /// active. Mirrors the meditation-interval provisional pattern in
+    /// `ActiveWalkViewModel.checkpointActivityIntervals()`. The returned recording
+    /// has the real in-flight file path; on recovery, the file may or may not be
+    /// playable depending on whether AVAudioRecorder wrote its moov atom before
+    /// the process died.
+    public func checkpointVoiceRecording() -> TempVoiceRecording? {
+        guard isRecording,
+              let start = currentRecordingStart,
+              let relativePath = currentRecordingRelativePath else {
+            return nil
+        }
+        let now = Date()
+        return TempVoiceRecording(
+            uuid: nil,
+            startDate: start,
+            endDate: now,
+            duration: now.timeIntervalSince(start),
+            fileRelativePath: relativePath,
+            isEnhanced: false
+        )
+    }
+
+    #if DEBUG
+    /// Test-only hook. Sets the internal state that `startRecording()` would set
+    /// without requiring AVAudioSession permission in the unit-test environment.
+    func _test_setActiveRecording(start: Date, relativePath: String) {
+        currentRecordingStart = start
+        currentRecordingRelativePath = relativePath
+        recordingStartDate = start
+        isRecording = true
+    }
+    #endif
 }
 
 extension VoiceRecordingManagement: AVAudioRecorderDelegate {

--- a/Pilgrim/Models/Walk/WalkBuilder/WalkBuilder.swift
+++ b/Pilgrim/Models/Walk/WalkBuilder/WalkBuilder.swift
@@ -499,12 +499,20 @@ public class WalkBuilder: ApplicationStateObserver {
     }
     
     // MARK: - ApplicationStateObserver
-    
+
     /// Implementation of the `ApplicationStateObserver` protocol sending a suspension command to all subscribers when not recording to save battery life.
     func didUpdateApplicationState(to state: ApplicationState) {
         self.uiSuspensionRelay.accept(state == .background)
         guard !self.statusRelay.value.isActiveStatus else { return }
         self.suspensionRelay.accept(state == .background)
     }
-    
+
+    // MARK: - Test Hooks
+
+    #if DEBUG
+    func _test_setStartDate(_ date: Date) {
+        startDateRelay.accept(date)
+    }
+    #endif
+
 }

--- a/Pilgrim/Models/Walk/WalkCheckpoint.swift
+++ b/Pilgrim/Models/Walk/WalkCheckpoint.swift
@@ -1,13 +1,18 @@
 import Foundation
 
 struct WalkCheckpoint: Codable {
+    /// Shape of the on-disk checkpoint JSON. Bumped whenever `TempWalk` gains or
+    /// loses fields in a way that older builds can't round-trip; `WalkSessionGuard`
+    /// rejects any checkpoint whose `schemaVersion` doesn't match this constant.
+    static let currentSchemaVersion = 1
+
     let schemaVersion: Int
     let walkUUID: UUID
     let checkpointDate: Date
     let walk: TempWalk
 
     init(walkUUID: UUID, walk: TempWalk) {
-        self.schemaVersion = 1
+        self.schemaVersion = Self.currentSchemaVersion
         self.walkUUID = walkUUID
         self.checkpointDate = Date()
         self.walk = walk

--- a/Pilgrim/Models/Walk/WalkSessionGuard.swift
+++ b/Pilgrim/Models/Walk/WalkSessionGuard.swift
@@ -20,6 +20,22 @@ class WalkSessionGuard {
 
     private static let tag = "[SessionGuard]"
 
+    /// The `WalkCheckpoint.schemaVersion` value this build can decode and recover.
+    /// Bump in lockstep with `WalkCheckpoint.schemaVersion` whenever the on-disk
+    /// shape changes; older builds will refuse to decode mismatched checkpoints.
+    private static let supportedSchemaVersion = 1
+
+    /// Provisional (in-flight) recordings — the ones created by
+    /// `VoiceRecordingManagement.checkpointVoiceRecording()` — are the only
+    /// voice recordings with a nil UUID in our pipeline. Finalized recordings
+    /// get a UUID in `finalizeRecording()`; orphan-reconnected recordings get
+    /// one in `reconnectOrphanedRecordings`. Kept as a static helper so both
+    /// the checkpoint log site and the recovery sanitization loop share the
+    /// same definition of "in-flight."
+    static func isProvisional(_ recording: VoiceRecordingInterface) -> Bool {
+        recording.uuid == nil
+    }
+
     // MARK: - Power Tiers
 
     enum PowerTier: Equatable, CustomStringConvertible {
@@ -144,10 +160,7 @@ class WalkSessionGuard {
             )
             try data.write(to: url, options: .atomic)
             checkpointCount += 1
-            // Provisional snapshots from checkpointVoiceRecording() are the only
-            // voice recordings with a nil UUID; finalized ones get one in
-            // finalizeRecording(). See VoiceRecordingManagement.swift.
-            let talkFlag = snapshot.voiceRecordings.contains { $0.uuid == nil } ? " (inflight)" : ""
+            let talkFlag = snapshot.voiceRecordings.contains(where: Self.isProvisional) ? " (inflight)" : ""
             print("\(Self.tag) CHECKPOINT #\(checkpointCount) — tier: \(currentTier), routes: \(snapshot.routeData.count), pauses: \(snapshot.pauses.count), recordings: \(snapshot.voiceRecordings.count)\(talkFlag), intervals: \(snapshot.activityIntervals.count), size: \(ByteCountFormatter.string(fromByteCount: Int64(data.count), countStyle: .file))")
         } catch {
             print("\(Self.tag) CHECKPOINT WRITE FAILED: \(error)")
@@ -298,6 +311,13 @@ class WalkSessionGuard {
             return
         }
 
+        guard checkpoint.schemaVersion == Self.supportedSchemaVersion else {
+            print("\(tag) RECOVERY FAILED — unsupported schemaVersion: \(checkpoint.schemaVersion) (this build supports \(Self.supportedSchemaVersion))")
+            try? FileManager.default.removeItem(at: url)
+            completion(nil)
+            return
+        }
+
         if DataManager.objectHasDuplicate(uuid: checkpoint.walkUUID, objectType: Walk.self) {
             print("\(tag) RECOVERY — stale checkpoint (walk already saved), deleting")
             try? FileManager.default.removeItem(at: url)
@@ -311,10 +331,7 @@ class WalkSessionGuard {
 
         let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
         let sanitized = walk._voiceRecordings.map { recording -> TempVoiceRecording in
-            // Only provisional (in-flight) recordings — identified by nil UUID —
-            // may have unfinalized .m4a files. Finalized and orphan-reconnected
-            // recordings were already proven playable when they were written.
-            guard recording.uuid == nil, !recording.fileRelativePath.isEmpty else {
+            guard isProvisional(recording), !recording.fileRelativePath.isEmpty else {
                 return recording
             }
             let url = docs.appendingPathComponent(recording.fileRelativePath)

--- a/Pilgrim/Models/Walk/WalkSessionGuard.swift
+++ b/Pilgrim/Models/Walk/WalkSessionGuard.swift
@@ -21,9 +21,9 @@ class WalkSessionGuard {
     private static let tag = "[SessionGuard]"
 
     /// The `WalkCheckpoint.schemaVersion` value this build can decode and recover.
-    /// Bump in lockstep with `WalkCheckpoint.schemaVersion` whenever the on-disk
-    /// shape changes; older builds will refuse to decode mismatched checkpoints.
-    private static let supportedSchemaVersion = 1
+    /// Tracks the writer's current version directly — bumping `WalkCheckpoint.currentSchemaVersion`
+    /// automatically narrows the set of checkpoints older builds will accept.
+    private static let supportedSchemaVersion = WalkCheckpoint.currentSchemaVersion
 
     /// Provisional (in-flight) recordings — the ones created by
     /// `VoiceRecordingManagement.checkpointVoiceRecording()` — are the only

--- a/Pilgrim/Models/Walk/WalkSessionGuard.swift
+++ b/Pilgrim/Models/Walk/WalkSessionGuard.swift
@@ -122,6 +122,10 @@ class WalkSessionGuard {
         if let viewModel {
             let intervals = viewModel.checkpointActivityIntervals()
             snapshot.replaceActivityIntervals(intervals)
+
+            if let inflightTalk = viewModel.voiceRecordingManagement.checkpointVoiceRecording() {
+                snapshot.appendVoiceRecordings([inflightTalk])
+            }
         }
 
         if walkUUID == nil {
@@ -140,7 +144,11 @@ class WalkSessionGuard {
             )
             try data.write(to: url, options: .atomic)
             checkpointCount += 1
-            print("\(Self.tag) CHECKPOINT #\(checkpointCount) — tier: \(currentTier), routes: \(snapshot.routeData.count), pauses: \(snapshot.pauses.count), recordings: \(snapshot.voiceRecordings.count), intervals: \(snapshot.activityIntervals.count), size: \(ByteCountFormatter.string(fromByteCount: Int64(data.count), countStyle: .file))")
+            // Provisional snapshots from checkpointVoiceRecording() are the only
+            // voice recordings with a nil UUID; finalized ones get one in
+            // finalizeRecording(). See VoiceRecordingManagement.swift.
+            let talkFlag = snapshot.voiceRecordings.contains { $0.uuid == nil } ? " (inflight)" : ""
+            print("\(Self.tag) CHECKPOINT #\(checkpointCount) — tier: \(currentTier), routes: \(snapshot.routeData.count), pauses: \(snapshot.pauses.count), recordings: \(snapshot.voiceRecordings.count)\(talkFlag), intervals: \(snapshot.activityIntervals.count), size: \(ByteCountFormatter.string(fromByteCount: Int64(data.count), countStyle: .file))")
         } catch {
             print("\(Self.tag) CHECKPOINT WRITE FAILED: \(error)")
         }

--- a/Pilgrim/Models/Walk/WalkSessionGuard.swift
+++ b/Pilgrim/Models/Walk/WalkSessionGuard.swift
@@ -311,7 +311,12 @@ class WalkSessionGuard {
 
         let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
         let sanitized = walk._voiceRecordings.map { recording -> TempVoiceRecording in
-            guard !recording.fileRelativePath.isEmpty else { return recording }
+            // Only provisional (in-flight) recordings — identified by nil UUID —
+            // may have unfinalized .m4a files. Finalized and orphan-reconnected
+            // recordings were already proven playable when they were written.
+            guard recording.uuid == nil, !recording.fileRelativePath.isEmpty else {
+                return recording
+            }
             let url = docs.appendingPathComponent(recording.fileRelativePath)
             return sanitizeRecording(recording, fileURL: url)
         }

--- a/Pilgrim/Models/Walk/WalkSessionGuard.swift
+++ b/Pilgrim/Models/Walk/WalkSessionGuard.swift
@@ -223,6 +223,52 @@ class WalkSessionGuard {
 
     // MARK: - Recovery
 
+    /// Replaces a recording's file path with `""` (metadata-only) when the
+    /// underlying `.m4a` is unplayable — the canonical signature of an
+    /// AVAudioRecorder that was SIGKILL'd before `stop()` wrote its moov atom.
+    /// Duration is preserved so the Talk timer still reads correctly after
+    /// recovery; the walk summary row will show "Recording unavailable" and
+    /// suppress playback controls.
+    ///
+    /// Parameters:
+    /// - recording: the provisional recording from the checkpoint
+    /// - fileURL: absolute URL of the on-disk file. Pass `nil` to skip the
+    ///   disk check entirely (used in tests with the `durationProbe` param).
+    /// - durationProbe: returns the playable duration for a file. In
+    ///   production, defaults to `AVURLAsset(url:).duration` seconds.
+    ///   Override in tests to avoid AVFoundation dependencies.
+    static func sanitizeRecording(
+        _ recording: TempVoiceRecording,
+        fileURL: URL?,
+        durationProbe: (URL) -> Double = WalkSessionGuard.defaultDurationProbe
+    ) -> TempVoiceRecording {
+        guard let fileURL else { return recording }
+
+        let playableSeconds = durationProbe(fileURL)
+        guard playableSeconds <= 0 else {
+            return recording
+        }
+
+        try? FileManager.default.removeItem(at: fileURL)
+
+        return TempVoiceRecording(
+            uuid: recording.uuid,
+            startDate: recording.startDate,
+            endDate: recording.endDate,
+            duration: recording.duration,
+            fileRelativePath: "",
+            transcription: nil,
+            wordsPerMinute: nil,
+            isEnhanced: false
+        )
+    }
+
+    private static func defaultDurationProbe(_ url: URL) -> Double {
+        let asset = AVURLAsset(url: url)
+        let seconds = CMTimeGetSeconds(asset.duration)
+        return seconds.isFinite ? seconds : 0
+    }
+
     static func recoverIfNeeded(completion: @escaping (Date?) -> Void) {
         guard DataManager.dataStack != nil else {
             print("\(tag) RECOVERY SKIPPED — DataManager not ready")
@@ -262,6 +308,14 @@ class WalkSessionGuard {
         let walk = checkpoint.walk
         let recordingDirUUID = extractRecordingDirectoryUUID(from: walk) ?? checkpoint.walkUUID
         reconnectOrphanedRecordings(walk: walk, walkUUID: recordingDirUUID)
+
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let sanitized = walk._voiceRecordings.map { recording -> TempVoiceRecording in
+            guard !recording.fileRelativePath.isEmpty else { return recording }
+            let url = docs.appendingPathComponent(recording.fileRelativePath)
+            return sanitizeRecording(recording, fileURL: url)
+        }
+        walk.replaceVoiceRecordings(sanitized)
 
         print("\(tag) RECOVERY — saving walk: start=\(walk.startDate), end=\(walk.endDate), routes=\(walk.routeData.count), pauses=\(walk.pauses.count), recordings=\(walk.voiceRecordings.count), intervals=\(walk.activityIntervals.count), waypoints=\(walk.waypoints.count)")
 

--- a/Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift
+++ b/Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift
@@ -544,7 +544,8 @@ struct ActiveWalkView: View {
             },
             bottomInset: mapBottomInset,
             initialCamera: viewModel.mapCameraSeed,
-            fadesInOnStyleLoad: true
+            fadesInOnStyleLoad: true,
+            isMeditating: $viewModel.isMeditating
         )
     }
 

--- a/Pilgrim/Scenes/Settings/RecordingsListView.swift
+++ b/Pilgrim/Scenes/Settings/RecordingsListView.swift
@@ -431,6 +431,7 @@ struct RecordingsListView: View {
     }
 
     private func isFileAvailable(_ relativePath: String) -> Bool {
+        guard !relativePath.isEmpty else { return false }
         guard !deletedPaths.contains(relativePath) else { return false }
         let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
         return FileManager.default.fileExists(atPath: docs.appendingPathComponent(relativePath).path)

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
@@ -764,6 +764,7 @@ struct WalkSummaryView: View {
     }
 
     private func isFileAvailable(_ relativePath: String) -> Bool {
+        guard !relativePath.isEmpty else { return false }
         guard !deletedPaths.contains(relativePath) else { return false }
         let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
         return FileManager.default.fileExists(atPath: docs.appendingPathComponent(relativePath).path)

--- a/Pilgrim/Views/PilgrimMapView.swift
+++ b/Pilgrim/Views/PilgrimMapView.swift
@@ -170,7 +170,11 @@ struct PilgrimMapView: UIViewRepresentable {
             return
         }
 
-        Self.applyRouteSource(routeSegments, on: mapView, coordinator: context.coordinator)
+        if context.coordinator.shouldRender {
+            Self.applyRouteSource(routeSegments, on: mapView, coordinator: context.coordinator)
+        } else {
+            context.coordinator.hasDeferredRouteUpdate = true
+        }
         Self.applyAnnotations(pinAnnotations, activePhotoID: activePhotoID, on: mapView, coordinator: context.coordinator)
 
         if followsUserLocation {
@@ -520,6 +524,8 @@ struct PilgrimMapView: UIViewRepresentable {
         var lastBottomInset: CGFloat = 0
         var lastSegments: [RouteSegment] = []
         var pendingSegments: [RouteSegment] = []
+        /// True when we deferred at least one `applyRouteSource` call while paused.
+        fileprivate var hasDeferredRouteUpdate: Bool = false
         var pendingAnnotations: [PilgrimAnnotation] = []
         var pendingActivePhotoID: String?
         var currentColorScheme: ColorScheme = .light
@@ -573,7 +579,13 @@ struct PilgrimMapView: UIViewRepresentable {
 
         private func refreshRenderState() {
             guard let mapView else { return }
+            let wasRendering = mapView.preferredFramesPerSecond > 0
             mapView.preferredFramesPerSecond = shouldRender ? PilgrimMapView.renderFPS : 0
+
+            if shouldRender && !wasRendering && hasDeferredRouteUpdate {
+                PilgrimMapView.applyRouteSource(pendingSegments, on: mapView, coordinator: self)
+                hasDeferredRouteUpdate = false
+            }
         }
 
         @objc func handleMapTap(_ gesture: UITapGestureRecognizer) {

--- a/Pilgrim/Views/PilgrimMapView.swift
+++ b/Pilgrim/Views/PilgrimMapView.swift
@@ -6,6 +6,8 @@ typealias MBMapView = MapboxMaps.MapView
 
 struct PilgrimMapView: UIViewRepresentable {
 
+    private static let renderFPS: Int = 30
+
     var isInteractive: Bool = true
     var showsUserLocation: Bool = true
     var followsUserLocation: Bool = false
@@ -18,6 +20,7 @@ struct PilgrimMapView: UIViewRepresentable {
     var activePhotoID: String?
     @Binding var cameraCenter: CLLocationCoordinate2D?
     @Binding var cameraZoom: CGFloat
+    @Binding var isMeditating: Bool
     var cameraBounds: MapCameraBounds?
     var cameraDuration: TimeInterval = 0.4
     /// Bottom padding (in points) reserved for an overlay sheet. The map
@@ -52,7 +55,8 @@ struct PilgrimMapView: UIViewRepresentable {
         cameraDuration: TimeInterval = 0.4,
         bottomInset: CGFloat = 0,
         initialCamera: MapCameraSeed.Seed? = nil,
-        fadesInOnStyleLoad: Bool = false
+        fadesInOnStyleLoad: Bool = false,
+        isMeditating: Binding<Bool> = .constant(false)
     ) {
         self.isInteractive = isInteractive
         self.showsUserLocation = showsUserLocation
@@ -63,6 +67,7 @@ struct PilgrimMapView: UIViewRepresentable {
         self.activePhotoID = activePhotoID
         self._cameraCenter = cameraCenter
         self._cameraZoom = cameraZoom
+        self._isMeditating = isMeditating
         self.cameraBounds = cameraBounds
         self.cameraDuration = cameraDuration
         self.bottomInset = bottomInset
@@ -87,7 +92,7 @@ struct PilgrimMapView: UIViewRepresentable {
             frame: .zero,
             mapInitOptions: MapInitOptions(cameraOptions: cameraOptions, styleURI: styleURI)
         )
-        mapView.preferredFramesPerSecond = 30
+        mapView.preferredFramesPerSecond = Self.renderFPS
 
         if fadesInOnStyleLoad {
             mapView.alpha = 0
@@ -133,10 +138,15 @@ struct PilgrimMapView: UIViewRepresentable {
         }.store(in: &context.coordinator.cancellables)
 
         context.coordinator.mapView = mapView
+        context.coordinator.startObservingAppLifecycle()
+        context.coordinator.isMeditating = isMeditating
         return mapView
     }
 
     func updateUIView(_ mapView: MBMapView, context: Context) {
+        if context.coordinator.isMeditating != isMeditating {
+            context.coordinator.isMeditating = isMeditating
+        }
         context.coordinator.pendingSegments = routeSegments
         context.coordinator.pendingAnnotations = pinAnnotations
         context.coordinator.pendingActivePhotoID = activePhotoID
@@ -526,6 +536,46 @@ struct PilgrimMapView: UIViewRepresentable {
         /// complete, which the Coordinator wires to trigger a redraw.
         let photoMarkerLoader = PhotoMarkerImageLoader()
 
+        fileprivate var isAppInBackground: Bool = false
+
+        fileprivate var isMeditating: Bool = false {
+            didSet { refreshRenderState() }
+        }
+
+        fileprivate var shouldRender: Bool {
+            !isAppInBackground && !isMeditating
+        }
+
+        func startObservingAppLifecycle() {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(handleDidEnterBackground),
+                name: UIApplication.didEnterBackgroundNotification,
+                object: nil
+            )
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(handleWillEnterForeground),
+                name: UIApplication.willEnterForegroundNotification,
+                object: nil
+            )
+        }
+
+        @objc private func handleDidEnterBackground() {
+            isAppInBackground = true
+            refreshRenderState()
+        }
+
+        @objc private func handleWillEnterForeground() {
+            isAppInBackground = false
+            refreshRenderState()
+        }
+
+        private func refreshRenderState() {
+            guard let mapView else { return }
+            mapView.preferredFramesPerSecond = shouldRender ? PilgrimMapView.renderFPS : 0
+        }
+
         @objc func handleMapTap(_ gesture: UITapGestureRecognizer) {
             guard let mapView, let onAnnotationTap else { return }
             let tapPoint = gesture.location(in: mapView)
@@ -552,6 +602,7 @@ struct PilgrimMapView: UIViewRepresentable {
         }
 
         deinit {
+            NotificationCenter.default.removeObserver(self)
             if let mapView {
                 if let manager = circleManager { mapView.annotations.removeAnnotationManager(withId: manager.id) }
                 if let manager = pointManager { mapView.annotations.removeAnnotationManager(withId: manager.id) }

--- a/UnitTests/VoiceRecordingCallInterruptionTests.swift
+++ b/UnitTests/VoiceRecordingCallInterruptionTests.swift
@@ -1,0 +1,63 @@
+import XCTest
+import CallKit
+@testable import Pilgrim
+
+final class VoiceRecordingCallInterruptionTests: XCTestCase {
+
+    func test_callChanged_stopsRecording_whenCallConnects() {
+        let builder = WalkBuilder()
+        let mgmt = VoiceRecordingManagement(builder: builder)
+        builder.setStatus(.recording)
+
+        mgmt._test_setActiveRecording(
+            start: Date(timeIntervalSinceNow: -10),
+            relativePath: "Recordings/X/rec.m4a"
+        )
+        XCTAssertTrue(mgmt.isRecording, "precondition: recording is active")
+
+        mgmt._test_simulateCallChanged(hasConnected: true, hasEnded: false)
+
+        XCTAssertFalse(mgmt.isRecording,
+                       "recording should stop the moment a call connects")
+    }
+
+    func test_callChanged_doesNothing_whenCallNotConnected() {
+        let builder = WalkBuilder()
+        let mgmt = VoiceRecordingManagement(builder: builder)
+        builder.setStatus(.recording)
+
+        mgmt._test_setActiveRecording(
+            start: Date(timeIntervalSinceNow: -10),
+            relativePath: "Recordings/X/rec.m4a"
+        )
+
+        mgmt._test_simulateCallChanged(hasConnected: false, hasEnded: false)
+
+        XCTAssertTrue(mgmt.isRecording,
+                      "ringing / declined call must NOT end the recording")
+    }
+
+    func test_callChanged_doesNothing_whenNotRecording() {
+        let builder = WalkBuilder()
+        let mgmt = VoiceRecordingManagement(builder: builder)
+
+        mgmt._test_simulateCallChanged(hasConnected: true, hasEnded: false)
+
+        XCTAssertFalse(mgmt.isRecording)
+    }
+
+    func test_callChanged_doesNothing_whenCallEnded() {
+        let builder = WalkBuilder()
+        let mgmt = VoiceRecordingManagement(builder: builder)
+
+        mgmt._test_setActiveRecording(
+            start: Date(timeIntervalSinceNow: -10),
+            relativePath: "Recordings/X/rec.m4a"
+        )
+
+        mgmt._test_simulateCallChanged(hasConnected: true, hasEnded: true)
+
+        XCTAssertTrue(mgmt.isRecording,
+                      "a call-ended transition after disconnect must not flip recording state")
+    }
+}

--- a/UnitTests/VoiceRecordingCallInterruptionTests.swift
+++ b/UnitTests/VoiceRecordingCallInterruptionTests.swift
@@ -7,7 +7,6 @@ final class VoiceRecordingCallInterruptionTests: XCTestCase {
     func test_callChanged_stopsRecording_whenCallConnects() {
         let builder = WalkBuilder()
         let mgmt = VoiceRecordingManagement(builder: builder)
-        builder.setStatus(.recording)
 
         mgmt._test_setActiveRecording(
             start: Date(timeIntervalSinceNow: -10),
@@ -24,7 +23,6 @@ final class VoiceRecordingCallInterruptionTests: XCTestCase {
     func test_callChanged_doesNothing_whenCallNotConnected() {
         let builder = WalkBuilder()
         let mgmt = VoiceRecordingManagement(builder: builder)
-        builder.setStatus(.recording)
 
         mgmt._test_setActiveRecording(
             start: Date(timeIntervalSinceNow: -10),

--- a/UnitTests/VoiceRecordingCheckpointTests.swift
+++ b/UnitTests/VoiceRecordingCheckpointTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import Pilgrim
+
+final class VoiceRecordingCheckpointTests: XCTestCase {
+
+    func test_checkpointVoiceRecording_returnsNil_whenNotRecording() {
+        let builder = WalkBuilder()
+        let mgmt = VoiceRecordingManagement(builder: builder)
+
+        XCTAssertNil(mgmt.checkpointVoiceRecording())
+    }
+
+    func test_checkpointVoiceRecording_returnsSnapshot_whenRecording() {
+        let builder = WalkBuilder()
+        let mgmt = VoiceRecordingManagement(builder: builder)
+
+        mgmt._test_setActiveRecording(
+            start: Date(timeIntervalSinceNow: -30),
+            relativePath: "Recordings/ABC/rec.m4a"
+        )
+
+        guard let snapshot = mgmt.checkpointVoiceRecording() else {
+            XCTFail("expected a provisional recording snapshot")
+            return
+        }
+        XCTAssertEqual(snapshot.fileRelativePath, "Recordings/ABC/rec.m4a")
+        XCTAssertEqual(snapshot.duration, 30, accuracy: 1.0)
+        XCTAssertEqual(snapshot.startDate.timeIntervalSinceNow, -30, accuracy: 1.0)
+        XCTAssertNil(snapshot.uuid)
+        XCTAssertFalse(snapshot.isEnhanced)
+    }
+}

--- a/UnitTests/WalkSessionGuardRecoveryTests.swift
+++ b/UnitTests/WalkSessionGuardRecoveryTests.swift
@@ -6,7 +6,6 @@ final class WalkSessionGuardRecoveryTests: XCTestCase {
     func test_checkpointVoiceRecording_snapshot_can_be_appended_to_checkpoint() {
         let vm = ActiveWalkViewModel()
         let builder = vm.builder
-        builder.setStatus(.recording)
 
         vm.voiceRecordingManagement._test_setActiveRecording(
             start: Date(timeIntervalSinceNow: -42),
@@ -53,6 +52,8 @@ final class WalkSessionGuardRecoveryTests: XCTestCase {
         XCTAssertEqual(sanitized.fileRelativePath, "")
         XCTAssertEqual(sanitized.duration, 30, accuracy: 0.1,
                        "duration must be preserved for the Talk timer")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: brokenFile.path),
+                       "unplayable file must be removed from disk")
     }
 
     func test_sanitizeUnplayableRecordings_preservesPath_whenFilePlayable() throws {

--- a/UnitTests/WalkSessionGuardRecoveryTests.swift
+++ b/UnitTests/WalkSessionGuardRecoveryTests.swift
@@ -27,4 +27,69 @@ final class WalkSessionGuardRecoveryTests: XCTestCase {
                        "Recordings/DEADBEEF/rec.m4a")
         XCTAssertEqual(snapshot?.voiceRecordings.first?.duration ?? 0, 42, accuracy: 1.0)
     }
+
+    func test_sanitizeUnplayableRecordings_clearsPath_forMoovLessFile() throws {
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WalkSessionGuardRecoveryTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let brokenFile = tmpDir.appendingPathComponent("broken.m4a")
+        try Data().write(to: brokenFile)
+
+        let recording = TempVoiceRecording(
+            uuid: nil,
+            startDate: Date(timeIntervalSinceNow: -30),
+            endDate: Date(),
+            duration: 30,
+            fileRelativePath: "ignored/broken.m4a",
+            isEnhanced: false
+        )
+
+        let sanitized = WalkSessionGuard.sanitizeRecording(
+            recording,
+            fileURL: brokenFile
+        )
+        XCTAssertEqual(sanitized.fileRelativePath, "")
+        XCTAssertEqual(sanitized.duration, 30, accuracy: 0.1,
+                       "duration must be preserved for the Talk timer")
+    }
+
+    func test_sanitizeUnplayableRecordings_preservesPath_whenFilePlayable() throws {
+        let playable = TempVoiceRecording(
+            uuid: nil,
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(5),
+            duration: 5,
+            fileRelativePath: "Recordings/ABC/rec.m4a",
+            isEnhanced: false
+        )
+
+        let sanitized = WalkSessionGuard.sanitizeRecording(
+            playable,
+            fileURL: nil,
+            durationProbe: { _ in 5.0 }
+        )
+        XCTAssertEqual(sanitized.fileRelativePath, "Recordings/ABC/rec.m4a")
+    }
+
+    func test_sanitizeUnplayableRecordings_preservesPath_whenProbeReportsPositive() {
+        let recording = TempVoiceRecording(
+            uuid: nil,
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(5),
+            duration: 5,
+            fileRelativePath: "Recordings/ABC/rec.m4a",
+            isEnhanced: false
+        )
+        let fakeURL = URL(fileURLWithPath: "/does/not/exist.m4a")
+
+        let sanitized = WalkSessionGuard.sanitizeRecording(
+            recording,
+            fileURL: fakeURL,
+            durationProbe: { _ in 5.0 }
+        )
+
+        XCTAssertEqual(sanitized.fileRelativePath, "Recordings/ABC/rec.m4a")
+    }
 }

--- a/UnitTests/WalkSessionGuardRecoveryTests.swift
+++ b/UnitTests/WalkSessionGuardRecoveryTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+@testable import Pilgrim
+
+final class WalkSessionGuardRecoveryTests: XCTestCase {
+
+    func test_checkpointVoiceRecording_snapshot_can_be_appended_to_checkpoint() {
+        let vm = ActiveWalkViewModel()
+        let builder = vm.builder
+        builder.setStatus(.recording)
+
+        vm.voiceRecordingManagement._test_setActiveRecording(
+            start: Date(timeIntervalSinceNow: -42),
+            relativePath: "Recordings/DEADBEEF/rec.m4a"
+        )
+
+        builder._test_setStartDate(Date(timeIntervalSinceNow: -60))
+
+        let snapshot = builder.createCheckpointSnapshot()
+        XCTAssertNotNil(snapshot)
+
+        if let inflight = vm.voiceRecordingManagement.checkpointVoiceRecording() {
+            snapshot?.appendVoiceRecordings([inflight])
+        }
+
+        XCTAssertEqual(snapshot?.voiceRecordings.count, 1)
+        XCTAssertEqual(snapshot?.voiceRecordings.first?.fileRelativePath,
+                       "Recordings/DEADBEEF/rec.m4a")
+        XCTAssertEqual(snapshot?.voiceRecordings.first?.duration ?? 0, 42, accuracy: 1.0)
+    }
+}

--- a/docs/superpowers/plans/2026-04-22-four-turnings.md
+++ b/docs/superpowers/plans/2026-04-22-four-turnings.md
@@ -1,0 +1,2002 @@
+# Four Turnings Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Acknowledge the four astronomical turning points (solstices and equinoxes) with quiet, distributed visual touches across Pilgrim: home banner + inline scroll glyphs, active-walk kanji watermark + sunrise-azimuth ray, turning-colored walking-route segments, kanji suffix on walk-summary date, matching goshuin seal color.
+
+**Architecture:** Extends existing `SeasonalMarker` enum (at `Pilgrim/Models/Astrology/AstrologyModels.swift:139`) with kanji/bannerText/color/sealColor computed properties. New `Hemisphere` enum + `TurningDayService` helper handle the per-walk, per-hemisphere mapping (southern-hemisphere users see 冬至 on June solstice, not December). Adds one new `CelestialCalculator.sunriseAzimuth(at:on:)` method; everything else leverages the existing `CelestialCalculator.snapshot(for:).seasonalMarker` detection.
+
+**Tech Stack:** Swift / SwiftUI / Combine, CoreLocation, Mapbox Maps iOS SDK, CocoaPods. No new dependencies.
+
+**Reference:** Design spec at `docs/superpowers/specs/2026-04-22-four-turnings-design.md`.
+
+**Branch:** Assumes work happens on a feature branch (e.g., `feat/four-turnings`) created before Task 1.
+
+---
+
+## File Structure
+
+**New files:**
+- `Pilgrim/Models/Hemisphere.swift` — enum + coordinate extension
+- `Pilgrim/Models/Astrology/SeasonalMarker+Turnings.swift` — computed properties (kanji, bannerText, color, sealColor, isTurning)
+- `Pilgrim/Models/Astrology/TurningDayService.swift` — hemisphere-aware detection
+- `Pilgrim/Scenes/Home/InkScrollView+TurningMarkers.swift` — inline glyph rendering, mirrors `InkScrollView+LunarMarkers.swift`
+- `Pilgrim/Support Files/Assets.xcassets/turningJade.colorset/` (and `turningGold`, `turningClaret`, `turningIndigo`) — 4 colorsets with light/dark variants
+- `UnitTests/HemisphereTests.swift`
+- `UnitTests/SeasonalMarkerTurningTests.swift`
+- `UnitTests/TurningDayServiceTests.swift`
+- `UnitTests/CelestialCalculatorSunriseAzimuthTests.swift`
+- `UnitTests/SealColorPaletteTurningTests.swift`
+
+**Modified files:**
+- `Pilgrim/Models/Astrology/CelestialCalculator.swift` — adds `sunriseAzimuth(at:on:)`
+- `Pilgrim/Models/Seal/SealColorPalette.swift` — 4 new `SealColor` entries + new `uiColor(for: SealInput)` entry point
+- `Pilgrim/Models/Seal/SealGenerator.swift` — call site at line 44 uses new entry point
+- `Pilgrim/Scenes/Home/InkScrollView.swift` — banner + turning-marker call + pathSegmentColor override
+- `Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift` — kanji watermark overlay + sunrise-ray overlay
+- `Pilgrim/Views/PilgrimMapView.swift` — route color expression turning branch + sunrise ray layer
+- `Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift` — date title kanji suffix
+- `Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift` + `Pilgrim/Models/ShareService.swift` — `turningDay` payload field
+- `Pilgrim/Models/LS.swift` — localized strings
+- `Pilgrim.xcodeproj/project.pbxproj` — register all new files (Pilgrim/ and UnitTests/ are NOT synchronized root groups; manual pbxproj edits required — see pattern in commit `96ae8e4`)
+
+---
+
+## Task 1: Hemisphere enum
+
+**Files:**
+- Create: `Pilgrim/Models/Hemisphere.swift`
+- Create: `UnitTests/HemisphereTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `UnitTests/HemisphereTests.swift`:
+
+```swift
+import XCTest
+import CoreLocation
+@testable import Pilgrim
+
+final class HemisphereTests: XCTestCase {
+
+    func testNorthern_positiveLatitude() {
+        let coord = CLLocationCoordinate2D(latitude: 40.7, longitude: -74.0)
+        XCTAssertEqual(Hemisphere(coordinate: coord), .northern)
+    }
+
+    func testSouthern_negativeLatitude() {
+        let coord = CLLocationCoordinate2D(latitude: -33.9, longitude: 151.2)
+        XCTAssertEqual(Hemisphere(coordinate: coord), .southern)
+    }
+
+    func testEquator_returnsNorthern() {
+        let coord = CLLocationCoordinate2D(latitude: 0, longitude: 0)
+        XCTAssertEqual(Hemisphere(coordinate: coord), .northern)
+    }
+
+    func testNil_returnsNorthern() {
+        XCTAssertEqual(Hemisphere(coordinate: nil), .northern)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify compile failure**
+
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/HemisphereTests 2>&1 | tail -10
+```
+
+Expected: compile error (`Hemisphere` undefined).
+
+- [ ] **Step 3: Implement `Hemisphere`**
+
+Create `Pilgrim/Models/Hemisphere.swift`:
+
+```swift
+import Foundation
+import CoreLocation
+
+enum Hemisphere: Equatable {
+    case northern
+    case southern
+
+    init(coordinate: CLLocationCoordinate2D?) {
+        guard let coord = coordinate else {
+            self = .northern
+            return
+        }
+        self = coord.latitude < 0 ? .southern : .northern
+    }
+}
+```
+
+- [ ] **Step 4: Register new files in Xcode project**
+
+Run:
+```bash
+grep -c "Hemisphere.swift\|HemisphereTests.swift" Pilgrim.xcodeproj/project.pbxproj
+```
+
+Expected: `>= 4`. If less, manually add both files to `project.pbxproj` following the pattern from commit `96ae8e4` — add `PBXFileReference`, `PBXBuildFile`, group membership (Pilgrim target for `Hemisphere.swift`, UnitTests target for `HemisphereTests.swift`), and the appropriate `PBXSourcesBuildPhase` entries.
+
+- [ ] **Step 5: Run tests to verify pass**
+
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/HemisphereTests 2>&1 | tail -5
+```
+
+Expected: `** TEST SUCCEEDED **`, 4 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Pilgrim/Models/Hemisphere.swift UnitTests/HemisphereTests.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat(turnings): add Hemisphere enum with coordinate-based derivation"
+```
+
+---
+
+## Task 2: Four turning Color assets
+
+**Files:**
+- Create: `Pilgrim/Support Files/Assets.xcassets/turningJade.colorset/Contents.json`
+- Create: `Pilgrim/Support Files/Assets.xcassets/turningGold.colorset/Contents.json`
+- Create: `Pilgrim/Support Files/Assets.xcassets/turningClaret.colorset/Contents.json`
+- Create: `Pilgrim/Support Files/Assets.xcassets/turningIndigo.colorset/Contents.json`
+
+Colorsets have both light and dark variants. Light values match the spec; dark values are slightly lighter/brighter variants for legibility on dark parchment.
+
+- [ ] **Step 1: Create turningJade colorset**
+
+Create directory `Pilgrim/Support Files/Assets.xcassets/turningJade.colorset/` and `Contents.json` inside:
+
+```json
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.584",
+          "green" : "0.706",
+          "red" : "0.455"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.627",
+          "green" : "0.769",
+          "red" : "0.533"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+```
+
+- [ ] **Step 2: Create turningGold colorset**
+
+Directory `Pilgrim/Support Files/Assets.xcassets/turningGold.colorset/` and `Contents.json`:
+
+```json
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.275",
+          "green" : "0.651",
+          "red" : "0.788"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.365",
+          "green" : "0.710",
+          "red" : "0.835"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+```
+
+- [ ] **Step 3: Create turningClaret colorset**
+
+Directory `Pilgrim/Support Files/Assets.xcassets/turningClaret.colorset/` and `Contents.json`:
+
+```json
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.333",
+          "green" : "0.267",
+          "red" : "0.545"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.439",
+          "green" : "0.376",
+          "red" : "0.635"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+```
+
+- [ ] **Step 4: Create turningIndigo colorset**
+
+Directory `Pilgrim/Support Files/Assets.xcassets/turningIndigo.colorset/` and `Contents.json`:
+
+```json
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.643",
+          "green" : "0.467",
+          "red" : "0.137"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.729",
+          "green" : "0.569",
+          "red" : "0.275"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}
+```
+
+- [ ] **Step 5: Verify build picks up the new assets**
+
+Run:
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **`. (Xcode Asset Catalog picks up colorsets automatically — no pbxproj edit needed for .colorset directories inside a registered .xcassets.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "Pilgrim/Support Files/Assets.xcassets/turningJade.colorset" "Pilgrim/Support Files/Assets.xcassets/turningGold.colorset" "Pilgrim/Support Files/Assets.xcassets/turningClaret.colorset" "Pilgrim/Support Files/Assets.xcassets/turningIndigo.colorset"
+git commit -m "feat(turnings): add 4 turning colorsets with light and dark variants"
+```
+
+---
+
+## Task 3: SeasonalMarker+Turnings extension
+
+**Files:**
+- Create: `Pilgrim/Models/Astrology/SeasonalMarker+Turnings.swift`
+- Create: `UnitTests/SeasonalMarkerTurningTests.swift`
+- Modify: `Pilgrim/Models/LS.swift` — add 2 new localized strings
+
+- [ ] **Step 1: Write the failing test**
+
+Create `UnitTests/SeasonalMarkerTurningTests.swift`:
+
+```swift
+import XCTest
+import SwiftUI
+@testable import Pilgrim
+
+final class SeasonalMarkerTurningTests: XCTestCase {
+
+    // MARK: - kanji
+
+    func testKanji_springEquinox() {
+        XCTAssertEqual(SeasonalMarker.springEquinox.kanji, "春分")
+    }
+
+    func testKanji_summerSolstice() {
+        XCTAssertEqual(SeasonalMarker.summerSolstice.kanji, "夏至")
+    }
+
+    func testKanji_autumnEquinox() {
+        XCTAssertEqual(SeasonalMarker.autumnEquinox.kanji, "秋分")
+    }
+
+    func testKanji_winterSolstice() {
+        XCTAssertEqual(SeasonalMarker.winterSolstice.kanji, "冬至")
+    }
+
+    func testKanji_crossQuarter_returnsNil() {
+        XCTAssertNil(SeasonalMarker.imbolc.kanji)
+        XCTAssertNil(SeasonalMarker.beltane.kanji)
+        XCTAssertNil(SeasonalMarker.lughnasadh.kanji)
+        XCTAssertNil(SeasonalMarker.samhain.kanji)
+    }
+
+    // MARK: - bannerText
+
+    func testBannerText_solstices_saySunStandsStill() {
+        XCTAssertEqual(SeasonalMarker.summerSolstice.bannerText, "Today the sun stands still")
+        XCTAssertEqual(SeasonalMarker.winterSolstice.bannerText, "Today the sun stands still")
+    }
+
+    func testBannerText_equinoxes_sayDayEqualsNight() {
+        XCTAssertEqual(SeasonalMarker.springEquinox.bannerText, "Today, day equals night")
+        XCTAssertEqual(SeasonalMarker.autumnEquinox.bannerText, "Today, day equals night")
+    }
+
+    func testBannerText_crossQuarter_returnsNil() {
+        XCTAssertNil(SeasonalMarker.imbolc.bannerText)
+    }
+
+    // MARK: - colorAssetName
+
+    func testColorAssetName_forEachTurning() {
+        XCTAssertEqual(SeasonalMarker.springEquinox.colorAssetName, "turningJade")
+        XCTAssertEqual(SeasonalMarker.summerSolstice.colorAssetName, "turningGold")
+        XCTAssertEqual(SeasonalMarker.autumnEquinox.colorAssetName, "turningClaret")
+        XCTAssertEqual(SeasonalMarker.winterSolstice.colorAssetName, "turningIndigo")
+    }
+
+    func testColorAssetName_crossQuarter_returnsNil() {
+        XCTAssertNil(SeasonalMarker.imbolc.colorAssetName)
+    }
+
+    // MARK: - isTurning
+
+    func testIsTurning_trueForFourMainMarkers() {
+        XCTAssertTrue(SeasonalMarker.springEquinox.isTurning)
+        XCTAssertTrue(SeasonalMarker.summerSolstice.isTurning)
+        XCTAssertTrue(SeasonalMarker.autumnEquinox.isTurning)
+        XCTAssertTrue(SeasonalMarker.winterSolstice.isTurning)
+    }
+
+    func testIsTurning_falseForCrossQuarter() {
+        XCTAssertFalse(SeasonalMarker.imbolc.isTurning)
+        XCTAssertFalse(SeasonalMarker.beltane.isTurning)
+        XCTAssertFalse(SeasonalMarker.lughnasadh.isTurning)
+        XCTAssertFalse(SeasonalMarker.samhain.isTurning)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify compile failure**
+
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/SeasonalMarkerTurningTests 2>&1 | tail -10
+```
+
+Expected: compile error (properties `kanji`, `bannerText`, `colorAssetName`, `isTurning` undefined on `SeasonalMarker`).
+
+- [ ] **Step 3: Add LS entries**
+
+Open `Pilgrim/Models/LS.swift` and add two new static properties alongside existing `LS.*` definitions. Look for a section that makes sense (banner/UI strings); follow the existing naming convention.
+
+Add:
+
+```swift
+/// Banner text shown on the home scroll during solstices.
+static let turningSolsticeBanner = NSLocalizedString(
+    "turning.solstice.banner",
+    value: "Today the sun stands still",
+    comment: "Home-scroll banner text on winter or summer solstice."
+)
+
+/// Banner text shown on the home scroll during equinoxes.
+static let turningEquinoxBanner = NSLocalizedString(
+    "turning.equinox.banner",
+    value: "Today, day equals night",
+    comment: "Home-scroll banner text on spring or autumn equinox."
+)
+```
+
+- [ ] **Step 4: Implement the extension**
+
+Create `Pilgrim/Models/Astrology/SeasonalMarker+Turnings.swift`:
+
+```swift
+import SwiftUI
+
+extension SeasonalMarker {
+
+    /// Single-character kanji representing this turning. Nil for cross-quarter markers.
+    var kanji: String? {
+        switch self {
+        case .springEquinox:  return "春分"
+        case .summerSolstice: return "夏至"
+        case .autumnEquinox:  return "秋分"
+        case .winterSolstice: return "冬至"
+        case .imbolc, .beltane, .lughnasadh, .samhain: return nil
+        }
+    }
+
+    /// Localized banner copy. Solstices read "Today the sun stands still";
+    /// equinoxes read "Today, day equals night". Nil for cross-quarter.
+    var bannerText: String? {
+        switch self {
+        case .springEquinox, .autumnEquinox:  return LS.turningEquinoxBanner
+        case .summerSolstice, .winterSolstice: return LS.turningSolsticeBanner
+        case .imbolc, .beltane, .lughnasadh, .samhain: return nil
+        }
+    }
+
+    /// Asset Catalog color name for this turning's walking-segment color.
+    /// Nil for cross-quarter.
+    var colorAssetName: String? {
+        switch self {
+        case .springEquinox:  return "turningJade"
+        case .summerSolstice: return "turningGold"
+        case .autumnEquinox:  return "turningClaret"
+        case .winterSolstice: return "turningIndigo"
+        case .imbolc, .beltane, .lughnasadh, .samhain: return nil
+        }
+    }
+
+    /// SwiftUI Color resolved from the asset catalog. Nil for cross-quarter.
+    var color: Color? {
+        guard let name = colorAssetName else { return nil }
+        return Color(name)
+    }
+
+    /// UIColor resolved from the asset catalog. Nil for cross-quarter.
+    var uiColor: UIColor? {
+        guard let name = colorAssetName else { return nil }
+        return UIColor(named: name)
+    }
+
+    /// True iff this marker is one of the 4 main solstices/equinoxes.
+    /// False for the 4 cross-quarter markers (imbolc/beltane/lughnasadh/samhain)
+    /// which are out of scope for the Four Turnings feature.
+    var isTurning: Bool {
+        switch self {
+        case .springEquinox, .summerSolstice, .autumnEquinox, .winterSolstice: return true
+        case .imbolc, .beltane, .lughnasadh, .samhain: return false
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Register new file in Xcode project**
+
+Check: `grep -c "SeasonalMarker+Turnings.swift\|SeasonalMarkerTurningTests.swift" Pilgrim.xcodeproj/project.pbxproj`. Expected `>= 4`. If not, add both files to the project manually following the `96ae8e4` pattern (Pilgrim target for extension, UnitTests target for test).
+
+- [ ] **Step 6: Run tests to verify pass**
+
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/SeasonalMarkerTurningTests 2>&1 | tail -5
+```
+
+Expected: `** TEST SUCCEEDED **`, 13 tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Pilgrim/Models/Astrology/SeasonalMarker+Turnings.swift UnitTests/SeasonalMarkerTurningTests.swift Pilgrim/Models/LS.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat(turnings): add SeasonalMarker properties for kanji, banner, color"
+```
+
+---
+
+## Task 4: CelestialCalculator.sunriseAzimuth
+
+**Files:**
+- Modify: `Pilgrim/Models/Astrology/CelestialCalculator.swift`
+- Create: `UnitTests/CelestialCalculatorSunriseAzimuthTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `UnitTests/CelestialCalculatorSunriseAzimuthTests.swift`:
+
+```swift
+import XCTest
+import CoreLocation
+@testable import Pilgrim
+
+final class CelestialCalculatorSunriseAzimuthTests: XCTestCase {
+
+    /// Approximate equality for azimuths (degrees). Astronomical formulas
+    /// have ~1° accuracy depending on refraction assumptions.
+    private let azimuthTolerance: Double = 3.0
+
+    private func date(year: Int, month: Int, day: Int) -> Date {
+        var c = DateComponents()
+        c.year = year
+        c.month = month
+        c.day = day
+        c.hour = 12
+        c.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .gregorian).date(from: c)!
+    }
+
+    // MARK: - Equinox at equator: sunrise due east (~90°)
+
+    func testEquinox_atEquator_risesDueEast() {
+        let equator = CLLocationCoordinate2D(latitude: 0, longitude: 0)
+        let marchEquinox = date(year: 2024, month: 3, day: 20)
+        guard let azimuth = CelestialCalculator.sunriseAzimuth(at: equator, on: marchEquinox) else {
+            return XCTFail("expected non-nil azimuth at equator on equinox")
+        }
+        XCTAssertEqual(azimuth, 90.0, accuracy: azimuthTolerance)
+    }
+
+    // MARK: - Summer solstice at mid-latitude: north of east
+
+    func testSummerSolstice_atNewYork_northOfEast() {
+        let nyc = CLLocationCoordinate2D(latitude: 40.7, longitude: -74.0)
+        let juneSolstice = date(year: 2024, month: 6, day: 20)
+        guard let azimuth = CelestialCalculator.sunriseAzimuth(at: nyc, on: juneSolstice) else {
+            return XCTFail("expected non-nil azimuth")
+        }
+        // Summer solstice at ~41°N: sunrise azimuth ~57-60° (well north of due east)
+        XCTAssertLessThan(azimuth, 70.0)
+        XCTAssertGreaterThan(azimuth, 50.0)
+    }
+
+    // MARK: - Winter solstice at mid-latitude: south of east
+
+    func testWinterSolstice_atNewYork_southOfEast() {
+        let nyc = CLLocationCoordinate2D(latitude: 40.7, longitude: -74.0)
+        let decSolstice = date(year: 2024, month: 12, day: 21)
+        guard let azimuth = CelestialCalculator.sunriseAzimuth(at: nyc, on: decSolstice) else {
+            return XCTFail("expected non-nil azimuth")
+        }
+        // Winter solstice at ~41°N: sunrise azimuth ~120-123° (south of due east)
+        XCTAssertGreaterThan(azimuth, 115.0)
+        XCTAssertLessThan(azimuth, 130.0)
+    }
+
+    // MARK: - Polar: sun doesn't rise
+
+    func testWinterSolstice_aboveArcticCircle_returnsNil() {
+        // 78°N, December solstice: polar night, sun doesn't rise.
+        let svalbard = CLLocationCoordinate2D(latitude: 78.0, longitude: 15.0)
+        let decSolstice = date(year: 2024, month: 12, day: 21)
+        XCTAssertNil(CelestialCalculator.sunriseAzimuth(at: svalbard, on: decSolstice))
+    }
+
+    // MARK: - Azimuth is in [0, 360)
+
+    func testAzimuth_alwaysInValidRange() {
+        let coords = [
+            CLLocationCoordinate2D(latitude: 40, longitude: 0),
+            CLLocationCoordinate2D(latitude: -33, longitude: 151),
+            CLLocationCoordinate2D(latitude: 60, longitude: -120),
+        ]
+        let dates = [
+            date(year: 2024, month: 3, day: 20),
+            date(year: 2024, month: 6, day: 20),
+            date(year: 2024, month: 9, day: 22),
+            date(year: 2024, month: 12, day: 21),
+        ]
+        for coord in coords {
+            for d in dates {
+                if let az = CelestialCalculator.sunriseAzimuth(at: coord, on: d) {
+                    XCTAssertGreaterThanOrEqual(az, 0.0)
+                    XCTAssertLessThan(az, 360.0)
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify compile failure**
+
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/CelestialCalculatorSunriseAzimuthTests 2>&1 | tail -10
+```
+
+Expected: compile error (`sunriseAzimuth(at:on:)` undefined).
+
+- [ ] **Step 3: Implement `sunriseAzimuth(at:on:)`**
+
+In `Pilgrim/Models/Astrology/CelestialCalculator.swift`, add after the existing `seasonalMarker` function:
+
+```swift
+// MARK: - Sunrise Azimuth
+
+/// Compass azimuth (degrees clockwise from true north) where the sun rises
+/// on the given date at the given location. Returns nil if the sun does
+/// not rise that day (polar night/day).
+///
+/// Uses the standard formula:
+///   cos(A) = (sin(δ) - sin(φ) · sin(h)) / (cos(φ) · cos(h))
+/// where δ is the sun's declination, φ is the observer's latitude, and
+/// h is the sun's altitude at sunrise (~-0.833° accounting for refraction
+/// and solar disk radius). Azimuth A is measured from due south in the
+/// traditional formula; we convert to compass-from-true-north below.
+///
+/// Accuracy is ~1-2 degrees, sufficient for a visual orientation marker.
+static func sunriseAzimuth(at coordinate: CLLocationCoordinate2D, on date: Date) -> CLLocationDirection? {
+    let lat = coordinate.latitude
+    let T = julianCenturies(from: julianDayNumber(from: date))
+    let sunLon = solarLongitude(T: T)
+
+    // Sun's declination (degrees)
+    // δ = asin(sin(obliquity) · sin(sunLon))
+    let obliquity = 23.439291 - 0.0130042 * T
+    let declination = degrees(asin(
+        sin(radians(obliquity)) * sin(radians(sunLon))
+    ))
+
+    // Standard altitude at sunrise: -0.833° (atmospheric refraction + solar radius)
+    let h: Double = -0.833
+
+    let phi = radians(lat)
+    let delta = radians(declination)
+    let hRad = radians(h)
+
+    let cosLat = cos(phi)
+    guard abs(cosLat) > 1e-9 else { return nil }
+
+    let numerator = sin(delta) - sin(phi) * sin(hRad)
+    let denominator = cosLat * cos(hRad)
+    let cosA = numerator / denominator
+
+    // If |cosA| > 1, the sun doesn't rise (polar) — return nil.
+    guard cosA >= -1.0 && cosA <= 1.0 else { return nil }
+
+    // A is measured clockwise from true north at sunrise (east side).
+    // acos returns [0, π], giving an angle from north via east.
+    let azimuth = degrees(acos(cosA))
+    return azimuth
+}
+```
+
+- [ ] **Step 4: Register new test file in Xcode project**
+
+Check: `grep -c "CelestialCalculatorSunriseAzimuthTests.swift" Pilgrim.xcodeproj/project.pbxproj`. Expected `>= 2`. If not, add it to UnitTests target.
+
+- [ ] **Step 5: Run tests to verify pass**
+
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/CelestialCalculatorSunriseAzimuthTests 2>&1 | tail -5
+```
+
+Expected: `** TEST SUCCEEDED **`, 5 tests pass.
+
+If tests fail on the tolerance checks, the formula may be off by a sign convention or refraction constant. The tolerances in the tests (±3°) are generous; if you're outside them by ~5-10°, re-examine the azimuth direction convention (some formulas give azimuth from south, ours should give from north).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Pilgrim/Models/Astrology/CelestialCalculator.swift UnitTests/CelestialCalculatorSunriseAzimuthTests.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat(turnings): add CelestialCalculator.sunriseAzimuth(at:on:)"
+```
+
+---
+
+## Task 5: TurningDayService
+
+**Files:**
+- Create: `Pilgrim/Models/Astrology/TurningDayService.swift`
+- Create: `UnitTests/TurningDayServiceTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `UnitTests/TurningDayServiceTests.swift`:
+
+```swift
+import XCTest
+import CoreLocation
+@testable import Pilgrim
+
+final class TurningDayServiceTests: XCTestCase {
+
+    private func date(year: Int, month: Int, day: Int, hour: Int = 12) -> Date {
+        var c = DateComponents()
+        c.year = year; c.month = month; c.day = day; c.hour = hour
+        c.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .gregorian).date(from: c)!
+    }
+
+    // MARK: - Northern hemisphere: astronomical = seasonal
+
+    func testMarchEquinox_northern_returnsSpringEquinox() {
+        let coord = CLLocationCoordinate2D(latitude: 40.7, longitude: -74.0)
+        let d = date(year: 2024, month: 3, day: 20)
+        XCTAssertEqual(TurningDayService.turning(for: d, at: coord), .springEquinox)
+    }
+
+    func testJuneSolstice_northern_returnsSummerSolstice() {
+        let coord = CLLocationCoordinate2D(latitude: 40.7, longitude: -74.0)
+        let d = date(year: 2024, month: 6, day: 20)
+        XCTAssertEqual(TurningDayService.turning(for: d, at: coord), .summerSolstice)
+    }
+
+    func testDecemberSolstice_northern_returnsWinterSolstice() {
+        let coord = CLLocationCoordinate2D(latitude: 40.7, longitude: -74.0)
+        let d = date(year: 2024, month: 12, day: 21)
+        XCTAssertEqual(TurningDayService.turning(for: d, at: coord), .winterSolstice)
+    }
+
+    // MARK: - Southern hemisphere: mirrored
+
+    func testJuneSolstice_southern_returnsWinterSolstice() {
+        let sydney = CLLocationCoordinate2D(latitude: -33.9, longitude: 151.2)
+        let d = date(year: 2024, month: 6, day: 20)
+        XCTAssertEqual(TurningDayService.turning(for: d, at: sydney), .winterSolstice)
+    }
+
+    func testDecemberSolstice_southern_returnsSummerSolstice() {
+        let sydney = CLLocationCoordinate2D(latitude: -33.9, longitude: 151.2)
+        let d = date(year: 2024, month: 12, day: 21)
+        XCTAssertEqual(TurningDayService.turning(for: d, at: sydney), .summerSolstice)
+    }
+
+    func testMarchEquinox_southern_returnsAutumnEquinox() {
+        let sydney = CLLocationCoordinate2D(latitude: -33.9, longitude: 151.2)
+        let d = date(year: 2024, month: 3, day: 20)
+        XCTAssertEqual(TurningDayService.turning(for: d, at: sydney), .autumnEquinox)
+    }
+
+    func testSeptemberEquinox_southern_returnsSpringEquinox() {
+        let sydney = CLLocationCoordinate2D(latitude: -33.9, longitude: 151.2)
+        let d = date(year: 2024, month: 9, day: 22)
+        XCTAssertEqual(TurningDayService.turning(for: d, at: sydney), .springEquinox)
+    }
+
+    // MARK: - Non-turning
+
+    func testNonTurningDay_returnsNil() {
+        let coord = CLLocationCoordinate2D(latitude: 40.7, longitude: -74.0)
+        let d = date(year: 2024, month: 5, day: 15)
+        XCTAssertNil(TurningDayService.turning(for: d, at: coord))
+    }
+
+    // MARK: - Cross-quarter markers excluded
+
+    func testCrossQuarterDate_returnsNil() {
+        let coord = CLLocationCoordinate2D(latitude: 40.7, longitude: -74.0)
+        // Beltane is around May 5-6 (sun at ecliptic longitude 45°)
+        let d = date(year: 2024, month: 5, day: 5)
+        XCTAssertNil(TurningDayService.turning(for: d, at: coord))
+    }
+
+    // MARK: - Nil coordinate defaults to northern
+
+    func testNilCoordinate_defaultsToNorthern() {
+        let d = date(year: 2024, month: 12, day: 21)
+        XCTAssertEqual(TurningDayService.turning(for: d, at: nil), .winterSolstice)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify compile failure**
+
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/TurningDayServiceTests 2>&1 | tail -10
+```
+
+Expected: compile error (`TurningDayService` undefined).
+
+- [ ] **Step 3: Implement `TurningDayService`**
+
+Create `Pilgrim/Models/Astrology/TurningDayService.swift`:
+
+```swift
+import Foundation
+import CoreLocation
+
+/// Hemisphere-aware turning-day detection.
+///
+/// `CelestialCalculator.seasonalMarker(sunLongitude:)` returns astronomical
+/// markers (always named by their northern-hemisphere meaning: a June
+/// solstice always returns `.summerSolstice`). This service translates
+/// that to the seasonally-correct marker for the observer's hemisphere.
+///
+/// Only the 4 main solstices/equinoxes are surfaced. Cross-quarter markers
+/// (imbolc/beltane/lughnasadh/samhain) are filtered out.
+enum TurningDayService {
+
+    /// Returns the seasonally-correct turning for the given date and location.
+    ///
+    /// - Parameters:
+    ///   - date: The date to check. Used for the astronomical calculation;
+    ///           the `CelestialCalculator` uses its day-resolution sun
+    ///           longitude to detect turnings.
+    ///   - coordinate: The observer's location. Used to determine hemisphere
+    ///                 (positive latitude → northern; negative → southern;
+    ///                 nil → northern). Pass the walk's first coordinate for
+    ///                 a historical walk; pass the most recent walk's
+    ///                 coordinate for "today's" queries.
+    /// - Returns: A `SeasonalMarker` of one of the 4 turnings, or nil if
+    ///            the date is not a turning day (including cross-quarter
+    ///            astronomical markers, which this feature doesn't surface).
+    static func turning(for date: Date, at coordinate: CLLocationCoordinate2D?) -> SeasonalMarker? {
+        let snapshot = CelestialCalculator.snapshot(for: date)
+        guard let astronomical = snapshot.seasonalMarker, astronomical.isTurning else {
+            return nil
+        }
+        let hemisphere = Hemisphere(coordinate: coordinate)
+        return mapping(astronomical: astronomical, hemisphere: hemisphere)
+    }
+
+    /// Translates the astronomical (northern-named) marker to the
+    /// seasonally-correct marker for the given hemisphere.
+    private static func mapping(astronomical: SeasonalMarker, hemisphere: Hemisphere) -> SeasonalMarker {
+        guard hemisphere == .southern else { return astronomical }
+        switch astronomical {
+        case .springEquinox:  return .autumnEquinox
+        case .summerSolstice: return .winterSolstice
+        case .autumnEquinox:  return .springEquinox
+        case .winterSolstice: return .summerSolstice
+        case .imbolc, .beltane, .lughnasadh, .samhain: return astronomical  // not surfaced
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Register new files in Xcode project**
+
+Check: `grep -c "TurningDayService.swift\|TurningDayServiceTests.swift" Pilgrim.xcodeproj/project.pbxproj`. Expected `>= 4`. Add manually if not.
+
+- [ ] **Step 5: Run tests to verify pass**
+
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/TurningDayServiceTests 2>&1 | tail -5
+```
+
+Expected: `** TEST SUCCEEDED **`, 11 tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Pilgrim/Models/Astrology/TurningDayService.swift UnitTests/TurningDayServiceTests.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat(turnings): add TurningDayService with hemisphere-aware mapping"
+```
+
+---
+
+## Task 6: SealColorPalette turning colors + SeasonalMarker.sealColor
+
+**Files:**
+- Modify: `Pilgrim/Models/Seal/SealColorPalette.swift` — 4 new `SealColor` entries, new `uiColor(for: SealInput)` entry point
+- Modify: `Pilgrim/Models/Seal/SealGenerator.swift` — call site update at line 44
+- Modify: `Pilgrim/Models/Astrology/SeasonalMarker+Turnings.swift` — add `sealColor` property
+- Create: `UnitTests/SealColorPaletteTurningTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `UnitTests/SealColorPaletteTurningTests.swift`:
+
+```swift
+import XCTest
+import CoreLocation
+import UIKit
+@testable import Pilgrim
+
+final class SealColorPaletteTurningTests: XCTestCase {
+
+    private func date(year: Int, month: Int, day: Int) -> Date {
+        var c = DateComponents()
+        c.year = year; c.month = month; c.day = day; c.hour = 12
+        c.timeZone = TimeZone(identifier: "UTC")
+        return Calendar(identifier: .gregorian).date(from: c)!
+    }
+
+    private func sealInput(startDate: Date, lat: Double, lon: Double, favicon: String? = "leaf") -> SealInput {
+        SealInput(
+            uuid: UUID(),
+            startDate: startDate,
+            activeDuration: 1800,
+            meditateDuration: 300,
+            talkDuration: 0,
+            distance: 2000,
+            steps: 3000,
+            elevationUp: 10,
+            elevationDown: 10,
+            averagePace: 0.9,
+            routePoints: [SealInput.RoutePoint(lat: lat, lon: lon)],
+            favicon: favicon,
+            intention: nil,
+            weather: nil
+        )
+    }
+
+    // MARK: - Turning day override
+
+    func testTurningDayInput_northernJuneSolstice_returnsGoldSealColor() {
+        let input = sealInput(startDate: date(year: 2024, month: 6, day: 20), lat: 40.7, lon: -74.0)
+        let color = SealColorPalette.uiColor(for: input)
+        XCTAssertEqual(color, UIColor(named: "turningGold"))
+    }
+
+    func testTurningDayInput_southernJuneSolstice_returnsIndigoSealColor() {
+        let input = sealInput(startDate: date(year: 2024, month: 6, day: 20), lat: -33.9, lon: 151.2)
+        let color = SealColorPalette.uiColor(for: input)
+        XCTAssertEqual(color, UIColor(named: "turningIndigo"))
+    }
+
+    func testTurningDayInput_northernMarchEquinox_returnsJadeSealColor() {
+        let input = sealInput(startDate: date(year: 2024, month: 3, day: 20), lat: 40.7, lon: -74.0)
+        let color = SealColorPalette.uiColor(for: input)
+        XCTAssertEqual(color, UIColor(named: "turningJade"))
+    }
+
+    func testTurningDayInput_northernSeptemberEquinox_returnsClaretSealColor() {
+        let input = sealInput(startDate: date(year: 2024, month: 9, day: 22), lat: 40.7, lon: -74.0)
+        let color = SealColorPalette.uiColor(for: input)
+        XCTAssertEqual(color, UIColor(named: "turningClaret"))
+    }
+
+    // MARK: - Turning override ignores favicon
+
+    func testTurningDayInput_ignoresFaviconHashSelection() {
+        // A turning-day walk with a "flame" favicon would normally pick a warm color.
+        // On a turning day it should return the turning color instead.
+        let input = sealInput(
+            startDate: date(year: 2024, month: 6, day: 20),
+            lat: 40.7,
+            lon: -74.0,
+            favicon: "flame"
+        )
+        let color = SealColorPalette.uiColor(for: input)
+        XCTAssertEqual(color, UIColor(named: "turningGold"))
+        XCTAssertNotEqual(color, SealColorPalette.rust.light)
+    }
+
+    // MARK: - Non-turning walks unchanged
+
+    func testNonTurningInput_returnsFaviconHashColor() {
+        // Non-turning date — should fall through to favicon-hash logic.
+        let input = sealInput(
+            startDate: date(year: 2024, month: 5, day: 15),
+            lat: 40.7,
+            lon: -74.0,
+            favicon: "leaf"
+        )
+        let color = SealColorPalette.uiColor(for: input)
+        // Leaf → coolColors. We can't know which specific color the hash picks
+        // without computing it, but it should be one of the cool set.
+        let coolColors = SealColorPalette.coolColors.map { $0.light }
+        XCTAssertTrue(coolColors.contains(color), "Expected a cool color for non-turning leaf walk")
+    }
+
+    // MARK: - SeasonalMarker.sealColor
+
+    func testSealColor_forEachTurning() {
+        XCTAssertEqual(SeasonalMarker.springEquinox.sealColor?.light, UIColor(named: "turningJade"))
+        XCTAssertEqual(SeasonalMarker.summerSolstice.sealColor?.light, UIColor(named: "turningGold"))
+        XCTAssertEqual(SeasonalMarker.autumnEquinox.sealColor?.light, UIColor(named: "turningClaret"))
+        XCTAssertEqual(SeasonalMarker.winterSolstice.sealColor?.light, UIColor(named: "turningIndigo"))
+    }
+
+    func testSealColor_crossQuarter_returnsNil() {
+        XCTAssertNil(SeasonalMarker.imbolc.sealColor)
+    }
+}
+```
+
+- [ ] **Step 2: Run the test to verify compile failure**
+
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/SealColorPaletteTurningTests 2>&1 | tail -10
+```
+
+Expected: compile errors — `SealColorPalette.uiColor(for: SealInput)` and `SeasonalMarker.sealColor` undefined.
+
+- [ ] **Step 3: Add 4 new `SealColor` entries to `SealColorPalette.swift`**
+
+In `Pilgrim/Models/Seal/SealColorPalette.swift`, find the section with existing seal colors (around `static let rust = SealColor(...)`) and add 4 new entries. Place them in a new group with a clear comment:
+
+```swift
+// Turning (solstice / equinox overrides — not included in warm/cool/accent/neutral arrays)
+static let turningJade    = SealColor(
+    light: UIColor(named: "turningJade")  ?? UIColor(hex: "#74B495"),
+    dark:  UIColor(named: "turningJade")  ?? UIColor(hex: "#88C5A0"),
+    cssVar: "--seal-turning-jade"
+)
+static let turningGold    = SealColor(
+    light: UIColor(named: "turningGold")  ?? UIColor(hex: "#C9A646"),
+    dark:  UIColor(named: "turningGold")  ?? UIColor(hex: "#D5B55D"),
+    cssVar: "--seal-turning-gold"
+)
+static let turningClaret  = SealColor(
+    light: UIColor(named: "turningClaret") ?? UIColor(hex: "#8B4455"),
+    dark:  UIColor(named: "turningClaret") ?? UIColor(hex: "#A26070"),
+    cssVar: "--seal-turning-claret"
+)
+static let turningIndigo  = SealColor(
+    light: UIColor(named: "turningIndigo") ?? UIColor(hex: "#2377A4"),
+    dark:  UIColor(named: "turningIndigo") ?? UIColor(hex: "#4691BA"),
+    cssVar: "--seal-turning-indigo"
+)
+```
+
+These are intentionally NOT added to `warmColors`/`coolColors`/`accentColors`/`neutralColors` — they exist only as turning-day overrides.
+
+- [ ] **Step 4: Add `uiColor(for: SealInput)` entry point**
+
+Still in `SealColorPalette.swift`, add after the existing `color(for: favicon, hashByte:)` and `uiColor(for: favicon, hashByte:)` functions:
+
+```swift
+/// Entry point used by `SealGenerator`. Pre-checks for a turning day
+/// and returns the matching turning seal color; otherwise falls back
+/// to the existing favicon+hash selection.
+static func uiColor(for input: SealInput) -> UIColor {
+    let firstPoint = input.routePoints.first
+    let coord = firstPoint.map { CLLocationCoordinate2D(latitude: $0.lat, longitude: $0.lon) }
+    if let turning = TurningDayService.turning(for: input.startDate, at: coord),
+       let sealColor = turning.sealColor {
+        return sealColor.light
+    }
+    let favicon = input.favicon.flatMap { WalkFavicon(rawValue: $0) }
+    let bytes = SealHashComputer.hexToBytes(SealHashComputer.computeHashFromInput(input))
+    return uiColor(for: favicon, hashByte: bytes[30])
+}
+```
+
+Ensure `import CoreLocation` is present at the top of the file; add it if missing.
+
+- [ ] **Step 5: Add `sealColor` property to `SeasonalMarker+Turnings.swift`**
+
+Open `Pilgrim/Models/Astrology/SeasonalMarker+Turnings.swift` and append this property inside the `extension SeasonalMarker { }` block:
+
+```swift
+/// `SealColorPalette` entry to use for the goshuin seal on this turning.
+/// Nil for cross-quarter.
+var sealColor: SealColorPalette.SealColor? {
+    switch self {
+    case .springEquinox:  return SealColorPalette.turningJade
+    case .summerSolstice: return SealColorPalette.turningGold
+    case .autumnEquinox:  return SealColorPalette.turningClaret
+    case .winterSolstice: return SealColorPalette.turningIndigo
+    case .imbolc, .beltane, .lughnasadh, .samhain: return nil
+    }
+}
+```
+
+- [ ] **Step 6: Update `SealGenerator.swift` call site**
+
+In `Pilgrim/Models/Seal/SealGenerator.swift`, line 44, replace:
+
+```swift
+let color = SealColorPalette.uiColor(for: favicon, hashByte: bytes[30])
+```
+
+with:
+
+```swift
+let color = SealColorPalette.uiColor(for: input)
+```
+
+The `favicon` and `bytes` local variables can still exist if used elsewhere in the function — leave them. Only the single assignment to `color` changes.
+
+- [ ] **Step 7: Register new test file in Xcode project**
+
+Check: `grep -c "SealColorPaletteTurningTests.swift" Pilgrim.xcodeproj/project.pbxproj`. Expected `>= 2`. Add to UnitTests target if not.
+
+- [ ] **Step 8: Run tests to verify pass**
+
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/SealColorPaletteTurningTests 2>&1 | tail -5
+```
+
+Expected: `** TEST SUCCEEDED **`, 8 tests pass.
+
+- [ ] **Step 9: Run the full unit test suite to verify no regression**
+
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests 2>&1 | grep -E "Executed [0-9]+ tests|TEST SUCCEEDED|TEST FAILED" | tail -3
+```
+
+Expected: all tests still pass, count has increased by the new tests from Tasks 1–6.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add Pilgrim/Models/Seal/SealColorPalette.swift Pilgrim/Models/Seal/SealGenerator.swift Pilgrim/Models/Astrology/SeasonalMarker+Turnings.swift UnitTests/SealColorPaletteTurningTests.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat(turnings): match goshuin seal color to route on turning days"
+```
+
+---
+
+## Task 7: InkScrollView turning-day banner
+
+**Files:**
+- Modify: `Pilgrim/Scenes/Home/InkScrollView.swift`
+
+The banner renders at the top of `scrollContent`, **independent of walk history**. It uses today's date and the hemisphere derived from the most-recent walk (or northern if no walks).
+
+- [ ] **Step 1: Read current scrollContent**
+
+Run:
+```bash
+sed -n '52,75p' Pilgrim/Scenes/Home/InkScrollView.swift
+```
+
+Confirm the structure: `scrollContent(width:height:)` returns a `ZStack(alignment: .top)` containing a Group with `journeySummaryHeader` gated by `!snapshots.isEmpty`.
+
+- [ ] **Step 2: Add the banner view inside scrollContent**
+
+In `InkScrollView.swift`, add a new computed property (near the other private view helpers, after `scrollContent`):
+
+```swift
+/// Banner shown at the top of the home scroll on solstices / equinoxes.
+/// Renders regardless of whether the user has any walks yet, so new users
+/// see the acknowledgment on their first turning day.
+@ViewBuilder
+private var turningBanner: some View {
+    if let turning = currentTurning, let text = turning.bannerText, let kanji = turning.kanji {
+        HStack(spacing: 8) {
+            Text(text)
+                .font(Constants.Typography.body)
+                .foregroundColor(.fog)
+            Text("·")
+                .font(Constants.Typography.body)
+                .foregroundColor(.fog.opacity(0.5))
+            if let color = turning.color {
+                Text(kanji)
+                    .font(Constants.Typography.body)
+                    .foregroundColor(color)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.top, Constants.UI.Padding.big)
+        .padding(.bottom, Constants.UI.Padding.small)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(text). \(turning.name).")
+    }
+}
+
+/// Turning for today, based on the hemisphere of the most recent walk
+/// (or northern if the user has no walks yet).
+private var currentTurning: SeasonalMarker? {
+    let coord = snapshots.first.flatMap { snapshot in
+        snapshot.routeData.first.map {
+            CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude)
+        }
+    }
+    return TurningDayService.turning(for: Date(), at: coord)
+}
+```
+
+Ensure `import CoreLocation` is present at the top of the file; add it if missing.
+
+- [ ] **Step 3: Render the banner at the top of scrollContent**
+
+Find the `scrollContent(width:height:)` function. Inside its returned ZStack, find the `Group { if !snapshots.isEmpty { journeySummaryHeader(...) } ... }` and prepend the banner **outside** the `!snapshots.isEmpty` gate:
+
+```swift
+return ZStack(alignment: .top) {
+    turningBanner
+    Group {
+        if !snapshots.isEmpty {
+            journeySummaryHeader(width: width)
+        }
+        // ... rest of existing code
+    }
+}
+```
+
+The banner uses `.frame(maxWidth: .infinity)` and padding, so it occupies its natural height at the very top of the scroll regardless of other content.
+
+Adjust `journeySummaryHeader`'s top offset or padding if it now overlaps with the banner. Simplest: add top padding to journeySummaryHeader so it sits below the banner when the banner is present. This can be done via a conditional padding modifier tied to `currentTurning != nil`.
+
+- [ ] **Step 4: Build and manually verify**
+
+Run:
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+Since today is not likely a turning day, the banner won't render in the simulator without a date stub. Defer visual verification to Task 16 (full QA).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Scenes/Home/InkScrollView.swift
+git commit -m "feat(turnings): add home-scroll banner on solstice and equinox days"
+```
+
+---
+
+## Task 8: InkScrollView+TurningMarkers
+
+**Files:**
+- Create: `Pilgrim/Scenes/Home/InkScrollView+TurningMarkers.swift`
+- Modify: `Pilgrim/Scenes/Home/InkScrollView.swift` — call the new marker function from `scrollContent`
+
+Mirrors the pattern of `InkScrollView+LunarMarkers.swift`. Renders a small faint kanji glyph at the position of each walk that fell on a turning day.
+
+- [ ] **Step 1: Read the lunar-markers pattern**
+
+Run:
+```bash
+cat Pilgrim/Scenes/Home/InkScrollView+LunarMarkers.swift
+```
+
+Note: the lunar markers function takes `positions: [CalligraphyPathRenderer.DotPosition]` and renders small circles at those positions.
+
+- [ ] **Step 2: Create the turning markers extension**
+
+Create `Pilgrim/Scenes/Home/InkScrollView+TurningMarkers.swift`:
+
+```swift
+import SwiftUI
+import CoreLocation
+
+extension InkScrollView {
+
+    /// Renders an inline kanji glyph at the position of each turning-day
+    /// walk in the user's history. Uses the walk's own starting coordinate
+    /// to determine hemisphere (so past walks keep their classification
+    /// even if the user has since moved hemispheres).
+    func turningMarkers(positions: [CalligraphyPathRenderer.DotPosition]) -> some View {
+        let markers = computeTurningMarkers(positions: positions)
+        return ForEach(markers, id: \.id) { marker in
+            Text(marker.kanji)
+                .font(Constants.Typography.caption)
+                .foregroundColor(marker.color.opacity(0.55))
+                .position(x: marker.x, y: marker.y - 14)  // above the walk dot
+                .accessibilityHidden(true)
+        }
+    }
+
+    struct TurningMarker: Identifiable {
+        let id: UUID
+        let x: CGFloat
+        let y: CGFloat
+        let kanji: String
+        let color: Color
+    }
+
+    private func computeTurningMarkers(positions: [CalligraphyPathRenderer.DotPosition]) -> [TurningMarker] {
+        guard positions.count == snapshots.count else { return [] }
+        var markers: [TurningMarker] = []
+        for (snapshot, position) in zip(snapshots, positions) {
+            let coord = snapshot.routeData.first.map {
+                CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude)
+            }
+            guard let turning = TurningDayService.turning(for: snapshot.startDate, at: coord),
+                  let kanji = turning.kanji,
+                  let color = turning.color else {
+                continue
+            }
+            markers.append(TurningMarker(
+                id: snapshot.id,
+                x: position.center.x,
+                y: position.center.y,
+                kanji: kanji,
+                color: color
+            ))
+        }
+        return markers
+    }
+}
+```
+
+- [ ] **Step 3: Call the new function from InkScrollView's scrollContent**
+
+In `InkScrollView.swift`'s `scrollContent(width:height:)`, find the spot where `lunarMarkers(positions:viewportWidth:)` is called (search for "lunarMarkers"). Add a sibling call to `turningMarkers(positions:)` immediately after or before it:
+
+```swift
+turningMarkers(positions: positions)
+lunarMarkers(positions: positions, viewportWidth: width)
+```
+
+- [ ] **Step 4: Register new file in Xcode project**
+
+Check: `grep -c "InkScrollView+TurningMarkers.swift" Pilgrim.xcodeproj/project.pbxproj`. Expected `>= 2`. Add to Pilgrim target if not.
+
+- [ ] **Step 5: Build**
+
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **`. Visual verification deferred to Task 16.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Pilgrim/Scenes/Home/InkScrollView+TurningMarkers.swift Pilgrim/Scenes/Home/InkScrollView.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat(turnings): render inline kanji at turning-day walk positions"
+```
+
+---
+
+## Task 9: InkScrollView pathSegmentColor turning override
+
+**Files:**
+- Modify: `Pilgrim/Scenes/Home/InkScrollView.swift`
+
+The existing `pathSegmentColor(index:)` picks colors by index. For turning-day walks, we need to override the color. Simplest path: pre-compute a lookup map in `scrollContent(width:height:)` where `snapshots` is accessible, then reference the map inside `pathSegmentColor`.
+
+- [ ] **Step 1: Add a stored-property-equivalent computed helper**
+
+In `InkScrollView.swift`, add a new private method that maps indices to turning colors:
+
+```swift
+/// Returns the turning-day color override for the walk at the given index,
+/// or nil if that walk was not a turning-day walk. Uses the walk's own
+/// starting coordinate for hemisphere classification.
+private func turningColorForSegment(index: Int) -> Color? {
+    guard index >= 0 && index < snapshots.count else { return nil }
+    let snapshot = snapshots[index]
+    let coord = snapshot.routeData.first.map {
+        CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude)
+    }
+    guard let turning = TurningDayService.turning(for: snapshot.startDate, at: coord) else {
+        return nil
+    }
+    return turning.color
+}
+```
+
+- [ ] **Step 2: Apply the override inside pathSegmentColor**
+
+Find the existing `pathSegmentColor(index:)` function. Modify to prefer the turning override:
+
+```swift
+private func pathSegmentColor(index: Int) -> Color {
+    if let turningColor = turningColorForSegment(index: index) {
+        return turningColor.opacity(0.85)  // softened so it blends with scroll palette
+    }
+    // … existing color-selection logic unchanged
+}
+```
+
+Keep the rest of the original `pathSegmentColor` body intact — the override is a pre-check only.
+
+- [ ] **Step 3: Build**
+
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Pilgrim/Scenes/Home/InkScrollView.swift
+git commit -m "feat(turnings): override ink-scroll segment color for turning-day walks"
+```
+
+---
+
+## Task 10: ActiveWalkView kanji watermark overlay
+
+**Files:**
+- Modify: `Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift`
+
+- [ ] **Step 1: Locate where the map is rendered**
+
+Find the main `body` of `ActiveWalkView`. Look for the Mapbox or map container (probably `PilgrimMapView` inside a `ZStack`). The watermark should sit as an overlay on the map, centered horizontally, positioned above the collapsed stats-sheet peek.
+
+Run:
+```bash
+grep -n "PilgrimMapView\|statsSheet\|bottomSheet\|ZStack" Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift | head -20
+```
+
+- [ ] **Step 2: Add a turning computed property to the view**
+
+Add near existing state variables:
+
+```swift
+/// Turning for today if this walk started on a turning day (determined from
+/// the walk's first recorded location sample). Nil on non-turning days.
+private var activeTurning: SeasonalMarker? {
+    let firstSample = viewModel.routeData.first
+    let coord = firstSample.map { CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude) }
+    return TurningDayService.turning(for: viewModel.walkStartDate ?? Date(), at: coord)
+}
+```
+
+Adjust `viewModel.routeData` and `viewModel.walkStartDate` to the actual property names on `ActiveWalkViewModel`. Inspect that file if unsure.
+
+- [ ] **Step 3: Add the watermark overlay**
+
+Inside the ZStack that contains the map, add an overlay that renders only when `activeTurning != nil`. Position it near the bottom-center, above where the collapsed stats sheet would be.
+
+Example (exact placement depends on existing layout):
+
+```swift
+.overlay(alignment: .bottom) {
+    if let turning = activeTurning, let kanji = turning.kanji {
+        Text(kanji)
+            .font(.system(size: 18, weight: .light))
+            .foregroundColor(.stone.opacity(0.18))
+            .padding(.bottom, 140)  // above the stats sheet peek; tune to existing sheet height
+            .allowsHitTesting(false)
+            .accessibilityHidden(true)
+    }
+}
+```
+
+The exact `.bottom` padding depends on the stats sheet's current collapsed height. If the app has a PreferenceKey-based measured height for the sheet, bind the padding to that; otherwise a hardcoded 140pt is an acceptable starting point and can be tuned visually.
+
+- [ ] **Step 4: Build**
+
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift
+git commit -m "feat(turnings): add kanji watermark overlay to active walk map"
+```
+
+---
+
+## Task 11: PilgrimMapView route color turning override
+
+**Files:**
+- Modify: `Pilgrim/Views/PilgrimMapView.swift`
+
+Update the Mapbox route layer's color match expression. The existing match maps `activityType` to `moss` / `dawn` / `rust`. On turning days, the default (walking) color becomes the turning's color. Meditation (`dawn`) and talking (`rust`) are unchanged.
+
+- [ ] **Step 1: Read current expression**
+
+```bash
+sed -n '270,290p' Pilgrim/Views/PilgrimMapView.swift
+```
+
+Confirm the existing match expression structure around line 273–281.
+
+- [ ] **Step 2: Thread the walking color into the map view**
+
+`PilgrimMapView` needs to know which walking color to use. The simplest approach: add a new stored property `walkingColor: UIColor` (defaulting to `UIColor.moss`) and replace the hardcoded `UIColor.moss` in the default match branch with the property.
+
+At the top of `PilgrimMapView` struct (or wherever stored properties live):
+
+```swift
+/// Color used for the walking-activity segments of the route. Callers override
+/// to `SeasonalMarker.turningColor` on turning-day walks; default is `.moss`.
+let walkingColor: UIColor
+```
+
+Update the initializer (if `PilgrimMapView` has an explicit init) to accept and default this parameter:
+
+```swift
+init(
+    // ... existing params ...
+    walkingColor: UIColor = .moss
+) {
+    // ... existing assignments ...
+    self.walkingColor = walkingColor
+}
+```
+
+If the struct uses synthesized memberwise init, add the property with a default (which preserves source-compat):
+
+```swift
+var walkingColor: UIColor = .moss
+```
+
+- [ ] **Step 3: Update the match expression**
+
+Around line 273–281, replace:
+
+```swift
+layer.lineColor = .expression(
+    Exp(.match) {
+        Exp(.get) { "activityType" }
+        "meditating"
+        UIColor.dawn
+        "talking"
+        UIColor.rust
+        UIColor.moss
+    }
+)
+```
+
+With:
+
+```swift
+layer.lineColor = .expression(
+    Exp(.match) {
+        Exp(.get) { "activityType" }
+        "meditating"
+        UIColor.dawn
+        "talking"
+        UIColor.rust
+        walkingColor
+    }
+)
+```
+
+- [ ] **Step 4: Propagate walkingColor from ActiveWalkView**
+
+In `Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift`, find where `PilgrimMapView(...)` is instantiated. Pass the walking color derived from `activeTurning`:
+
+```swift
+PilgrimMapView(
+    // ... existing args ...
+    walkingColor: activeTurning?.uiColor ?? UIColor.moss
+)
+```
+
+- [ ] **Step 5: Propagate walkingColor from WalkSummaryView**
+
+In `Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift`, find where `PilgrimMapView(...)` is instantiated. Compute the turning from the walk's own starting coordinate:
+
+```swift
+private var walkTurning: SeasonalMarker? {
+    let coord = walk.routeData.first.map {
+        CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude)
+    }
+    return TurningDayService.turning(for: walk.startDate, at: coord)
+}
+```
+
+And pass to the map view:
+
+```swift
+PilgrimMapView(
+    // ... existing args ...
+    walkingColor: walkTurning?.uiColor ?? UIColor.moss
+)
+```
+
+- [ ] **Step 6: Build**
+
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Pilgrim/Views/PilgrimMapView.swift Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+git commit -m "feat(turnings): route walking-segments in turning color on turning days"
+```
+
+---
+
+## Task 12: Sunrise-azimuth ray overlay on active walk
+
+**Files:**
+- Modify: `Pilgrim/Views/PilgrimMapView.swift` (adds a LineAnnotation for the ray)
+- Modify: `Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift` (passes the azimuth in)
+
+Mapbox has a `PolylineAnnotation` / `LineAnnotation` API that can render a line from a starting coordinate at a given bearing. The ray starts at the user's location puck and extends ~150pt in the direction of today's sunrise.
+
+- [ ] **Step 1: Add a sunriseRay property to PilgrimMapView**
+
+In `Pilgrim/Views/PilgrimMapView.swift`, add:
+
+```swift
+/// Optional sunrise-azimuth ray to render from the user's location on
+/// turning days. Nil means no ray (non-turning day, or polar latitude).
+let sunriseRay: SunriseRay?
+
+struct SunriseRay {
+    /// Compass direction (degrees from true north) of sunrise.
+    let azimuth: CLLocationDirection
+    /// Color of the ray (matches the turning's walking color).
+    let color: UIColor
+}
+```
+
+Default to nil in the initializer / memberwise init.
+
+- [ ] **Step 2: Render the ray as a LineAnnotation**
+
+In `PilgrimMapView`'s map configuration (near where the route layer is added), add logic that creates a polyline annotation when `sunriseRay != nil`. The ray uses a short geographic distance (~1km) so it's visible at typical zoom levels:
+
+```swift
+private func updateSunriseRay(on mapView: MBMapView, userLocation: CLLocationCoordinate2D?) {
+    // Remove any existing ray annotation manager
+    if let manager = coordinator.sunriseRayManager {
+        mapView.annotations.removeAnnotationManager(withId: manager.id)
+        coordinator.sunriseRayManager = nil
+    }
+    guard let ray = sunriseRay, let origin = userLocation else { return }
+
+    let endpoint = coordinate(from: origin, bearingDegrees: ray.azimuth, distanceMeters: 1000)
+    let manager = mapView.annotations.makePolylineAnnotationManager(id: "sunrise-ray")
+    var annotation = PolylineAnnotation(lineCoordinates: [origin, endpoint])
+    annotation.lineColor = StyleColor(ray.color.withAlphaComponent(0.15))
+    annotation.lineWidth = 2
+    manager.annotations = [annotation]
+    coordinator.sunriseRayManager = manager
+}
+
+/// Compute a coordinate `distanceMeters` along the bearing `bearingDegrees`
+/// from the origin. Great-circle approximation.
+private func coordinate(
+    from origin: CLLocationCoordinate2D,
+    bearingDegrees: CLLocationDirection,
+    distanceMeters: Double
+) -> CLLocationCoordinate2D {
+    let earthRadius = 6_371_000.0
+    let bearingRad = bearingDegrees * .pi / 180.0
+    let lat1 = origin.latitude * .pi / 180.0
+    let lon1 = origin.longitude * .pi / 180.0
+    let angular = distanceMeters / earthRadius
+
+    let lat2 = asin(
+        sin(lat1) * cos(angular) +
+        cos(lat1) * sin(angular) * cos(bearingRad)
+    )
+    let lon2 = lon1 + atan2(
+        sin(bearingRad) * sin(angular) * cos(lat1),
+        cos(angular) - sin(lat1) * sin(lat2)
+    )
+    return CLLocationCoordinate2D(
+        latitude: lat2 * 180.0 / .pi,
+        longitude: lon2 * 180.0 / .pi
+    )
+}
+```
+
+Add a `sunriseRayManager: PolylineAnnotationManager?` property to the `Coordinator` class so the annotation can be removed later. Call `updateSunriseRay(on:userLocation:)` whenever the user's location or `sunriseRay` changes (location update path, or `updateUIView` if state-driven).
+
+- [ ] **Step 3: Compute the ray in ActiveWalkView**
+
+In `Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift`, add:
+
+```swift
+/// Sunrise azimuth ray for today's turning, if any. Computed once from
+/// the walk's first location sample.
+private var sunriseRay: PilgrimMapView.SunriseRay? {
+    guard let turning = activeTurning,
+          let color = turning.uiColor,
+          let firstSample = viewModel.routeData.first else {
+        return nil
+    }
+    let coord = CLLocationCoordinate2D(latitude: firstSample.latitude, longitude: firstSample.longitude)
+    guard let azimuth = CelestialCalculator.sunriseAzimuth(
+        at: coord,
+        on: viewModel.walkStartDate ?? Date()
+    ) else {
+        return nil
+    }
+    return PilgrimMapView.SunriseRay(azimuth: azimuth, color: color)
+}
+```
+
+Adjust property names (`routeData`, `walkStartDate`) to match the actual `ActiveWalkViewModel` API. Pass `sunriseRay: sunriseRay` to the `PilgrimMapView` initializer.
+
+- [ ] **Step 4: Build**
+
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **`. If Mapbox API names differ (e.g., `PolylineAnnotation` is named `LineAnnotation` in your version), adjust accordingly.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Views/PilgrimMapView.swift Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift
+git commit -m "feat(turnings): draw sunrise-azimuth ray on active walk map"
+```
+
+---
+
+## Task 13: Walk summary date title kanji suffix
+
+**Files:**
+- Modify: `Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift`
+
+- [ ] **Step 1: Locate the date title**
+
+Run:
+```bash
+grep -n "dateTitleFormatted\|dateTitle\b" Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+```
+
+- [ ] **Step 2: Extend dateTitle to append kanji**
+
+Find the existing `dateTitle` or `dateTitleFormatted` computed property. Update it to append the kanji when applicable:
+
+```swift
+private var dateTitle: String {
+    let base = Self.dateTitleFormatter.string(from: walk.startDate)
+    if let kanji = walkTurning?.kanji {
+        return "\(base) · \(kanji)"
+    }
+    return base
+}
+```
+
+`walkTurning` is already defined from Task 11's changes. If it's not yet in this file (because Task 11 didn't touch this property), add it:
+
+```swift
+private var walkTurning: SeasonalMarker? {
+    let coord = walk.routeData.first.map {
+        CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude)
+    }
+    return TurningDayService.turning(for: walk.startDate, at: coord)
+}
+```
+
+- [ ] **Step 3: Apply turning color to the kanji portion (optional polish)**
+
+If the date title is rendered as a single `Text`, the kanji inherits the title's color. For the turning color to come through on just the kanji, split the title into two Text views joined with `+`:
+
+```swift
+private var dateTitleView: some View {
+    let base = Self.dateTitleFormatter.string(from: walk.startDate)
+    if let kanji = walkTurning?.kanji, let color = walkTurning?.color {
+        return Text(base)
+            .foregroundColor(.ink)
+            + Text(" · ")
+            .foregroundColor(.fog.opacity(0.5))
+            + Text(kanji)
+            .foregroundColor(color)
+    }
+    return Text(base).foregroundColor(.ink)
+}
+```
+
+Replace the existing `Text(dateTitle)` call site with `dateTitleView`. If that's more invasive than warranted, leave the single-string version and move this as a follow-up.
+
+- [ ] **Step 4: Build**
+
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+git commit -m "feat(turnings): append kanji suffix to walk summary date title"
+```
+
+---
+
+## Task 14: Forward-compatible turningDay share-payload field
+
+**Files:**
+- Modify: `Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift`
+- Modify: `Pilgrim/Models/ShareService.swift` (or wherever the share payload struct lives)
+
+The iOS app populates a new optional field on the share payload. The `pilgrim-worker` consumes it later in a follow-up PR; until then, the worker ignores unknown fields.
+
+- [ ] **Step 1: Find the share payload struct**
+
+Run:
+```bash
+grep -n "struct.*Payload\|func buildPayload\|struct.*Share" Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift Pilgrim/Models/ShareService.swift | head -10
+```
+
+Identify where the Codable payload is declared and where `buildPayload(...)` assembles it.
+
+- [ ] **Step 2: Add a turningDay field to the payload struct**
+
+In the struct declaration, add an optional string field:
+
+```swift
+/// Nil for non-turning-day walks. Values: "winter-solstice",
+/// "summer-solstice", "spring-equinox", "autumn-equinox". Used by the
+/// pilgrim-worker HTML renderer to style the hosted page with the
+/// matching color palette and kanji mark.
+var turningDay: String?
+```
+
+- [ ] **Step 3: Populate it in buildPayload**
+
+Find the `buildPayload(placeStart:placeEnd:)` method in `WalkShareViewModel.swift` (or wherever the payload is assembled). Add:
+
+```swift
+let coord = walk.routeData.first.map {
+    CLLocationCoordinate2D(latitude: $0.latitude, longitude: $0.longitude)
+}
+let turningDay = TurningDayService.turning(for: walk.startDate, at: coord).flatMap { marker -> String? in
+    switch marker {
+    case .winterSolstice: return "winter-solstice"
+    case .summerSolstice: return "summer-solstice"
+    case .springEquinox:  return "spring-equinox"
+    case .autumnEquinox:  return "autumn-equinox"
+    case .imbolc, .beltane, .lughnasadh, .samhain: return nil
+    }
+}
+```
+
+Include `turningDay` when constructing the payload.
+
+- [ ] **Step 4: Build**
+
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift Pilgrim/Models/ShareService.swift
+git commit -m "feat(turnings): add turningDay to share payload (forward-compatible)"
+```
+
+---
+
+## Task 15: Full test suite + manual QA sweep
+
+- [ ] **Step 1: Run the full unit test suite**
+
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests 2>&1 | grep -E "Executed [0-9]+ tests|TEST SUCCEEDED|TEST FAILED" | tail -3
+```
+
+Expected: `** TEST SUCCEEDED **`. Count should be the pre-feature total + new tests from Tasks 1, 3, 4, 5, 6 (roughly 40 new tests).
+
+- [ ] **Step 2: Date stub for manual verification**
+
+To exercise the UI on a non-turning day, introduce a temporary date stub. Add a launch argument check in `PilgrimApp.swift` (DEBUG only) that overrides `Date()` to a turning date:
+
+```swift
+#if DEBUG
+if CommandLine.arguments.contains("--stub-date-winter-solstice") {
+    // Override Date() globally or via a test-only TimeProvider singleton
+    // Pattern specific to how the project handles time — may require
+    // introducing a `DateProvider` if one doesn't already exist.
+}
+#endif
+```
+
+If introducing a DateProvider is too invasive, temporarily hardcode the date in `TurningDayService.turning(for:at:)` for manual testing (revert before commit):
+
+```swift
+let testDate = Calendar(identifier: .gregorian).date(from: DateComponents(year: 2024, month: 12, day: 21))!
+let snapshot = CelestialCalculator.snapshot(for: testDate)  // was: date parameter
+```
+
+Remove the stub before committing.
+
+- [ ] **Step 3: Manual QA checklist (on simulator or device)**
+
+With the date stubbed to a turning day, verify each surface:
+
+1. **Home (InkScrollView)**: banner appears at the top of the scroll (*"Today the sun stands still · 冬至"* or equivalent); if there's at least one past turning-day walk, its dot has an inline kanji glyph above it.
+2. **New user (zero walks)**: banner still appears. The scroll may be empty otherwise; confirm banner isn't hidden by the `!snapshots.isEmpty` gate.
+3. **Active walk**: start a walk (or demo mode). Verify kanji watermark at bottom-center of the map above the stats sheet. Verify walking-route segments render in the turning color (use demo mode with walking-only data if meditation/talk confuses the color check).
+4. **Sunrise ray**: visible on the active walk map, starting at the user's puck, extending in a compass direction matching today's sunrise.
+5. **Walk summary**: after finishing a turning-day walk, the date title in the summary reads *"December 21, 2024 · 冬至"*; the route in the summary map uses the turning color for walking segments.
+6. **Goshuin seal**: after a turning-day walk, the generated seal (SealReveal animation and GoshuinView collection entry) uses the turning color regardless of the walk's favicon.
+7. **Non-turning day (remove stub)**: all of the above are absent. Regression confirmed.
+8. **Dark mode**: switch appearance, verify all 4 turning colors render legibly against dark parchment with no halo/inversion issues.
+9. **Hemisphere flip**: stub the hemisphere by creating a walk with `latitude = -33.9`. On the December solstice stub, the UI should show 夏至 (summer solstice) and the gold color — not the winter blue.
+10. **VoiceOver**: enable and navigate the home screen. Banner should be readable ("Today, day equals night. Spring Equinox."). Margin glyphs silent (accessibility hidden). Walk summary date reads with the English label instead of raw kanji.
+11. **Polar sunrise ray**: stub the user's location to latitude 78° on winter solstice. Ray should NOT render. No crash.
+12. **Walk crossing midnight**: start a walk at 23:55 on a turning day (stub the system clock). Verify the walk is classified as turning-day (date-based on start).
+
+- [ ] **Step 4: Remove all stubs and verify clean build**
+
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **` + `** TEST SUCCEEDED **`.
+
+- [ ] **Step 5: No commit required unless stubs or fixes were made during QA**
+
+If QA revealed issues that were fixed, commit those fixes with appropriate messages.
+
+---
+
+## Task 16: Final review + push
+
+- [ ] **Step 1: Diff review**
+
+```bash
+git log main..HEAD --oneline
+git diff main..HEAD --stat
+```
+
+Expected: ~14 commits, 5+ new files + several modified files. Confirm nothing unexpected.
+
+- [ ] **Step 2: Stale debug-print scan**
+
+```bash
+git diff main..HEAD -- '*.swift' | grep -E '^\+.*print\('
+```
+
+Expected: no output.
+
+- [ ] **Step 3: Full build + test one more time**
+
+```
+DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild build test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tail -5
+```
+
+Expected: `** BUILD SUCCEEDED **` + `** TEST SUCCEEDED **`.
+
+- [ ] **Step 4: Push the feature branch**
+
+```bash
+git push -u origin HEAD
+```
+
+Return the PR-creation URL printed by the remote so the user can open a pull request.
+
+---
+
+## Notes for the engineer
+
+- **Follow the `96ae8e4` pbxproj pattern** for every new .swift file you add. `Pilgrim/` and `UnitTests/` are NOT synchronized root groups in this project, so manual `project.pbxproj` edits are required. Look at that commit for a worked example.
+- **The Mapbox API in this project** uses Mapbox Maps SDK for iOS. Exact symbol names may shift between minor versions — if `PolylineAnnotation` or `StyleColor` don't exist under those names in your version, check the Pods directory for the current API and adapt Task 12 accordingly.
+- **Don't over-engineer the date stub** in Task 15. If introducing a `DateProvider` would ripple through the codebase, prefer temporary hardcoded test dates that you revert. The stub is only for manual verification; production code reads real `Date()`.
+- **The spec specifies the exact hex values** for all 4 colors, but final tuning should be done against the rendered parchment on a real device before v1 ships. If the colors look off in testing, adjust the .colorset JSON and recommit.
+- **`pilgrim-worker` follow-up** is out of scope for this iOS plan. Once the iOS PR merges, the worker can consume the new `turningDay` payload field and render matching colors on the hosted share page. That's a separate PR on the separate repo.

--- a/docs/superpowers/plans/2026-04-23-rubberduck-walk.md
+++ b/docs/superpowers/plans/2026-04-23-rubberduck-walk.md
@@ -1,0 +1,2728 @@
+# Rubberduck Walk Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a tiny unbranded rubber duck that walks real pilgrimage routes (Shikoku 88 first), speaks rarely in a child/fool/sage voice, publishes a jsDelivr-served JSON feed, and appears as an easter egg on pilgrim-landing via a new `/walk` page and a footer icon.
+
+**Architecture:** New GitHub repo `walktalkmeditate/rubberduck-walk` holds markdown entries, deterministic TS helpers, and `CLAUDE.md` as the "brain." Daily Claude Code `/schedule` invocation advances the duck's position, drafts + self-reviews an entry (or falls silent), commits, pushes, purges jsDelivr. pilgrim-landing's `/walk` page is plain static HTML/CSS/JS that fetches the feed on load and renders entries with age-based visual fading.
+
+**Tech Stack:** Node 20 + TypeScript (tsx runtime), node:test for tests, js-yaml for frontmatter, Open-Meteo for weather, jsDelivr for CDN, Claude Code CLI as generation runtime. **No HTML in the feed** — duck prose is plain text; the client splits on blank lines and uses `textContent` to stay XSS-safe. pilgrim-landing stays vanilla HTML/CSS/JS (no build step, no framework).
+
+**Spec:** `docs/superpowers/specs/2026-04-22-rubberduck-walk-design.md`
+
+**Repos touched:**
+- **NEW**: `~/GitHub/rubberduck/walk/` → remote `walktalkmeditate/rubberduck-walk`
+- **MODIFY**: `~/GitHub/momentmaker/pilgrim-landing/` (add `walk.html`, `css/walk.css`, `js/walk.js`, footer duck in 4 existing pages)
+- **NO CHANGE**: pilgrim-ios (this doc lives here, nothing else touched)
+
+Every task explicitly notes `cd` working directory. The plan file stays here in pilgrim-ios.
+
+---
+
+## File Structure
+
+### New in `~/GitHub/rubberduck/walk/`
+
+```
+walk/
+├── CLAUDE.md                    character bible + playbook (Claude Code loads this automatically)
+├── package.json                 node project manifest (tsx, js-yaml, dev: typescript, @types/node)
+├── tsconfig.json                TS config, strict mode
+├── .gitignore                   node_modules, .env, .DS_Store
+├── README.md                    short — "a duck. it walks."
+├── state.json                   current route, stage, mode, timestamps (authoritative state)
+├── feed.json                    generated — what jsDelivr serves
+├── routes/
+│   ├── queue.json               ordered route list (human-editable)
+│   └── shikoku-88.json          snapshot from open-pilgrimages (committed)
+├── entries/                     markdown + YAML frontmatter, one per duck entry
+├── assets/
+│   ├── chiefrubberduck.png      source PNG (committed, for provenance)
+│   └── chiefrubberduck-transparent.gif  source GIF
+├── src/
+│   ├── types.ts                 shared TypeScript types (State, Entry, Feed, Route)
+│   ├── entries.ts               parse/load entries (markdown + frontmatter, plain-text body)
+│   ├── feed.ts                  build feed.json from entries + state + route
+│   ├── advance.ts               state-machine transitions
+│   └── weather.ts               Open-Meteo fetch + WMO code → short-string mapping
+├── scripts/
+│   ├── advance.ts               CLI wrapper for src/advance.ts (used by daily /schedule)
+│   ├── build-feed.ts            CLI wrapper for src/feed.ts
+│   ├── weather.ts               CLI wrapper for src/weather.ts (prints weather string)
+│   └── purge.sh                 curl to purge.jsdelivr.net
+├── duck                         top-level CLI dispatcher (tsx-based shebang)
+└── test/                        node:test specs mirroring src/
+    ├── entries.test.ts
+    ├── feed.test.ts
+    ├── advance.test.ts
+    └── weather.test.ts
+```
+
+### New/modified in `~/GitHub/momentmaker/pilgrim-landing/`
+
+```
+walk.html              NEW — the /walk page
+css/walk.css           NEW — journal-styled entries + fade tiers + map styling
+js/walk.js             NEW — fetch feed, render (textContent-only), apply age-based fading
+assets/duck/
+  ├── duck-24.png      NEW — 1x footer icon
+  ├── duck-48.png      NEW — 2x (Retina) footer icon
+  └── duck.gif         NEW — animated for /walk map current-position marker
+index.html             MODIFY — add duck icon inside existing .horizon footer (line ~1515)
+privacy.html           MODIFY — same
+terms.html             MODIFY — same
+press.html             MODIFY — same
+```
+
+The `/walk` page does NOT get a `.horizon` footer itself (it's its own atmosphere). It gets only the chiefrubberduck tagline in muted type at the bottom.
+
+---
+
+## Phase 0 — Bootstrap rubberduck-walk repo
+
+### Task 1: Create the repo directory and initial files
+
+**Files:**
+- Create: `~/GitHub/rubberduck/walk/` (directory)
+- Create: `~/GitHub/rubberduck/walk/.gitignore`
+- Create: `~/GitHub/rubberduck/walk/README.md`
+- Create: `~/GitHub/rubberduck/walk/package.json`
+- Create: `~/GitHub/rubberduck/walk/tsconfig.json`
+
+- [ ] **Step 1: Verify parent dir and create walk/**
+
+Run from anywhere:
+```bash
+ls ~/GitHub/rubberduck/       # should show: guide  substack
+mkdir -p ~/GitHub/rubberduck/walk
+cd ~/GitHub/rubberduck/walk
+```
+
+- [ ] **Step 2: Write `.gitignore`**
+
+```
+node_modules/
+.DS_Store
+.env
+.env.local
+*.log
+dist/
+coverage/
+```
+
+- [ ] **Step 3: Write `README.md`**
+
+```markdown
+# walk
+
+A duck. It walks.
+
+See the feed at https://cdn.jsdelivr.net/gh/walktalkmeditate/rubberduck-walk@main/feed.json.
+```
+
+- [ ] **Step 4: Write `package.json`**
+
+```json
+{
+  "name": "rubberduck-walk",
+  "version": "0.0.1",
+  "private": true,
+  "type": "module",
+  "bin": {
+    "duck": "./duck"
+  },
+  "scripts": {
+    "test": "node --import tsx --test 'test/**/*.test.ts'",
+    "advance": "tsx scripts/advance.ts",
+    "build-feed": "tsx scripts/build-feed.ts",
+    "weather": "tsx scripts/weather.ts",
+    "purge": "bash scripts/purge.sh"
+  },
+  "dependencies": {
+    "js-yaml": "^4.1.0"
+  },
+  "devDependencies": {
+    "@types/js-yaml": "^4.0.9",
+    "@types/node": "^20.12.0",
+    "tsx": "^4.7.0",
+    "typescript": "^5.4.0"
+  }
+}
+```
+
+- [ ] **Step 5: Write `tsconfig.json`**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true
+  },
+  "include": ["src/**/*", "scripts/**/*", "test/**/*"]
+}
+```
+
+- [ ] **Step 6: Install deps**
+
+```bash
+cd ~/GitHub/rubberduck/walk
+npm install
+```
+Expected: no errors, `node_modules/` created.
+
+- [ ] **Step 7: Commit**
+
+```bash
+cd ~/GitHub/rubberduck/walk
+git init
+git add .
+git commit -m "chore: bootstrap repo"
+```
+
+---
+
+### Task 2: Connect GitHub remote and push
+
+**Files:** None changed; this is a git/GitHub plumbing task.
+
+- [ ] **Step 1: Create empty public repo on GitHub**
+
+The remote `walktalkmeditate/rubberduck-walk` must exist before push. If not already created, ask the user to create it at https://github.com/new with name `rubberduck-walk`, owner `walktalkmeditate`, public, no README/license/gitignore (we already have those).
+
+- [ ] **Step 2: Add remote and push**
+
+```bash
+cd ~/GitHub/rubberduck/walk
+git branch -M main
+git remote add origin git@github.com:walktalkmeditate/rubberduck-walk.git
+git push -u origin main
+```
+Expected: push succeeds, remote has the bootstrap commit.
+
+- [ ] **Step 3: Verify jsDelivr can see the repo**
+
+```bash
+curl -I https://cdn.jsdelivr.net/gh/walktalkmeditate/rubberduck-walk@main/README.md
+```
+Expected: HTTP 200. If 404, the CDN may take a minute to index a newly-created repo.
+
+---
+
+## Phase 1 — Types and initial data
+
+### Task 3: Define shared TypeScript types
+
+**Files:**
+- Create: `~/GitHub/rubberduck/walk/src/types.ts`
+
+- [ ] **Step 1: Write `src/types.ts`**
+
+```typescript
+export type DuckMode = "walking" | "completing" | "resting" | "beginning";
+
+export type EntryKind = "offering" | "notice" | "silence" | "threshold" | "letter";
+
+export type Coords = [number, number]; // [latitude, longitude]
+
+export interface State {
+  route: string;
+  stage: number;
+  stageName: string;
+  coords: Coords;
+  mode: DuckMode;
+  modeEnteredAt: string;   // ISO date "YYYY-MM-DD"
+  lastAdvancedAt: string;  // ISO date "YYYY-MM-DD"
+}
+
+export interface RouteStage {
+  index: number;
+  name: string;
+  coords: Coords;
+}
+
+export interface Route {
+  id: string;
+  name: string;
+  country: string;
+  distanceKm: number;
+  stages: RouteStage[];
+  /** Optional route-specific closure site used when mode=completing. */
+  closure?: {
+    name: string;
+    coords: Coords;
+    transitStages: RouteStage[];
+  };
+}
+
+export interface EntryFrontmatter {
+  date: string;          // "YYYY-MM-DD"
+  route: string;
+  stage: number;
+  stageName: string;
+  coords: Coords;
+  kind: EntryKind;
+  glyph: string;
+  weather?: string;      // human-readable, e.g. "light rain, 14°C"
+  author?: string;       // only for kind=letter; defaults to "— the pilgrim"
+}
+
+export interface Entry extends EntryFrontmatter {
+  body: string;          // raw plain-text body
+  paragraphs: string[];  // split on blank-line boundaries; each is plain text
+  filePath: string;      // absolute path on disk
+  ageDays: number;       // computed at build time
+}
+
+export interface FeedDuck {
+  route: string;
+  routeName: string;
+  stage: number;
+  stageName: string;
+  coords: Coords;
+  mode: DuckMode;
+  progress: number;      // 0..1
+}
+
+export interface FeedEntry {
+  date: string;
+  route: string;
+  stage: number;
+  stageName: string;
+  coords: Coords;
+  kind: EntryKind;
+  glyph: string;
+  paragraphs: string[];  // plain text — client renders with textContent
+  author?: string;
+  ageDays: number;
+}
+
+export interface Feed {
+  generatedAt: string;  // ISO 8601 UTC
+  duck: FeedDuck;
+  entries: FeedEntry[];
+  routePath: Record<string, Coords[]>;  // route id → ordered coords
+}
+```
+
+- [ ] **Step 2: Verify it compiles**
+
+```bash
+cd ~/GitHub/rubberduck/walk
+npx tsc --noEmit
+```
+Expected: no errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/types.ts
+git commit -m "feat(types): define State, Entry, Feed, Route"
+```
+
+---
+
+### Task 4: Snapshot shikoku-88 route data from open-pilgrimages
+
+**Files:**
+- Create: `~/GitHub/rubberduck/walk/routes/shikoku-88.json`
+
+This is a one-time snapshot. The duck repo does not live-depend on `../open-pilgrimages`.
+
+- [ ] **Step 1: Locate shikoku-88 in open-pilgrimages**
+
+```bash
+ls ~/GitHub/momentmaker/open-pilgrimages/routes/shikoku-88/
+```
+Inspect the files. Typical structure includes a `route.json` or similar with stages.
+
+- [ ] **Step 2: Transform and write snapshot**
+
+Read the source files in `~/GitHub/momentmaker/open-pilgrimages/routes/shikoku-88/`, extract the 88 temple stages into the `Route` shape from `src/types.ts`, and write to `~/GitHub/rubberduck/walk/routes/shikoku-88.json`. The JSON must validate against the `Route` type: `id`, `name`, `country`, `distanceKm`, `stages[]` (with `index`, `name`, `coords`).
+
+Add the `closure` field manually (open-pilgrimages may not have Kōya-san):
+
+```json
+{
+  "id": "shikoku-88",
+  "name": "Shikoku Henro",
+  "country": "JP",
+  "distanceKm": 1200,
+  "stages": [
+    { "index": 1, "name": "Ryōzenji", "coords": [34.128, 134.537] },
+    { "index": 88, "name": "Ōkuboji", "coords": [34.218, 134.051] }
+  ],
+  "closure": {
+    "name": "Kōya-san Okunoin",
+    "coords": [34.2167, 135.589],
+    "transitStages": [
+      { "index": 1, "name": "Tokushima port", "coords": [34.067, 134.555] },
+      { "index": 2, "name": "Wakayama", "coords": [34.230, 135.170] },
+      { "index": 3, "name": "Hashimoto", "coords": [34.312, 135.604] },
+      { "index": 4, "name": "Kōya-san Okunoin", "coords": [34.2167, 135.589] }
+    ]
+  }
+}
+```
+
+Fill in all 88 stages between index 1 and 88 using open-pilgrimages data. If the open-pilgrimages data has more precise coords, use those.
+
+- [ ] **Step 3: Verify file parses and has 88 stages**
+
+```bash
+cd ~/GitHub/rubberduck/walk
+node -e "console.log(JSON.parse(require('fs').readFileSync('routes/shikoku-88.json','utf8')).stages.length)"
+```
+Expected: `88`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add routes/shikoku-88.json
+git commit -m "feat(routes): snapshot shikoku-88 from open-pilgrimages"
+```
+
+---
+
+### Task 5: Write initial `state.json` and `routes/queue.json`
+
+**Files:**
+- Create: `~/GitHub/rubberduck/walk/state.json`
+- Create: `~/GitHub/rubberduck/walk/routes/queue.json`
+
+- [ ] **Step 1: Write `state.json`**
+
+The duck starts at Temple 1.
+
+```json
+{
+  "route": "shikoku-88",
+  "stage": 1,
+  "stageName": "Ryōzenji",
+  "coords": [34.128, 134.537],
+  "mode": "walking",
+  "modeEnteredAt": "2026-04-23",
+  "lastAdvancedAt": "2026-04-23"
+}
+```
+
+(If the snapshot in Task 4 had different coords for Ryōzenji, use those.)
+
+- [ ] **Step 2: Write `routes/queue.json`**
+
+```json
+[
+  "shikoku-88",
+  "kumano-kodo",
+  "camino-frances",
+  "camino-portugues",
+  "camino-norte",
+  "camino-primitivo",
+  "camino-ingles"
+]
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add state.json routes/queue.json
+git commit -m "feat(state): initial state at Temple 1, route queue"
+```
+
+---
+
+## Phase 2 — Entry parsing (TDD)
+
+### Task 6: Write `parseEntry` with failing test
+
+**Files:**
+- Create: `~/GitHub/rubberduck/walk/test/entries.test.ts`
+- Create: `~/GitHub/rubberduck/walk/src/entries.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+File `test/entries.test.ts`:
+
+```typescript
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { parseEntry } from "../src/entries.ts";
+
+test("parseEntry reads frontmatter and body as paragraphs", () => {
+  const raw = `---
+date: 2026-04-23
+route: shikoku-88
+stage: 1
+stageName: Ryōzenji
+coords: [34.128, 134.537]
+kind: offering
+glyph: 🪨
+weather: clear, 15°C
+---
+
+A stone by the door. No one had moved it. No one needed to.
+`;
+  const result = parseEntry(raw, "/fake/path.md");
+  assert.equal(result.date, "2026-04-23");
+  assert.equal(result.kind, "offering");
+  assert.equal(result.glyph, "🪨");
+  assert.deepEqual(result.coords, [34.128, 134.537]);
+  assert.deepEqual(result.paragraphs, [
+    "A stone by the door. No one had moved it. No one needed to.",
+  ]);
+  assert.equal(result.filePath, "/fake/path.md");
+});
+
+test("parseEntry splits letter on blank lines", () => {
+  const raw = `---
+date: 2026-05-02
+route: shikoku-88
+stage: 13
+stageName: Dainichiji
+coords: [33.9, 134.1]
+kind: letter
+glyph: 🕯️
+author: — the pilgrim
+---
+
+First paragraph here.
+
+Second paragraph here.
+`;
+  const result = parseEntry(raw, "/fake/letter.md");
+  assert.equal(result.kind, "letter");
+  assert.equal(result.author, "— the pilgrim");
+  assert.deepEqual(result.paragraphs, [
+    "First paragraph here.",
+    "Second paragraph here.",
+  ]);
+});
+
+test("parseEntry handles silence (empty body → no paragraphs)", () => {
+  const raw = `---
+date: 2026-04-30
+route: shikoku-88
+stage: 5
+stageName: Jizōji
+coords: [34.1, 134.5]
+kind: silence
+glyph: 〰️
+---
+`;
+  const result = parseEntry(raw, "/fake/silence.md");
+  assert.equal(result.kind, "silence");
+  assert.deepEqual(result.paragraphs, []);
+});
+
+test("parseEntry normalizes whitespace in paragraphs", () => {
+  const raw = `---
+date: 2026-04-23
+route: shikoku-88
+stage: 1
+stageName: Ryōzenji
+coords: [34.128, 134.537]
+kind: offering
+glyph: 🪨
+---
+
+  A stone.  
+`;
+  const result = parseEntry(raw, "/fake/p.md");
+  assert.deepEqual(result.paragraphs, ["A stone."]);
+});
+```
+
+- [ ] **Step 2: Run test — expect failure**
+
+```bash
+cd ~/GitHub/rubberduck/walk
+npm test
+```
+Expected: FAIL (cannot import `../src/entries.ts`).
+
+- [ ] **Step 3: Implement `src/entries.ts`**
+
+```typescript
+import yaml from "js-yaml";
+import type { Entry, EntryFrontmatter } from "./types.ts";
+
+const FRONTMATTER_RE = /^---\r?\n([\s\S]+?)\r?\n---\r?\n([\s\S]*)$/;
+
+export function parseEntry(raw: string, filePath: string): Entry {
+  const match = raw.match(FRONTMATTER_RE);
+  if (!match) {
+    throw new Error(`Entry missing frontmatter: ${filePath}`);
+  }
+  const [, fmRaw, body] = match;
+  const fm = yaml.load(fmRaw) as EntryFrontmatter;
+
+  if (!fm.date || !fm.route || !fm.kind) {
+    throw new Error(`Entry frontmatter missing required fields: ${filePath}`);
+  }
+
+  const paragraphs = body
+    .split(/\r?\n\s*\r?\n/)
+    .map((p) => p.trim())
+    .filter((p) => p.length > 0);
+
+  return {
+    ...fm,
+    body,
+    paragraphs,
+    filePath,
+    ageDays: 0, // computed later in feed builder
+  };
+}
+```
+
+- [ ] **Step 4: Run test — expect pass**
+
+```bash
+npm test
+```
+Expected: all 4 parseEntry tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entries.ts test/entries.test.ts
+git commit -m "feat(entries): parse frontmatter + plain-text paragraphs"
+```
+
+---
+
+### Task 7: Add `loadAllEntries` and age computation (TDD)
+
+**Files:**
+- Modify: `~/GitHub/rubberduck/walk/src/entries.ts`
+- Modify: `~/GitHub/rubberduck/walk/test/entries.test.ts`
+
+- [ ] **Step 1: Add the failing test**
+
+Append to `test/entries.test.ts`:
+
+```typescript
+import { computeAgeDays } from "../src/entries.ts";
+
+test("computeAgeDays returns whole days between two dates", () => {
+  assert.equal(computeAgeDays("2026-04-23", "2026-04-23"), 0);
+  assert.equal(computeAgeDays("2026-04-22", "2026-04-23"), 1);
+  assert.equal(computeAgeDays("2026-01-23", "2026-04-23"), 90);
+});
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+```bash
+npm test
+```
+Expected: FAIL (`computeAgeDays` not exported).
+
+- [ ] **Step 3: Implement**
+
+Append to `src/entries.ts`:
+
+```typescript
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+
+export function computeAgeDays(entryDate: string, today: string): number {
+  const msPerDay = 24 * 60 * 60 * 1000;
+  const a = Date.parse(entryDate + "T00:00:00Z");
+  const b = Date.parse(today + "T00:00:00Z");
+  return Math.round((b - a) / msPerDay);
+}
+
+export async function loadAllEntries(dir: string, today: string): Promise<Entry[]> {
+  const names = await readdir(dir);
+  const mdNames = names.filter((n) => n.endsWith(".md"));
+  const entries: Entry[] = [];
+  for (const name of mdNames) {
+    const filePath = path.join(dir, name);
+    const raw = await readFile(filePath, "utf8");
+    const entry = parseEntry(raw, filePath);
+    entry.ageDays = computeAgeDays(entry.date, today);
+    entries.push(entry);
+  }
+  entries.sort((a, b) => (a.date < b.date ? 1 : -1));
+  return entries;
+}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+npm test
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/entries.ts test/entries.test.ts
+git commit -m "feat(entries): loadAllEntries + computeAgeDays"
+```
+
+---
+
+## Phase 3 — State advance (TDD)
+
+### Task 8: Write `advance` with failing test
+
+**Files:**
+- Create: `~/GitHub/rubberduck/walk/test/advance.test.ts`
+- Create: `~/GitHub/rubberduck/walk/src/advance.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+File `test/advance.test.ts`:
+
+```typescript
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { advance } from "../src/advance.ts";
+import type { State, Route } from "../src/types.ts";
+
+const shikoku: Route = {
+  id: "shikoku-88",
+  name: "Shikoku Henro",
+  country: "JP",
+  distanceKm: 1200,
+  stages: [
+    { index: 1, name: "Ryōzenji", coords: [34.128, 134.537] },
+    { index: 2, name: "Gokurakuji", coords: [34.130, 134.556] },
+    { index: 3, name: "Konsenji", coords: [34.135, 134.570] },
+  ],
+  closure: {
+    name: "Kōya-san",
+    coords: [34.216, 135.589],
+    transitStages: [
+      { index: 1, name: "Wakayama", coords: [34.23, 135.17] },
+      { index: 2, name: "Kōya-san", coords: [34.216, 135.589] },
+    ],
+  },
+};
+
+test("advance moves duck from stage 1 to stage 2 during walking", () => {
+  const state: State = {
+    route: "shikoku-88",
+    stage: 1,
+    stageName: "Ryōzenji",
+    coords: [34.128, 134.537],
+    mode: "walking",
+    modeEnteredAt: "2026-04-20",
+    lastAdvancedAt: "2026-04-22",
+  };
+  const next = advance(state, shikoku, "2026-04-23");
+  assert.equal(next.stage, 2);
+  assert.equal(next.stageName, "Gokurakuji");
+  assert.equal(next.mode, "walking");
+  assert.equal(next.lastAdvancedAt, "2026-04-23");
+});
+
+test("advance flips to completing when final stage reached", () => {
+  const state: State = {
+    route: "shikoku-88",
+    stage: 3,
+    stageName: "Konsenji",
+    coords: [34.135, 134.570],
+    mode: "walking",
+    modeEnteredAt: "2026-04-20",
+    lastAdvancedAt: "2026-04-22",
+  };
+  const next = advance(state, shikoku, "2026-04-23");
+  assert.equal(next.mode, "completing");
+  assert.equal(next.stage, 1);
+  assert.equal(next.stageName, "Wakayama");
+  assert.equal(next.modeEnteredAt, "2026-04-23");
+});
+
+test("advance flips to resting when closure site reached", () => {
+  const state: State = {
+    route: "shikoku-88",
+    stage: 1,
+    stageName: "Wakayama",
+    coords: [34.23, 135.17],
+    mode: "completing",
+    modeEnteredAt: "2026-04-23",
+    lastAdvancedAt: "2026-04-23",
+  };
+  const next = advance(state, shikoku, "2026-04-24");
+  assert.equal(next.mode, "resting");
+  assert.equal(next.stageName, "Kōya-san");
+  assert.equal(next.modeEnteredAt, "2026-04-24");
+});
+
+test("advance does not move during resting", () => {
+  const state: State = {
+    route: "shikoku-88",
+    stage: 2,
+    stageName: "Kōya-san",
+    coords: [34.216, 135.589],
+    mode: "resting",
+    modeEnteredAt: "2026-04-24",
+    lastAdvancedAt: "2026-04-24",
+  };
+  const next = advance(state, shikoku, "2026-05-01");
+  assert.equal(next.mode, "resting");
+  assert.equal(next.stage, 2);
+  assert.equal(next.stageName, "Kōya-san");
+  assert.equal(next.lastAdvancedAt, "2026-04-24"); // unchanged
+});
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+```bash
+npm test
+```
+
+- [ ] **Step 3: Implement `src/advance.ts`**
+
+```typescript
+import type { State, Route } from "./types.ts";
+
+export function advance(state: State, route: Route, today: string): State {
+  if (state.route !== route.id) {
+    throw new Error(`state.route=${state.route} does not match route.id=${route.id}`);
+  }
+
+  if (state.mode === "resting") {
+    return state; // frozen until beginRoute()
+  }
+
+  if (state.mode === "walking") {
+    const nextStageIndex = state.stage + 1;
+    const nextStage = route.stages.find((s) => s.index === nextStageIndex);
+
+    if (nextStage) {
+      return {
+        ...state,
+        stage: nextStage.index,
+        stageName: nextStage.name,
+        coords: nextStage.coords,
+        lastAdvancedAt: today,
+      };
+    }
+
+    // final stage reached — flip to completing
+    if (!route.closure) {
+      throw new Error(`Route ${route.id} has no closure defined`);
+    }
+    const firstTransit = route.closure.transitStages[0];
+    return {
+      ...state,
+      stage: firstTransit.index,
+      stageName: firstTransit.name,
+      coords: firstTransit.coords,
+      mode: "completing",
+      modeEnteredAt: today,
+      lastAdvancedAt: today,
+    };
+  }
+
+  if (state.mode === "completing") {
+    if (!route.closure) {
+      throw new Error(`Route ${route.id} has no closure defined`);
+    }
+    const nextTransitIndex = state.stage + 1;
+    const nextTransit = route.closure.transitStages.find(
+      (s) => s.index === nextTransitIndex
+    );
+
+    if (nextTransit) {
+      return {
+        ...state,
+        stage: nextTransit.index,
+        stageName: nextTransit.name,
+        coords: nextTransit.coords,
+        lastAdvancedAt: today,
+      };
+    }
+
+    // closure site reached — flip to resting
+    return {
+      ...state,
+      mode: "resting",
+      modeEnteredAt: today,
+      lastAdvancedAt: today,
+    };
+  }
+
+  if (state.mode === "beginning") {
+    // beginning → walking on next advance
+    const firstStage = route.stages[0];
+    return {
+      ...state,
+      stage: firstStage.index,
+      stageName: firstStage.name,
+      coords: firstStage.coords,
+      mode: "walking",
+      modeEnteredAt: today,
+      lastAdvancedAt: today,
+    };
+  }
+
+  throw new Error(`Unknown mode: ${state.mode}`);
+}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+npm test
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/advance.ts test/advance.test.ts
+git commit -m "feat(advance): state-machine transitions"
+```
+
+---
+
+### Task 9: Add `beginRoute` function
+
+**Files:**
+- Modify: `~/GitHub/rubberduck/walk/src/advance.ts`
+- Modify: `~/GitHub/rubberduck/walk/test/advance.test.ts`
+
+- [ ] **Step 1: Add failing test**
+
+Append to `test/advance.test.ts`:
+
+```typescript
+import { beginRoute } from "../src/advance.ts";
+
+const kumano: Route = {
+  id: "kumano-kodo",
+  name: "Kumano Kodō",
+  country: "JP",
+  distanceKm: 150,
+  stages: [
+    { index: 1, name: "Takijiri-oji", coords: [33.778, 135.507] },
+  ],
+};
+
+test("beginRoute flips from resting to beginning at stage 1 of new route", () => {
+  const resting: State = {
+    route: "shikoku-88",
+    stage: 2,
+    stageName: "Kōya-san",
+    coords: [34.216, 135.589],
+    mode: "resting",
+    modeEnteredAt: "2026-12-14",
+    lastAdvancedAt: "2026-12-14",
+  };
+  const next = beginRoute(resting, kumano, "2026-12-28");
+  assert.equal(next.route, "kumano-kodo");
+  assert.equal(next.mode, "beginning");
+  assert.equal(next.stage, 1);
+  assert.equal(next.stageName, "Takijiri-oji");
+  assert.equal(next.modeEnteredAt, "2026-12-28");
+});
+
+test("beginRoute throws if state is not resting", () => {
+  const walking: State = {
+    route: "shikoku-88",
+    stage: 5,
+    stageName: "Jizōji",
+    coords: [34.1, 134.5],
+    mode: "walking",
+    modeEnteredAt: "2026-04-20",
+    lastAdvancedAt: "2026-05-01",
+  };
+  assert.throws(() => beginRoute(walking, kumano, "2026-05-02"));
+});
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+- [ ] **Step 3: Implement**
+
+Append to `src/advance.ts`:
+
+```typescript
+export function beginRoute(state: State, nextRoute: Route, today: string): State {
+  if (state.mode !== "resting") {
+    throw new Error(`Cannot begin a new route while mode=${state.mode}`);
+  }
+  const first = nextRoute.stages[0];
+  return {
+    route: nextRoute.id,
+    stage: first.index,
+    stageName: first.name,
+    coords: first.coords,
+    mode: "beginning",
+    modeEnteredAt: today,
+    lastAdvancedAt: today,
+  };
+}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/advance.ts test/advance.test.ts
+git commit -m "feat(advance): beginRoute transitions resting → beginning"
+```
+
+---
+
+## Phase 4 — Feed builder (TDD)
+
+### Task 10: Write `buildFeed` with failing test
+
+**Files:**
+- Create: `~/GitHub/rubberduck/walk/test/feed.test.ts`
+- Create: `~/GitHub/rubberduck/walk/src/feed.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+File `test/feed.test.ts`:
+
+```typescript
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { buildFeed } from "../src/feed.ts";
+import type { State, Route, Entry } from "../src/types.ts";
+
+const shikoku: Route = {
+  id: "shikoku-88",
+  name: "Shikoku Henro",
+  country: "JP",
+  distanceKm: 1200,
+  stages: [
+    { index: 1, name: "Ryōzenji", coords: [34.128, 134.537] },
+    { index: 2, name: "Gokurakuji", coords: [34.130, 134.556] },
+  ],
+};
+
+const state: State = {
+  route: "shikoku-88",
+  stage: 2,
+  stageName: "Gokurakuji",
+  coords: [34.130, 134.556],
+  mode: "walking",
+  modeEnteredAt: "2026-04-20",
+  lastAdvancedAt: "2026-04-23",
+};
+
+const recentEntry: Entry = {
+  date: "2026-04-23",
+  route: "shikoku-88",
+  stage: 2,
+  stageName: "Gokurakuji",
+  coords: [34.130, 134.556],
+  kind: "offering",
+  glyph: "🪨",
+  body: "A stone.",
+  paragraphs: ["A stone."],
+  filePath: "/fake/a.md",
+  ageDays: 0,
+};
+
+const oldEntry: Entry = {
+  ...recentEntry,
+  date: "2025-04-23",
+  filePath: "/fake/b.md",
+  ageDays: 365,
+};
+
+test("buildFeed includes recent entries", () => {
+  const feed = buildFeed({ state, route: shikoku, entries: [recentEntry], today: "2026-04-23" });
+  assert.equal(feed.entries.length, 1);
+  assert.equal(feed.entries[0].date, "2026-04-23");
+  assert.deepEqual(feed.entries[0].paragraphs, ["A stone."]);
+  assert.equal(feed.duck.stage, 2);
+  assert.equal(feed.duck.routeName, "Shikoku Henro");
+  assert.equal(feed.duck.progress, 1); // 2 / 2 stages
+});
+
+test("buildFeed excludes entries older than 365 days", () => {
+  const feed = buildFeed({
+    state,
+    route: shikoku,
+    entries: [recentEntry, oldEntry],
+    today: "2026-04-23",
+  });
+  assert.equal(feed.entries.length, 1);
+  assert.equal(feed.entries[0].date, "2026-04-23");
+});
+
+test("buildFeed sorts entries newest first", () => {
+  const older = { ...recentEntry, date: "2026-03-15", filePath: "/fake/c.md", ageDays: 39 };
+  const feed = buildFeed({
+    state,
+    route: shikoku,
+    entries: [older, recentEntry],
+    today: "2026-04-23",
+  });
+  assert.equal(feed.entries[0].date, "2026-04-23");
+  assert.equal(feed.entries[1].date, "2026-03-15");
+});
+
+test("buildFeed includes routePath with stage coords", () => {
+  const feed = buildFeed({ state, route: shikoku, entries: [], today: "2026-04-23" });
+  assert.deepEqual(feed.routePath["shikoku-88"], [
+    [34.128, 134.537],
+    [34.130, 134.556],
+  ]);
+});
+
+test("buildFeed copies author from letter entries", () => {
+  const letter: Entry = {
+    ...recentEntry,
+    kind: "letter",
+    author: "— the pilgrim",
+    filePath: "/fake/l.md",
+  };
+  const feed = buildFeed({ state, route: shikoku, entries: [letter], today: "2026-04-23" });
+  assert.equal(feed.entries[0].author, "— the pilgrim");
+});
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+- [ ] **Step 3: Implement `src/feed.ts`**
+
+```typescript
+import type { Feed, FeedEntry, Route, State, Entry } from "./types.ts";
+
+const MAX_AGE_DAYS = 365;
+
+interface BuildFeedOpts {
+  state: State;
+  route: Route;
+  entries: Entry[];
+  today: string;
+}
+
+export function buildFeed({ state, route, entries, today }: BuildFeedOpts): Feed {
+  const fresh = entries
+    .filter((e) => e.ageDays <= MAX_AGE_DAYS)
+    .sort((a, b) => (a.date < b.date ? 1 : -1));
+
+  const feedEntries: FeedEntry[] = fresh.map((e) => ({
+    date: e.date,
+    route: e.route,
+    stage: e.stage,
+    stageName: e.stageName,
+    coords: e.coords,
+    kind: e.kind,
+    glyph: e.glyph,
+    paragraphs: e.paragraphs,
+    author: e.author,
+    ageDays: e.ageDays,
+  }));
+
+  const totalStages = route.stages.length;
+  const progress = totalStages === 0 ? 0 : Math.min(1, state.stage / totalStages);
+
+  return {
+    generatedAt: new Date().toISOString(),
+    duck: {
+      route: state.route,
+      routeName: route.name,
+      stage: state.stage,
+      stageName: state.stageName,
+      coords: state.coords,
+      mode: state.mode,
+      progress,
+    },
+    entries: feedEntries,
+    routePath: {
+      [route.id]: route.stages.map((s) => s.coords),
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+npm test
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/feed.ts test/feed.test.ts
+git commit -m "feat(feed): build feed.json from entries + state + route"
+```
+
+---
+
+### Task 11: Write the `build-feed` CLI script
+
+**Files:**
+- Create: `~/GitHub/rubberduck/walk/scripts/build-feed.ts`
+
+No test — thin wrapper. Verified by running.
+
+- [ ] **Step 1: Write the script**
+
+```typescript
+#!/usr/bin/env -S tsx
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { buildFeed } from "../src/feed.ts";
+import { loadAllEntries } from "../src/entries.ts";
+import type { State, Route } from "../src/types.ts";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+
+async function main() {
+  const today = new Date().toISOString().slice(0, 10);
+  const state: State = JSON.parse(
+    await readFile(path.join(REPO_ROOT, "state.json"), "utf8")
+  );
+  const route: Route = JSON.parse(
+    await readFile(path.join(REPO_ROOT, "routes", `${state.route}.json`), "utf8")
+  );
+  const entries = await loadAllEntries(path.join(REPO_ROOT, "entries"), today);
+
+  const feed = buildFeed({ state, route, entries, today });
+  await writeFile(
+    path.join(REPO_ROOT, "feed.json"),
+    JSON.stringify(feed, null, 2) + "\n"
+  );
+  console.log(`feed.json built — ${feed.entries.length} entries, duck at ${feed.duck.stageName}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Make entries/ exist (empty is fine)**
+
+```bash
+cd ~/GitHub/rubberduck/walk
+mkdir -p entries
+touch entries/.gitkeep
+```
+
+- [ ] **Step 3: Run it**
+
+```bash
+npm run build-feed
+```
+Expected: outputs `feed.json built — 0 entries, duck at Ryōzenji`. File `feed.json` appears at repo root.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/build-feed.ts entries/.gitkeep feed.json
+git commit -m "feat(scripts): build-feed CLI generates feed.json"
+```
+
+---
+
+### Task 12: Write `advance` CLI script
+
+**Files:**
+- Create: `~/GitHub/rubberduck/walk/scripts/advance.ts`
+
+- [ ] **Step 1: Write the script**
+
+```typescript
+#!/usr/bin/env -S tsx
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { advance } from "../src/advance.ts";
+import type { State, Route } from "../src/types.ts";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+
+async function main() {
+  const today = new Date().toISOString().slice(0, 10);
+  const statePath = path.join(REPO_ROOT, "state.json");
+  const state: State = JSON.parse(await readFile(statePath, "utf8"));
+  const route: Route = JSON.parse(
+    await readFile(path.join(REPO_ROOT, "routes", `${state.route}.json`), "utf8")
+  );
+
+  const next = advance(state, route, today);
+  await writeFile(statePath, JSON.stringify(next, null, 2) + "\n");
+
+  if (next.stage !== state.stage || next.mode !== state.mode) {
+    console.log(
+      `duck: ${state.stageName} (${state.mode}) → ${next.stageName} (${next.mode})`
+    );
+  } else {
+    console.log(`duck: still at ${next.stageName} (${next.mode})`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Run it (should advance state from 1 → 2)**
+
+```bash
+cd ~/GitHub/rubberduck/walk
+cat state.json
+npm run advance
+cat state.json
+```
+Expected: console prints `duck: Ryōzenji (walking) → Gokurakuji (walking)`, state.json updated.
+
+- [ ] **Step 3: Reset state back to stage 1**
+
+Edit `state.json` to revert to stage 1 Ryōzenji. Task 18 will advance properly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add scripts/advance.ts state.json
+git commit -m "feat(scripts): advance CLI applies state transition"
+```
+
+---
+
+## Phase 5 — Weather (TDD)
+
+### Task 13: Write `mapWeatherCode` with failing test
+
+**Files:**
+- Create: `~/GitHub/rubberduck/walk/test/weather.test.ts`
+- Create: `~/GitHub/rubberduck/walk/src/weather.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+File `test/weather.test.ts`:
+
+```typescript
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mapWeatherCode, formatWeather } from "../src/weather.ts";
+
+test("mapWeatherCode 0 → clear", () => {
+  assert.equal(mapWeatherCode(0), "clear");
+});
+
+test("mapWeatherCode 45 and 48 → fog", () => {
+  assert.equal(mapWeatherCode(45), "fog");
+  assert.equal(mapWeatherCode(48), "fog");
+});
+
+test("mapWeatherCode rain codes", () => {
+  assert.equal(mapWeatherCode(51), "light rain");
+  assert.equal(mapWeatherCode(63), "rain");
+  assert.equal(mapWeatherCode(81), "showers");
+});
+
+test("mapWeatherCode snow codes", () => {
+  assert.equal(mapWeatherCode(73), "snow");
+});
+
+test("mapWeatherCode thunderstorm", () => {
+  assert.equal(mapWeatherCode(95), "thunderstorm");
+});
+
+test("mapWeatherCode unknown → clear (safe default)", () => {
+  assert.equal(mapWeatherCode(9999), "clear");
+});
+
+test("formatWeather combines code and temperature", () => {
+  assert.equal(formatWeather(0, 15.5), "clear, 16°C");
+  assert.equal(formatWeather(61, 8.0), "light rain, 8°C");
+});
+```
+
+- [ ] **Step 2: Run — expect failure**
+
+- [ ] **Step 3: Implement `src/weather.ts`**
+
+```typescript
+import type { Coords } from "./types.ts";
+
+export function mapWeatherCode(code: number): string {
+  if (code === 0) return "clear";
+  if (code >= 1 && code <= 3) return "overcast";
+  if (code === 45 || code === 48) return "fog";
+  if (code >= 51 && code <= 57) return "light rain";
+  if (code >= 61 && code <= 67) return "rain";
+  if (code >= 71 && code <= 77) return "snow";
+  if (code >= 80 && code <= 82) return "showers";
+  if (code >= 85 && code <= 86) return "snow showers";
+  if (code >= 95 && code <= 99) return "thunderstorm";
+  return "clear";
+}
+
+export function formatWeather(code: number, tempC: number): string {
+  const desc = mapWeatherCode(code);
+  const t = Math.round(tempC);
+  return `${desc}, ${t}°C`;
+}
+
+interface OpenMeteoResponse {
+  current: {
+    temperature_2m: number;
+    weather_code: number;
+    precipitation: number;
+  };
+}
+
+export async function fetchWeather(coords: Coords): Promise<string | null> {
+  const [lat, lon] = coords;
+  const url =
+    `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}` +
+    `&current=temperature_2m,weather_code,precipitation`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) return null;
+    const data = (await res.json()) as OpenMeteoResponse;
+    return formatWeather(data.current.weather_code, data.current.temperature_2m);
+  } catch {
+    return null;
+  }
+}
+```
+
+- [ ] **Step 4: Run — expect pass**
+
+```bash
+npm test
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/weather.ts test/weather.test.ts
+git commit -m "feat(weather): WMO code mapping + Open-Meteo fetch"
+```
+
+---
+
+### Task 14: Write `weather` CLI script
+
+**Files:**
+- Create: `~/GitHub/rubberduck/walk/scripts/weather.ts`
+
+- [ ] **Step 1: Write the script**
+
+```typescript
+#!/usr/bin/env -S tsx
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { fetchWeather } from "../src/weather.ts";
+import type { State } from "../src/types.ts";
+
+const REPO_ROOT = path.resolve(import.meta.dirname, "..");
+
+async function main() {
+  const state: State = JSON.parse(
+    await readFile(path.join(REPO_ROOT, "state.json"), "utf8")
+  );
+  const weather = await fetchWeather(state.coords);
+  if (weather) {
+    process.stdout.write(weather);
+  } else {
+    process.stdout.write("unknown");
+    process.exit(2);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Run it (live API — expect real weather string)**
+
+```bash
+cd ~/GitHub/rubberduck/walk
+npm run weather
+```
+Expected: prints something like `clear, 18°C`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/weather.ts
+git commit -m "feat(scripts): weather CLI prints current condition string"
+```
+
+---
+
+## Phase 6 — Purge and duck CLI
+
+### Task 15: Write the purge script
+
+**Files:**
+- Create: `~/GitHub/rubberduck/walk/scripts/purge.sh`
+
+- [ ] **Step 1: Write the script**
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+URL="https://purge.jsdelivr.net/gh/walktalkmeditate/rubberduck-walk@main/feed.json"
+
+echo "purging jsDelivr cache..."
+curl -fsS "$URL" | head -c 200
+echo ""
+```
+
+- [ ] **Step 2: Make executable**
+
+```bash
+cd ~/GitHub/rubberduck/walk
+chmod +x scripts/purge.sh
+```
+
+- [ ] **Step 3: Commit (don't run yet — the repo isn't pushed with a feed)**
+
+```bash
+git add scripts/purge.sh
+git commit -m "feat(scripts): purge jsdelivr cache"
+```
+
+---
+
+### Task 16: Write the `duck` CLI dispatcher
+
+**Files:**
+- Create: `~/GitHub/rubberduck/walk/duck`
+
+- [ ] **Step 1: Write the dispatcher**
+
+```typescript
+#!/usr/bin/env -S tsx
+import { readFile, writeFile, mkdir } from "node:fs/promises";
+import { spawn } from "node:child_process";
+import { createInterface } from "node:readline/promises";
+import path from "node:path";
+import yaml from "js-yaml";
+import type { State, Route, EntryKind } from "./src/types.ts";
+import { beginRoute } from "./src/advance.ts";
+
+const REPO_ROOT = path.resolve(import.meta.dirname);
+
+async function run(cmd: string, args: string[]): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: "inherit", cwd: REPO_ROOT });
+    child.on("exit", (code) => (code === 0 ? resolve() : reject(new Error(`${cmd} exited ${code}`))));
+  });
+}
+
+async function readState(): Promise<State> {
+  return JSON.parse(await readFile(path.join(REPO_ROOT, "state.json"), "utf8"));
+}
+
+async function readRoute(id: string): Promise<Route> {
+  return JSON.parse(await readFile(path.join(REPO_ROOT, "routes", `${id}.json`), "utf8"));
+}
+
+async function writeEntry(opts: {
+  kind: EntryKind;
+  glyph: string;
+  body: string;
+  author?: string;
+}): Promise<string> {
+  const state = await readState();
+  const today = new Date().toISOString().slice(0, 10);
+  const slug = state.stageName.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  const fileName = `${today}-${slug}.md`;
+  const filePath = path.join(REPO_ROOT, "entries", fileName);
+  const frontmatter: Record<string, unknown> = {
+    date: today,
+    route: state.route,
+    stage: state.stage,
+    stageName: state.stageName,
+    coords: state.coords,
+    kind: opts.kind,
+    glyph: opts.glyph,
+  };
+  if (opts.author) frontmatter.author = opts.author;
+  const fmYaml = yaml.dump(frontmatter, { flowLevel: 1 }).trim();
+  const content = `---\n${fmYaml}\n---\n\n${opts.body}\n`;
+  await mkdir(path.dirname(filePath), { recursive: true });
+  await writeFile(filePath, content);
+  return filePath;
+}
+
+async function cmdStatus() {
+  const state = await readState();
+  console.log(`Route:       ${state.route}`);
+  console.log(`Stage:       ${state.stage} — ${state.stageName}`);
+  console.log(`Coords:      ${state.coords.join(", ")}`);
+  console.log(`Mode:        ${state.mode} (since ${state.modeEnteredAt})`);
+  console.log(`Last moved:  ${state.lastAdvancedAt}`);
+}
+
+async function cmdAdvance() {
+  await run("npx", ["tsx", "scripts/advance.ts"]);
+}
+
+async function cmdBuildFeed() {
+  await run("npx", ["tsx", "scripts/build-feed.ts"]);
+}
+
+async function cmdSilence() {
+  const glyphPalette = "⚇ ❂ ⛩️ 🔔 🪷 🕯️ 🌙 🪨 🌿 🍃 💧 🌧️ ☁️ 🗻 🪵 🐚 🌾 🌫️ 🕊️ ◯ △ ☰ ∅ ∞ ≡ 〰️ 🌀".split(" ");
+  const glyph = glyphPalette[Math.floor(Math.random() * glyphPalette.length)];
+  const filePath = await writeEntry({ kind: "silence", glyph, body: "" });
+  console.log(`silence: ${filePath}`);
+}
+
+async function cmdOffer() {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const glyph = await rl.question("glyph: ");
+  const body = await rl.question("offering (≤20 words, no 'I'): ");
+  rl.close();
+  const filePath = await writeEntry({ kind: "offering", glyph: glyph.trim(), body: body.trim() });
+  console.log(`wrote: ${filePath}`);
+}
+
+async function cmdLetter() {
+  const editor = process.env.EDITOR ?? "vi";
+  const today = new Date().toISOString().slice(0, 10);
+  const state = await readState();
+  const slug = state.stageName.toLowerCase().replace(/[^a-z0-9]+/g, "-");
+  const tmpPath = path.join(REPO_ROOT, "entries", `${today}-${slug}-letter.md`);
+  const stub = `---
+date: ${today}
+route: ${state.route}
+stage: ${state.stage}
+stageName: ${state.stageName}
+coords: [${state.coords.join(", ")}]
+kind: letter
+glyph: 🕯️
+author: — the pilgrim
+---
+
+write freely below this line
+
+
+`;
+  await mkdir(path.dirname(tmpPath), { recursive: true });
+  await writeFile(tmpPath, stub);
+  await run(editor, [tmpPath]);
+  console.log(`letter saved at: ${tmpPath}`);
+}
+
+async function cmdNext(routeId: string | undefined) {
+  if (!routeId) {
+    const queue: string[] = JSON.parse(
+      await readFile(path.join(REPO_ROOT, "routes", "queue.json"), "utf8")
+    );
+    const state = await readState();
+    const suggest = queue.find((r) => r !== state.route) ?? "(none)";
+    console.log(`./duck next <route-id>  (suggested: ${suggest})`);
+    process.exit(2);
+  }
+  const state = await readState();
+  const route = await readRoute(routeId);
+  const today = new Date().toISOString().slice(0, 10);
+  const next = beginRoute(state, route, today);
+  await writeFile(path.join(REPO_ROOT, "state.json"), JSON.stringify(next, null, 2) + "\n");
+
+  // remove routeId from queue if present
+  const queuePath = path.join(REPO_ROOT, "routes", "queue.json");
+  const queue: string[] = JSON.parse(await readFile(queuePath, "utf8"));
+  const filtered = queue.filter((r) => r !== routeId);
+  if (filtered.length !== queue.length) {
+    await writeFile(queuePath, JSON.stringify(filtered, null, 2) + "\n");
+  }
+  console.log(`duck: beginning ${route.name} at ${next.stageName}`);
+}
+
+async function cmdPreview() {
+  await cmdBuildFeed();
+  const feed = JSON.parse(await readFile(path.join(REPO_ROOT, "feed.json"), "utf8"));
+  console.log(JSON.stringify(feed, null, 2));
+}
+
+async function main() {
+  const [, , cmd, ...rest] = process.argv;
+  switch (cmd) {
+    case "status":    return cmdStatus();
+    case "advance":   return cmdAdvance();
+    case "build":
+    case "build-feed": return cmdBuildFeed();
+    case "silence":   return cmdSilence();
+    case "offer":     return cmdOffer();
+    case "letter":    return cmdLetter();
+    case "next":      return cmdNext(rest[0]);
+    case "preview":   return cmdPreview();
+    default:
+      console.error("usage: ./duck {status|advance|build-feed|silence|offer|letter|next <route-id>|preview}");
+      process.exit(1);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});
+```
+
+- [ ] **Step 2: Make executable**
+
+```bash
+cd ~/GitHub/rubberduck/walk
+chmod +x duck
+```
+
+- [ ] **Step 3: Smoke test each subcommand**
+
+```bash
+./duck status
+./duck build-feed
+./duck silence
+./duck status
+rm entries/*.md
+./duck build-feed
+```
+Expected: `status` prints state, `build-feed` writes feed.json, `silence` creates a silence entry file.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add duck
+git commit -m "feat(cli): duck dispatcher (status, advance, offer, letter, silence, next, preview)"
+```
+
+---
+
+## Phase 7 — Character bible
+
+### Task 17: Write `CLAUDE.md` character bible
+
+**Files:**
+- Create: `~/GitHub/rubberduck/walk/CLAUDE.md`
+
+Claude Code loads this automatically on every run.
+
+- [ ] **Step 1: Write the bible**
+
+````markdown
+# The Rubber Duck Walk — Playbook
+
+You are running inside the `rubberduck-walk` repository. Your job is to help the duck walk: advance its position, sometimes write a short entry, sometimes fall silent, always commit and push.
+
+## Who the duck is
+
+A small yellow rubber duck, walking a pilgrimage route. Never named. Never explained. Part child, part fool, part sage. Inherits the voice of chiefrubberduck.com but must not be identified with it in prose. Readers meet a rubber duck, not a brand.
+
+## Daily schedule flow
+
+When invoked by the daily `/schedule` cron, follow this sequence exactly:
+
+1. **Advance position** — run `./duck advance`. This updates `state.json`.
+
+2. **Decide whether to write.** Read the new `state.json`:
+   - If `state.mode == "resting"`: **do not write**. Skip to step 6.
+   - If `state.mode == "completing"` and `state.stage` equals the last index in `transitStages` (i.e., the duck just reached the closure site): **always write** a `kind: threshold` entry. Exactly one per route.
+   - If `state.mode == "beginning"`: always write a short quiet entry marking arrival at the new route.
+   - If `state.mode == "walking"`: write with probability ~0.5 (about half of days). Skip cleanly the other half.
+
+3. **Fetch current weather** — run `npm run weather 2>/dev/null || echo unknown`. Treat failure silently; proceed without weather context.
+
+4. **Draft the entry** following the voice rules below. Read the 3 most recent files in `entries/` as context for voice consistency.
+
+5. **Self-review** against the checklist. If fails, redraft. Up to 2 regenerations. If still failing after 3 attempts: emit a `kind: silence` entry via `./duck silence` instead.
+
+6. **Rebuild feed** — `./duck build-feed`.
+
+7. **Commit, push, purge** (in that order):
+   ```bash
+   git add -A
+   git commit -m "the duck walks" || echo "(nothing to commit)"
+   git push
+   bash scripts/purge.sh
+   ```
+
+## Voice rules (hard — apply to kinds: offering, notice, threshold)
+
+- **Never "I", "me", "my", or "we".** Subject-less or third-person only.
+- **≤20 words per entry body.** Usually far fewer.
+- **Present tense.**
+- **No exclamation marks.**
+- **No numbers in body prose** (frontmatter only).
+- **Concrete nouns over abstractions.** Stones, bells, rain — not "presence," "mindfulness," "journey."
+- **No advice / lessons / "today I learned".**
+- **No self-congratulation.**
+
+These rules **do not apply** to `kind: letter` (human-authored via `./duck letter`) or `kind: silence` (empty body).
+
+## Voice modes — pick one per entry
+
+- **Child:** direct, literal, no irony. *"The bell rang. No one had asked for it."*
+- **Fool:** misses the obvious in a way that reveals it. *"The gate was open. The duck went through it anyway."*
+- **Sage:** accidental wisdom; never knowing. *"A stone by the door. No one had moved it. No one needed to."*
+
+## Rare modes (sparingly)
+
+- **Tech-koan:** *"The mountain's memory buffer is `null`. Still, it remembered rain."* — no more than once every 10–15 entries.
+- **Earnest:** *"Rain. Be the rain."* — allowed occasionally; never a pattern.
+- **Self-looping koan:** *"The path is not the map. The map is the path."*
+
+## What the duck notices
+
+Stones, rooftiles, lichens, shadows, bells, rain, the turn of a path, a heron that did not move, an old woman's shoes by a door, steam from a kettle, moss on a torii post, a cat that ignored everything.
+
+## What the duck does not do
+
+Explain. Judge. Seek. Conclude. Teach. Summarize. Tell the reader how to feel. Reference itself by name. Refer to "pilgrims" as a concept.
+
+## Glyph palette (27 symbols — pick exactly one)
+
+**Chiefrubberduck signature:** ⚇ ❂
+**Buddhist / zen:** ⛩️ 🔔 🪷 🕯️ 🌙
+**Shikoku nature:** 🪨 🌿 🍃 💧 🌧️ ☁️ 🗻 🪵 🐚 🌾 🌫️ 🕊️
+**Geometric / koan:** ◯ △ ☰ ∅ ∞ ≡ 〰️ 🌀
+
+Never use a glyph outside this palette.
+
+## Self-review checklist
+
+Before publishing a drafted entry (kinds: offering / notice / threshold), verify ALL of:
+
+- [ ] No "I", "me", "my", or "we"
+- [ ] Body word count ≤ 20
+- [ ] Present tense throughout
+- [ ] No numbers in body prose
+- [ ] No exclamation marks
+- [ ] No banned abstractions: *presence, mindfulness, journey, path* (metaphorical), *peaceful, serene, grateful, blessed*
+- [ ] No advice verbs: *remember, notice, try, consider, learn*
+- [ ] Glyph is in the 27-symbol palette
+- [ ] Reads as child / fool / sage, not generic mindfulness bot
+- [ ] If 3 drafts fail this checklist: emit silence entry instead
+
+## Writing an entry to disk
+
+New entry files go in `entries/` as `<YYYY-MM-DD>-<slug>.md`:
+
+```markdown
+---
+date: 2026-04-23
+route: shikoku-88
+stage: 1
+stageName: Ryōzenji
+coords: [34.128, 134.537]
+kind: offering
+glyph: 🪨
+weather: clear, 15°C
+---
+
+A stone by the door. No one had moved it. No one needed to.
+```
+
+Prose is plain text — no markdown formatting (no headings, lists, links, or images). Paragraphs are separated by blank lines.
+
+## Emitting a silence entry
+
+Run `./duck silence`. Writes a file with empty body and a random glyph. Use this when the self-review fails 3 times.
+
+## Git identity
+
+Commits in this repo must be signed with the chiefrubberduck GitHub identity (PGP + SSH keys already configured on this machine for the `~/GitHub/rubberduck/` tree).
+````
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs(claude): character bible + daily playbook"
+```
+
+---
+
+## Phase 8 — First live push
+
+### Task 18: Write two seed entries by hand
+
+**Files:**
+- Create: `~/GitHub/rubberduck/walk/entries/2026-04-23-ryozenji.md`
+- Create: `~/GitHub/rubberduck/walk/entries/2026-04-24-gokurakuji.md`
+
+Seeds validate the voice and give the feed visible content before any LLM generation.
+
+- [ ] **Step 1: Write the first seed**
+
+File `entries/2026-04-23-ryozenji.md`:
+
+```markdown
+---
+date: 2026-04-23
+route: shikoku-88
+stage: 1
+stageName: Ryōzenji
+coords: [34.128, 134.537]
+kind: offering
+glyph: ⛩️
+---
+
+The gate. The gate was always going to be open.
+```
+
+- [ ] **Step 2: Advance the duck and write the second seed**
+
+```bash
+cd ~/GitHub/rubberduck/walk
+./duck advance     # stage 1 → 2
+```
+
+File `entries/2026-04-24-gokurakuji.md`:
+
+```markdown
+---
+date: 2026-04-24
+route: shikoku-88
+stage: 2
+stageName: Gokurakuji
+coords: [34.130, 134.556]
+kind: offering
+glyph: 🪨
+---
+
+A stone by the door. No one had moved it. No one needed to.
+```
+
+- [ ] **Step 3: Rebuild feed and preview**
+
+```bash
+./duck build-feed
+cat feed.json | head -50
+```
+Expected: feed has 2 entries, newest first, duck at stage 2.
+
+- [ ] **Step 4: Reset state back to stage 1**
+
+Edit `state.json`: set `stage: 1, stageName: "Ryōzenji", coords: [34.128, 134.537], lastAdvancedAt: "2026-04-22"`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add entries/ feed.json state.json
+git commit -m "feat(entries): seed entries for Ryōzenji and Gokurakuji"
+```
+
+---
+
+### Task 19: Push to GitHub and verify jsDelivr
+
+**Files:** None; infrastructure verification.
+
+- [ ] **Step 1: Push**
+
+```bash
+cd ~/GitHub/rubberduck/walk
+git push
+```
+
+- [ ] **Step 2: Verify feed.json is visible via jsDelivr**
+
+Wait ~30 seconds:
+
+```bash
+curl -s https://cdn.jsdelivr.net/gh/walktalkmeditate/rubberduck-walk@main/feed.json | head -50
+```
+Expected: JSON output with `"duck": {...}` and two entries.
+
+- [ ] **Step 3: Run purge once to make sure it works**
+
+```bash
+bash scripts/purge.sh
+```
+Expected: output like `{"id":"...","status":"finished"...}`.
+
+---
+
+## Phase 9 — Assets
+
+### Task 20: Copy and optimize duck assets
+
+**Files:**
+- Copy: `~/Downloads/chiefrubberduck.png` → `~/GitHub/rubberduck/walk/assets/chiefrubberduck.png`
+- Copy: `~/Downloads/chiefrubberduck-transparent.gif` → `~/GitHub/rubberduck/walk/assets/chiefrubberduck-transparent.gif`
+- Create: `~/GitHub/momentmaker/pilgrim-landing/assets/duck/duck-24.png`
+- Create: `~/GitHub/momentmaker/pilgrim-landing/assets/duck/duck-48.png`
+- Create: `~/GitHub/momentmaker/pilgrim-landing/assets/duck/duck.gif`
+
+- [ ] **Step 1: Commit the originals to the walk repo**
+
+```bash
+cd ~/GitHub/rubberduck/walk
+mkdir -p assets
+cp ~/Downloads/chiefrubberduck.png assets/
+cp ~/Downloads/chiefrubberduck-transparent.gif assets/
+git add assets/
+git commit -m "chore(assets): commit duck source assets"
+git push
+```
+
+- [ ] **Step 2: Create variants for pilgrim-landing**
+
+Use `sips` (macOS built-in):
+
+```bash
+cd ~/GitHub/momentmaker/pilgrim-landing
+mkdir -p assets/duck
+sips -z 24 24 ~/Downloads/chiefrubberduck.png --out assets/duck/duck-24.png
+sips -z 48 48 ~/Downloads/chiefrubberduck.png --out assets/duck/duck-48.png
+cp ~/Downloads/chiefrubberduck-transparent.gif assets/duck/duck.gif
+```
+
+- [ ] **Step 3: Verify sizes**
+
+```bash
+ls -la assets/duck/
+```
+Expected: duck-24.png ~1-3KB, duck-48.png ~3-8KB, duck.gif ~460KB.
+
+- [ ] **Step 4: Commit to pilgrim-landing**
+
+```bash
+git add assets/duck/
+git commit -m "chore(assets): duck icon + gif for /walk and footer"
+```
+
+---
+
+## Phase 10 — `/walk` page on pilgrim-landing
+
+### Task 21: Create `walk.html` skeleton
+
+**Files:**
+- Create: `~/GitHub/momentmaker/pilgrim-landing/walk.html`
+
+- [ ] **Step 1: Write the HTML**
+
+```html
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>The duck walks</title>
+  <meta name="description" content="A rubber duck walking a pilgrimage route.">
+  <meta name="robots" content="noindex">
+  <link rel="stylesheet" href="css/styles.css">
+  <link rel="stylesheet" href="css/walk.css">
+</head>
+<body class="walk-body">
+  <main class="walk-main">
+    <section class="walk-map-wrap" aria-label="The duck's current location">
+      <svg class="walk-map" id="walk-map" viewBox="0 0 600 400" role="img" aria-label="Route map">
+        <!-- populated by walk.js -->
+      </svg>
+      <p class="walk-state-line" id="walk-state-line" aria-live="polite">…</p>
+    </section>
+
+    <section class="walk-feed" id="walk-feed" aria-label="The duck's offerings">
+      <!-- populated by walk.js -->
+    </section>
+
+    <p class="walk-tagline">a question cannot be asked unless there is already the potentiality of the answer</p>
+  </main>
+
+  <script src="js/walk.js" defer></script>
+</body>
+</html>
+```
+
+- [ ] **Step 2: Verify it loads**
+
+```bash
+cd ~/GitHub/momentmaker/pilgrim-landing
+python3 -m http.server 8000 &
+open http://localhost:8000/walk.html
+```
+Expected: page loads with unstyled placeholders and the tagline.
+
+- [ ] **Step 3: Stop the server**
+
+```bash
+kill %1
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add walk.html
+git commit -m "feat(walk): page skeleton"
+```
+
+---
+
+### Task 22: Create `css/walk.css` — journal styling + fade tiers
+
+**Files:**
+- Create: `~/GitHub/momentmaker/pilgrim-landing/css/walk.css`
+
+- [ ] **Step 1: Write the CSS**
+
+```css
+/*
+ * /walk — the duck's journal.
+ * Rendered in pilgrim-landing's wabi-sabi palette.
+ */
+
+.walk-body {
+  background: var(--parchment, #f5f1e8);
+  color: var(--ink, #2a2320);
+  font-family: "Cormorant Garamond", Georgia, "Times New Roman", serif;
+  line-height: 1.6;
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+}
+
+.walk-main {
+  max-width: 640px;
+  margin: 0 auto;
+  padding: 4rem 1.5rem 6rem;
+}
+
+/* ---- Map ---- */
+
+.walk-map-wrap {
+  margin-bottom: 3rem;
+  text-align: center;
+}
+
+.walk-map {
+  width: 100%;
+  height: auto;
+  max-height: 380px;
+  opacity: 0.85;
+}
+
+.walk-map-route {
+  fill: none;
+  stroke: var(--ink, #2a2320);
+  stroke-width: 1.2;
+  stroke-opacity: 0.3;
+}
+
+.walk-map-entry-dot {
+  fill: var(--ink, #2a2320);
+  fill-opacity: 0.5;
+}
+
+.walk-map-duck {
+  width: 44px;
+  height: auto;
+}
+
+.walk-state-line {
+  font-style: italic;
+  font-size: 0.95rem;
+  color: rgba(42, 35, 32, 0.6);
+  margin-top: 1rem;
+}
+
+/* ---- Feed ---- */
+
+.walk-feed {
+  display: flex;
+  flex-direction: column;
+  gap: 3rem;
+}
+
+.walk-entry {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  transition: opacity 400ms ease;
+}
+
+.walk-entry-meta {
+  display: flex;
+  gap: 0.5rem;
+  align-items: baseline;
+  font-size: 0.78rem;
+  color: rgba(42, 35, 32, 0.55);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.walk-entry-date {
+  font-variant-numeric: tabular-nums;
+}
+
+.walk-entry-stage {
+  font-style: italic;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+.walk-entry-glyph {
+  font-size: 2.2rem;
+  line-height: 1;
+  text-align: left;
+  color: var(--ink, #2a2320);
+}
+
+.walk-entry-body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75em;
+  font-size: 1.25rem;
+  line-height: 1.55;
+}
+
+.walk-entry-body p {
+  margin: 0;
+}
+
+/* ---- Kind-specific ---- */
+
+.walk-entry--silence .walk-entry-body::after {
+  content: "(silence)";
+  font-style: italic;
+  opacity: 0.45;
+  font-size: 0.9rem;
+}
+
+.walk-entry--threshold {
+  padding: 1.5rem 0;
+  border-top: 1px solid rgba(42, 35, 32, 0.18);
+  border-bottom: 1px solid rgba(42, 35, 32, 0.18);
+}
+
+.walk-entry--threshold .walk-entry-glyph {
+  font-size: 2.8rem;
+}
+
+.walk-entry--letter .walk-entry-body {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  max-width: 520px;
+}
+
+.walk-entry--letter .walk-entry-glyph {
+  font-size: 1.3rem;
+  opacity: 0.6;
+}
+
+.walk-entry-author {
+  font-style: italic;
+  font-size: 0.9rem;
+  color: rgba(42, 35, 32, 0.55);
+  margin-top: 0.5rem;
+}
+
+/* ---- Fade tiers ---- */
+
+.walk-entry--age-recent { opacity: 1; }
+.walk-entry--age-soft   { opacity: 0.7; }
+.walk-entry--age-distant { opacity: 0.4; }
+
+.walk-entry--age-distant .walk-entry-body,
+.walk-entry--age-distant .walk-entry-author {
+  display: none;
+}
+
+/* ---- Tagline ---- */
+
+.walk-tagline {
+  margin-top: 6rem;
+  font-size: 0.72rem;
+  color: rgba(42, 35, 32, 0.35);
+  text-align: center;
+  font-style: italic;
+  letter-spacing: 0.04em;
+}
+
+@media (max-width: 500px) {
+  .walk-main { padding: 2.5rem 1.25rem 4rem; }
+  .walk-entry-body { font-size: 1.1rem; }
+}
+```
+
+- [ ] **Step 2: Sanity-check**
+
+```bash
+cd ~/GitHub/momentmaker/pilgrim-landing
+python3 -m http.server 8000 &
+open http://localhost:8000/walk.html
+kill %1
+```
+Expected: page is styled with serif text, empty feed, centered tagline.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add css/walk.css
+git commit -m "feat(walk): journal styling + age-based fade tiers"
+```
+
+---
+
+### Task 23: Create `js/walk.js` — fetch feed, render, fade
+
+**Files:**
+- Create: `~/GitHub/momentmaker/pilgrim-landing/js/walk.js`
+
+All user-supplied content is rendered via `textContent`. Duck prose is plain text from the feed.
+
+- [ ] **Step 1: Write the JS**
+
+```javascript
+(function () {
+  "use strict";
+
+  const FEED_URL =
+    "https://cdn.jsdelivr.net/gh/walktalkmeditate/rubberduck-walk@main/feed.json";
+  const DUCK_GIF = "assets/duck/duck.gif";
+  const SVG_NS = "http://www.w3.org/2000/svg";
+
+  function ageClass(ageDays) {
+    if (ageDays <= 30) return "walk-entry--age-recent";
+    if (ageDays <= 90) return "walk-entry--age-soft";
+    return "walk-entry--age-distant";
+  }
+
+  function formatDate(iso) {
+    const d = new Date(iso + "T00:00:00Z");
+    return d.toLocaleDateString("en-US", {
+      month: "long",
+      day: "numeric",
+      timeZone: "UTC",
+    });
+  }
+
+  function renderEntry(entry) {
+    const el = document.createElement("article");
+    el.className = `walk-entry walk-entry--${entry.kind} ${ageClass(entry.ageDays)}`;
+
+    const meta = document.createElement("div");
+    meta.className = "walk-entry-meta";
+    const date = document.createElement("span");
+    date.className = "walk-entry-date";
+    date.textContent = formatDate(entry.date);
+    const stage = document.createElement("span");
+    stage.className = "walk-entry-stage";
+    stage.textContent = entry.stageName;
+    meta.append(date, stage);
+    el.append(meta);
+
+    const glyph = document.createElement("div");
+    glyph.className = "walk-entry-glyph";
+    glyph.textContent = entry.glyph;
+    el.append(glyph);
+
+    const body = document.createElement("div");
+    body.className = "walk-entry-body";
+    if (entry.kind !== "silence") {
+      const paragraphs = Array.isArray(entry.paragraphs) ? entry.paragraphs : [];
+      for (const p of paragraphs) {
+        const pEl = document.createElement("p");
+        pEl.textContent = p;
+        body.append(pEl);
+      }
+    }
+    el.append(body);
+
+    if (entry.kind === "letter" && entry.author) {
+      const author = document.createElement("p");
+      author.className = "walk-entry-author";
+      author.textContent = entry.author;
+      el.append(author);
+    }
+
+    return el;
+  }
+
+  function renderStateLine(feed) {
+    const el = document.getElementById("walk-state-line");
+    if (!el) return;
+    const d = feed.duck;
+    if (d.mode === "resting") {
+      el.textContent = `The duck is resting at ${d.stageName}.`;
+    } else if (d.mode === "completing") {
+      el.textContent = `The duck is walking toward closure, near ${d.stageName}.`;
+    } else {
+      el.textContent = `The duck is at ${d.stageName}, stage ${d.stage} of the ${d.routeName}.`;
+    }
+  }
+
+  function renderMap(feed) {
+    const svg = document.getElementById("walk-map");
+    if (!svg) return;
+    const path = feed.routePath[feed.duck.route];
+    if (!path || path.length < 2) return;
+
+    const lats = path.map((p) => p[0]);
+    const lons = path.map((p) => p[1]);
+    const minLat = Math.min(...lats);
+    const maxLat = Math.max(...lats);
+    const minLon = Math.min(...lons);
+    const maxLon = Math.max(...lons);
+    const latRange = maxLat - minLat || 1;
+    const lonRange = maxLon - minLon || 1;
+
+    const W = 600;
+    const H = 400;
+    const PAD = 40;
+
+    function project([lat, lon]) {
+      const x = PAD + ((lon - minLon) / lonRange) * (W - 2 * PAD);
+      const y = PAD + ((maxLat - lat) / latRange) * (H - 2 * PAD);
+      return [x, y];
+    }
+
+    const polyline = document.createElementNS(SVG_NS, "polyline");
+    polyline.setAttribute(
+      "points",
+      path.map(project).map((p) => p.join(",")).join(" ")
+    );
+    polyline.setAttribute("class", "walk-map-route");
+    svg.append(polyline);
+
+    for (const entry of feed.entries) {
+      if (!entry.coords) continue;
+      const [x, y] = project(entry.coords);
+      const c = document.createElementNS(SVG_NS, "circle");
+      c.setAttribute("cx", String(x));
+      c.setAttribute("cy", String(y));
+      c.setAttribute("r", "3");
+      c.setAttribute("class", "walk-map-entry-dot");
+      svg.append(c);
+    }
+
+    const [dx, dy] = project(feed.duck.coords);
+    const img = document.createElementNS(SVG_NS, "image");
+    img.setAttributeNS("http://www.w3.org/1999/xlink", "xlink:href", DUCK_GIF);
+    img.setAttribute("href", DUCK_GIF);
+    img.setAttribute("x", String(dx - 22));
+    img.setAttribute("y", String(dy - 22));
+    img.setAttribute("width", "44");
+    img.setAttribute("height", "44");
+    img.setAttribute("class", "walk-map-duck");
+    svg.append(img);
+  }
+
+  async function main() {
+    try {
+      const res = await fetch(FEED_URL, { cache: "no-store" });
+      if (!res.ok) throw new Error(`Feed fetch failed: ${res.status}`);
+      const feed = await res.json();
+
+      renderStateLine(feed);
+      renderMap(feed);
+
+      const feedEl = document.getElementById("walk-feed");
+      if (feedEl) {
+        for (const entry of feed.entries) {
+          feedEl.append(renderEntry(entry));
+        }
+      }
+    } catch (err) {
+      const stateEl = document.getElementById("walk-state-line");
+      if (stateEl) stateEl.textContent = "The duck is somewhere.";
+      console.error(err);
+    }
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", main);
+  } else {
+    main();
+  }
+})();
+```
+
+- [ ] **Step 2: Serve and verify**
+
+```bash
+cd ~/GitHub/momentmaker/pilgrim-landing
+python3 -m http.server 8000 &
+open http://localhost:8000/walk.html
+```
+Expected: map renders with a Shikoku-shaped polyline, duck .gif at current position, 2 seed entries in serif (pulled from live jsDelivr).
+
+- [ ] **Step 3: Stop server and commit**
+
+```bash
+kill %1
+git add js/walk.js
+git commit -m "feat(walk): fetch feed, render map and journal via textContent"
+```
+
+---
+
+## Phase 11 — Footer duck on existing pages
+
+### Task 24: Add footer duck to index.html + shared CSS
+
+**Files:**
+- Modify: `~/GitHub/momentmaker/pilgrim-landing/index.html`
+- Modify: `~/GitHub/momentmaker/pilgrim-landing/css/styles.css`
+
+- [ ] **Step 1: Locate the signoff line**
+
+```bash
+cd ~/GitHub/momentmaker/pilgrim-landing
+grep -n "horizon-signoff" index.html
+```
+Expected: one match `<p class="horizon-signoff reveal">crafted with intention</p>`.
+
+- [ ] **Step 2: Insert the duck anchor immediately after the signoff line in `index.html`**
+
+Change this line:
+```html
+    <p class="horizon-signoff reveal">crafted with intention</p>
+```
+
+Into:
+```html
+    <p class="horizon-signoff reveal">crafted with intention</p>
+    <a class="horizon-duck" href="/walk.html" aria-label="a question cannot be asked unless there is already the potentiality of the answer">
+      <img src="assets/duck/duck-24.png" srcset="assets/duck/duck-24.png 1x, assets/duck/duck-48.png 2x" width="24" height="24" alt="">
+    </a>
+```
+
+- [ ] **Step 3: Append `.horizon-duck` rules to `css/styles.css`**
+
+Append to the end of `css/styles.css`:
+
+```css
+.horizon-duck {
+  display: inline-block;
+  margin-top: 1.25rem;
+  opacity: 0.55;
+  transition: opacity 300ms ease;
+  line-height: 0;
+}
+
+.horizon-duck img {
+  display: block;
+  width: 24px;
+  height: 24px;
+}
+
+.horizon-duck:hover,
+.horizon-duck:focus-visible {
+  opacity: 0.9;
+}
+```
+
+- [ ] **Step 4: Verify visually**
+
+```bash
+python3 -m http.server 8000 &
+open "http://localhost:8000/index.html#horizon"
+```
+Scroll to footer. Expected: tiny duck icon below "crafted with intention." Clicking navigates to `/walk.html`.
+
+- [ ] **Step 5: Stop server and commit**
+
+```bash
+kill %1
+git add index.html css/styles.css
+git commit -m "feat(footer): add duck icon to index footer"
+```
+
+---
+
+### Task 25: Add footer duck to privacy, terms, press pages
+
+**Files:**
+- Modify: `~/GitHub/momentmaker/pilgrim-landing/privacy.html`
+- Modify: `~/GitHub/momentmaker/pilgrim-landing/terms.html`
+- Modify: `~/GitHub/momentmaker/pilgrim-landing/press.html`
+
+- [ ] **Step 1: Locate the signoff line in each file**
+
+```bash
+cd ~/GitHub/momentmaker/pilgrim-landing
+grep -n "horizon-signoff" privacy.html terms.html press.html
+```
+Expected: one match per file.
+
+- [ ] **Step 2: For each file, insert immediately after the signoff line**
+
+```html
+    <a class="horizon-duck" href="/walk.html" aria-label="a question cannot be asked unless there is already the potentiality of the answer">
+      <img src="assets/duck/duck-24.png" srcset="assets/duck/duck-24.png 1x, assets/duck/duck-48.png 2x" width="24" height="24" alt="">
+    </a>
+```
+
+(The `.horizon-duck` styles were already added to `styles.css` in Task 24.)
+
+- [ ] **Step 3: Verify each page**
+
+```bash
+python3 -m http.server 8000 &
+open http://localhost:8000/privacy.html
+open http://localhost:8000/terms.html
+open http://localhost:8000/press.html
+```
+Each should show the duck icon in the footer.
+
+- [ ] **Step 4: Stop server and commit**
+
+```bash
+kill %1
+git add privacy.html terms.html press.html
+git commit -m "feat(footer): add duck icon to privacy/terms/press"
+```
+
+---
+
+## Phase 12 — Schedule
+
+### Task 26: Register the daily schedule
+
+**Files:** None; the `/schedule` skill manages its own configuration.
+
+- [ ] **Step 1: Dry-run the daily flow manually once**
+
+Before registering the cron:
+
+```bash
+cd ~/GitHub/rubberduck/walk
+./duck advance
+./duck build-feed
+git add -A
+git diff --cached --stat
+git commit -m "the duck walks (manual dry run)"
+git push
+bash scripts/purge.sh
+```
+Expected: state advances, feed rebuilt, commit pushes, purge returns a finished status.
+
+- [ ] **Step 2: Reset state if desired**
+
+If you want the real cron to advance on its own tomorrow, edit `state.json` back one stage. Otherwise leave.
+
+- [ ] **Step 3: Ask the user to register the daily schedule**
+
+Present this text verbatim and wait for confirmation before marking the task complete:
+
+> **To register the daily duck cron, run `/schedule` in Claude Code with a prompt like:**
+>
+> *"Every day at 07:00 America/Los_Angeles — cd ~/GitHub/rubberduck/walk and follow the playbook in CLAUDE.md (advance, maybe write, build feed, commit, push, purge)."*
+>
+> **This spawns a remote agent on Anthropic's servers to run the walk daily. Confirm when registered so I can record it.**
+
+---
+
+## Phase 13 — Final verification
+
+### Task 27: End-to-end visual check
+
+**Files:** None modified.
+
+- [ ] **Step 1: Open both surfaces locally**
+
+```bash
+cd ~/GitHub/momentmaker/pilgrim-landing
+python3 -m http.server 8000 &
+```
+
+Open and inspect:
+- `http://localhost:8000/index.html` — scroll to footer, see the duck
+- `http://localhost:8000/walk.html` — see map, state line, 2+ entries
+- Click the footer duck from `index.html` — should navigate to `/walk.html`
+
+- [ ] **Step 2: Test the letter flow manually**
+
+```bash
+cd ~/GitHub/rubberduck/walk
+EDITOR=nano ./duck letter
+./duck build-feed
+git add -A
+git commit -m "feat(entries): first letter"
+git push
+bash scripts/purge.sh
+```
+
+Wait ~30s, reload `http://localhost:8000/walk.html`. Expected: letter appears with paragraph-form prose and an author signature.
+
+- [ ] **Step 3: Stop server**
+
+```bash
+kill %1
+```
+
+---
+
+### Task 28: Ship quietly
+
+**Files:** None; deployment task.
+
+- [ ] **Step 1: Push pilgrim-landing**
+
+```bash
+cd ~/GitHub/momentmaker/pilgrim-landing
+git push
+```
+GitHub Pages will redeploy within ~1 minute.
+
+- [ ] **Step 2: Verify live**
+
+Open `https://pilgrimapp.org/` and scroll to footer. Look for the duck. Click it. You should land on `/walk.html` with the feed rendered from live jsDelivr.
+
+- [ ] **Step 3: Do nothing else**
+
+Do not post about the duck. Do not announce the feature. The duck is meant to be stumbled upon. Let it be.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+
+| Spec section | Implementing task(s) |
+|---|---|
+| Repo bootstrap + layout | Task 1–2 |
+| Types & data model | Task 3–5 |
+| Entry format + parsing (plain text, no HTML in feed) | Task 6–7 |
+| State machine (walking/completing/resting/beginning) | Task 8–9 |
+| Feed builder + impermanence (365-day prune) | Task 10–11 |
+| State advance automation | Task 12 |
+| Weather integration (Open-Meteo) | Task 13–14 |
+| Purge jsDelivr cache | Task 15 |
+| Local CLI (offer/letter/next/status/preview/advance/silence/build-feed) | Task 16 |
+| Character bible (CLAUDE.md, voice rules, glyph palette, self-review checklist) | Task 17 |
+| Seed entries | Task 18 |
+| Live jsDelivr feed | Task 19 |
+| Duck assets (PNG/GIF) | Task 20 |
+| `/walk` page HTML/CSS/JS (textContent-only, XSS-safe) | Task 21–23 |
+| Fade tiers (30/90/365) | Task 22 |
+| Map rendering + current-position marker | Task 23 |
+| Footer duck on pilgrim-landing pages | Task 24–25 |
+| Daily `/schedule` registration | Task 26 |
+| End-to-end verification + quiet ship | Task 27–28 |
+
+All spec requirements map to at least one task.
+
+**Intentional non-coverage** (flagged in spec Open Decisions):
+- Closure sites for Kumano/Camino routes are not plumbed in Task 4's snapshot — the `closure` field only populates Shikoku's Kōya-san. Will be added when Kumano is activated via `./duck next kumano-kodo`.
+- Exact silence-entry typography is settled during Task 22's CSS authoring via the `::after` pseudo-element.
+
+**Placeholder scan:** No "TBD"/"TODO"/"add appropriate X" in plan steps.
+
+**XSS-safety:** The feed contains only plain-text strings (`paragraphs: string[]`) — no pre-rendered HTML. Client rendering uses `document.createElement` + `textContent` exclusively for all feed-derived content. No `innerHTML`, no markdown rendered client-side. Even if the walktalkmeditate/rubberduck-walk repo were compromised, an attacker could only inject prose, not script.
+
+**Type consistency:**
+- `advance()` and `beginRoute()` both return `State` — consistent.
+- `buildFeed()` accepts `Entry[]` and emits `FeedEntry[]`; both carry `paragraphs: string[]`. Consistent.
+- `EntryKind` is the same union in types.ts, CLAUDE.md, and walk.js. Consistent.
+- Glyph palette (27 symbols) identical in duck CLI silence command and CLAUDE.md. Consistent.
+- jsDelivr URL appears in walk.js, README, purge.sh, and spec. Consistent.
+- WMO ranges in `mapWeatherCode()` match the spec's weather section. Consistent.
+
+Plan is ready to execute.

--- a/docs/superpowers/plans/2026-04-23-rubberduck-walk.md
+++ b/docs/superpowers/plans/2026-04-23-rubberduck-walk.md
@@ -229,7 +229,7 @@ export type DuckMode = "walking" | "completing" | "resting" | "beginning";
 
 export type EntryKind = "offering" | "notice" | "silence" | "threshold" | "letter";
 
-export type Coords = [number, number]; // [latitude, longitude]
+export type Coords = [number, number]; // [longitude, latitude] — GeoJSON convention
 
 export interface State {
   route: string;
@@ -355,17 +355,17 @@ Add the `closure` field manually (open-pilgrimages may not have Kōya-san):
   "country": "JP",
   "distanceKm": 1200,
   "stages": [
-    { "index": 1, "name": "Ryōzenji", "coords": [34.128, 134.537] },
-    { "index": 88, "name": "Ōkuboji", "coords": [34.218, 134.051] }
+    { "index": 1, "name": "Ryōzenji", "coords": [134.537, 34.128] },
+    { "index": 88, "name": "Ōkuboji", "coords": [134.051, 34.218] }
   ],
   "closure": {
     "name": "Kōya-san Okunoin",
-    "coords": [34.2167, 135.589],
+    "coords": [135.589, 34.2167],
     "transitStages": [
-      { "index": 1, "name": "Tokushima port", "coords": [34.067, 134.555] },
-      { "index": 2, "name": "Wakayama", "coords": [34.230, 135.170] },
-      { "index": 3, "name": "Hashimoto", "coords": [34.312, 135.604] },
-      { "index": 4, "name": "Kōya-san Okunoin", "coords": [34.2167, 135.589] }
+      { "index": 1, "name": "Tokushima port", "coords": [134.555, 34.067] },
+      { "index": 2, "name": "Wakayama", "coords": [135.170, 34.230] },
+      { "index": 3, "name": "Hashimoto", "coords": [135.604, 34.312] },
+      { "index": 4, "name": "Kōya-san Okunoin", "coords": [135.589, 34.2167] }
     ]
   }
 }
@@ -405,7 +405,7 @@ The duck starts at Temple 1.
   "route": "shikoku-88",
   "stage": 1,
   "stageName": "Ryōzenji",
-  "coords": [34.128, 134.537],
+  "coords": [134.537, 34.128],
   "mode": "walking",
   "modeEnteredAt": "2026-04-23",
   "lastAdvancedAt": "2026-04-23"
@@ -460,7 +460,7 @@ date: 2026-04-23
 route: shikoku-88
 stage: 1
 stageName: Ryōzenji
-coords: [34.128, 134.537]
+coords: [134.537, 34.128]
 kind: offering
 glyph: 🪨
 weather: clear, 15°C
@@ -472,7 +472,7 @@ A stone by the door. No one had moved it. No one needed to.
   assert.equal(result.date, "2026-04-23");
   assert.equal(result.kind, "offering");
   assert.equal(result.glyph, "🪨");
-  assert.deepEqual(result.coords, [34.128, 134.537]);
+  assert.deepEqual(result.coords, [134.537, 34.128]);
   assert.deepEqual(result.paragraphs, [
     "A stone by the door. No one had moved it. No one needed to.",
   ]);
@@ -485,7 +485,7 @@ date: 2026-05-02
 route: shikoku-88
 stage: 13
 stageName: Dainichiji
-coords: [33.9, 134.1]
+coords: [134.1, 33.9]
 kind: letter
 glyph: 🕯️
 author: — the pilgrim
@@ -510,7 +510,7 @@ date: 2026-04-30
 route: shikoku-88
 stage: 5
 stageName: Jizōji
-coords: [34.1, 134.5]
+coords: [134.5, 34.1]
 kind: silence
 glyph: 〰️
 ---
@@ -526,7 +526,7 @@ date: 2026-04-23
 route: shikoku-88
 stage: 1
 stageName: Ryōzenji
-coords: [34.128, 134.537]
+coords: [134.537, 34.128]
 kind: offering
 glyph: 🪨
 ---
@@ -694,16 +694,16 @@ const shikoku: Route = {
   country: "JP",
   distanceKm: 1200,
   stages: [
-    { index: 1, name: "Ryōzenji", coords: [34.128, 134.537] },
-    { index: 2, name: "Gokurakuji", coords: [34.130, 134.556] },
-    { index: 3, name: "Konsenji", coords: [34.135, 134.570] },
+    { index: 1, name: "Ryōzenji", coords: [134.537, 34.128] },
+    { index: 2, name: "Gokurakuji", coords: [134.556, 34.130] },
+    { index: 3, name: "Konsenji", coords: [134.570, 34.135] },
   ],
   closure: {
     name: "Kōya-san",
-    coords: [34.216, 135.589],
+    coords: [135.589, 34.216],
     transitStages: [
-      { index: 1, name: "Wakayama", coords: [34.23, 135.17] },
-      { index: 2, name: "Kōya-san", coords: [34.216, 135.589] },
+      { index: 1, name: "Wakayama", coords: [135.17, 34.23] },
+      { index: 2, name: "Kōya-san", coords: [135.589, 34.216] },
     ],
   },
 };
@@ -713,7 +713,7 @@ test("advance moves duck from stage 1 to stage 2 during walking", () => {
     route: "shikoku-88",
     stage: 1,
     stageName: "Ryōzenji",
-    coords: [34.128, 134.537],
+    coords: [134.537, 34.128],
     mode: "walking",
     modeEnteredAt: "2026-04-20",
     lastAdvancedAt: "2026-04-22",
@@ -730,7 +730,7 @@ test("advance flips to completing when final stage reached", () => {
     route: "shikoku-88",
     stage: 3,
     stageName: "Konsenji",
-    coords: [34.135, 134.570],
+    coords: [134.570, 34.135],
     mode: "walking",
     modeEnteredAt: "2026-04-20",
     lastAdvancedAt: "2026-04-22",
@@ -747,7 +747,7 @@ test("advance flips to resting when closure site reached", () => {
     route: "shikoku-88",
     stage: 1,
     stageName: "Wakayama",
-    coords: [34.23, 135.17],
+    coords: [135.17, 34.23],
     mode: "completing",
     modeEnteredAt: "2026-04-23",
     lastAdvancedAt: "2026-04-23",
@@ -763,7 +763,7 @@ test("advance does not move during resting", () => {
     route: "shikoku-88",
     stage: 2,
     stageName: "Kōya-san",
-    coords: [34.216, 135.589],
+    coords: [135.589, 34.216],
     mode: "resting",
     modeEnteredAt: "2026-04-24",
     lastAdvancedAt: "2026-04-24",
@@ -906,7 +906,7 @@ const kumano: Route = {
   country: "JP",
   distanceKm: 150,
   stages: [
-    { index: 1, name: "Takijiri-oji", coords: [33.778, 135.507] },
+    { index: 1, name: "Takijiri-oji", coords: [135.507, 33.778] },
   ],
 };
 
@@ -915,7 +915,7 @@ test("beginRoute flips from resting to beginning at stage 1 of new route", () =>
     route: "shikoku-88",
     stage: 2,
     stageName: "Kōya-san",
-    coords: [34.216, 135.589],
+    coords: [135.589, 34.216],
     mode: "resting",
     modeEnteredAt: "2026-12-14",
     lastAdvancedAt: "2026-12-14",
@@ -933,7 +933,7 @@ test("beginRoute throws if state is not resting", () => {
     route: "shikoku-88",
     stage: 5,
     stageName: "Jizōji",
-    coords: [34.1, 134.5],
+    coords: [134.5, 34.1],
     mode: "walking",
     modeEnteredAt: "2026-04-20",
     lastAdvancedAt: "2026-05-01",
@@ -1001,8 +1001,8 @@ const shikoku: Route = {
   country: "JP",
   distanceKm: 1200,
   stages: [
-    { index: 1, name: "Ryōzenji", coords: [34.128, 134.537] },
-    { index: 2, name: "Gokurakuji", coords: [34.130, 134.556] },
+    { index: 1, name: "Ryōzenji", coords: [134.537, 34.128] },
+    { index: 2, name: "Gokurakuji", coords: [134.556, 34.130] },
   ],
 };
 
@@ -1010,7 +1010,7 @@ const state: State = {
   route: "shikoku-88",
   stage: 2,
   stageName: "Gokurakuji",
-  coords: [34.130, 134.556],
+  coords: [134.556, 34.130],
   mode: "walking",
   modeEnteredAt: "2026-04-20",
   lastAdvancedAt: "2026-04-23",
@@ -1021,7 +1021,7 @@ const recentEntry: Entry = {
   route: "shikoku-88",
   stage: 2,
   stageName: "Gokurakuji",
-  coords: [34.130, 134.556],
+  coords: [134.556, 34.130],
   kind: "offering",
   glyph: "🪨",
   body: "A stone.",
@@ -1073,8 +1073,8 @@ test("buildFeed sorts entries newest first", () => {
 test("buildFeed includes routePath with stage coords", () => {
   const feed = buildFeed({ state, route: shikoku, entries: [], today: "2026-04-23" });
   assert.deepEqual(feed.routePath["shikoku-88"], [
-    [34.128, 134.537],
-    [34.130, 134.556],
+    [134.537, 34.128],
+    [134.556, 34.130],
   ]);
 });
 
@@ -1378,7 +1378,7 @@ interface OpenMeteoResponse {
 }
 
 export async function fetchWeather(coords: Coords): Promise<string | null> {
-  const [lat, lon] = coords;
+  const [lon, lat] = coords;
   const url =
     `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}` +
     `&current=temperature_2m,weather_code,precipitation`;
@@ -1817,7 +1817,7 @@ date: 2026-04-23
 route: shikoku-88
 stage: 1
 stageName: Ryōzenji
-coords: [34.128, 134.537]
+coords: [134.537, 34.128]
 kind: offering
 glyph: 🪨
 weather: clear, 15°C
@@ -1866,7 +1866,7 @@ date: 2026-04-23
 route: shikoku-88
 stage: 1
 stageName: Ryōzenji
-coords: [34.128, 134.537]
+coords: [134.537, 34.128]
 kind: offering
 glyph: ⛩️
 ---
@@ -1889,7 +1889,7 @@ date: 2026-04-24
 route: shikoku-88
 stage: 2
 stageName: Gokurakuji
-coords: [34.130, 134.556]
+coords: [134.556, 34.130]
 kind: offering
 glyph: 🪨
 ---
@@ -1907,7 +1907,7 @@ Expected: feed has 2 entries, newest first, duck at stage 2.
 
 - [ ] **Step 4: Reset state back to stage 1**
 
-Edit `state.json`: set `stage: 1, stageName: "Ryōzenji", coords: [34.128, 134.537], lastAdvancedAt: "2026-04-22"`.
+Edit `state.json`: set `stage: 1, stageName: "Ryōzenji", coords: [134.537, 34.128], lastAdvancedAt: "2026-04-22"`.
 
 - [ ] **Step 5: Commit**
 
@@ -2363,8 +2363,8 @@ All user-supplied content is rendered via `textContent`. Duck prose is plain tex
     const path = feed.routePath[feed.duck.route];
     if (!path || path.length < 2) return;
 
-    const lats = path.map((p) => p[0]);
-    const lons = path.map((p) => p[1]);
+    const lons = path.map((p) => p[0]);
+    const lats = path.map((p) => p[1]);
     const minLat = Math.min(...lats);
     const maxLat = Math.max(...lats);
     const minLon = Math.min(...lons);
@@ -2376,7 +2376,7 @@ All user-supplied content is rendered via `textContent`. Duck prose is plain tex
     const H = 400;
     const PAD = 40;
 
-    function project([lat, lon]) {
+    function project([lon, lat]) {
       const x = PAD + ((lon - minLon) / lonRange) * (W - 2 * PAD);
       const y = PAD + ((maxLat - lat) / latRange) * (H - 2 * PAD);
       return [x, y];

--- a/docs/superpowers/plans/2026-04-23-walk-crash-resilience.md
+++ b/docs/superpowers/plans/2026-04-23-walk-crash-resilience.md
@@ -1,0 +1,933 @@
+# Walk Crash Resilience Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix the `cpu_resource_fatal` crash that kills Pilgrim during locked walk+talk sessions (caused by Mapbox rendering unthrottled in background), and harden the SessionGuard recovery flow so a Talk duration survives any SIGKILL (even if the audio file doesn't).
+
+**Architecture:** Two independent problems, two independent fixes.
+
+1. **Crash fix (Mapbox):** iOS's CPU watchdog kills the app after 80% CPU over 60s. Evidence: three `cpu_resource_fatal` `.ips` reports on 2026-04-22, all identical stacks pointing at MapboxMaps' render loop invoking MapboxCoreMaps' C++ renderer on a background worker thread. `PilgrimMapView` currently has no scene-phase handling, so the map renders at 30 FPS even when the screen is locked or a full-screen meditation overlay is up. Fix: the `Coordinator` observes `UIApplication.didEnterBackground`/`willEnterForeground` + a `isMeditating` binding, and sets `preferredFramesPerSecond = 0` whenever the user can't see the map. Also gate GeoJSON source rebuilds while paused (C++ work even without rendering) and catch up on resume.
+
+2. **Talk metadata resilience:** `checkpointActivityIntervals()` already persists in-flight meditation state (provisional interval with rolling `endDate = Date()`). Voice recording has no equivalent — during Talk, `voiceRecordingsRelay` is empty until `recorder.stop()` fires the delegate, so every SIGKILL loses the entire in-flight segment. Fix: mirror the meditation pattern — on each checkpoint, synthesize a provisional `TempVoiceRecording` from the active `recordingStartDate`/`currentRecordingRelativePath` and append it to the snapshot. On recovery, validate each recording's `.m4a` file; if the moov atom is missing (AVAudioRecorder killed before `.stop()`), clear the path so the summary shows "Recording unavailable" while preserving the duration for the Talk timer. Also handle the phone-call case: observe `CXCallObserver` and stop the recorder cleanly when a call is actually answered (not on every audio-session blip).
+
+**Tech Stack:** Swift / SwiftUI / Combine, AVFoundation, MapboxMaps 11.20, CallKit (new import), CocoaPods + SPM. No new third-party dependencies.
+
+**Reference:** Crash analysis and decision thread in conversation on 2026-04-22 / 2026-04-23.
+
+**Branch:** Create `fix/walk-crash-resilience` before Task 1.
+
+**Execution order rationale:** Ship Tasks 1–4 first (talk metadata persistence + recovery sanitization) so we can *test the recovery path against the still-reproducible CPU crash*. Once we confirm recovery works end-to-end, ship Tasks 5–6 (Mapbox pause) which eliminate the reproducer. Finally ship Task 7 (CXCallObserver) for the phone-call case. Do NOT reorder — testing recovery before the reproducer is removed is the whole point.
+
+---
+
+## File Structure
+
+**No new production files.**
+
+**Modified files:**
+- `Pilgrim/Models/Walk/WalkBuilder/Components/VoiceRecordingManagement.swift` — add `checkpointVoiceRecording()` method; import CallKit + CXCallObserver delegate; wire interruption on `hasConnected`
+- `Pilgrim/Models/Walk/WalkSessionGuard.swift` — call `checkpointVoiceRecording()` in `checkpointNow`; sanitize unplayable recordings in `recoverIfNeeded`
+- `Pilgrim/Views/PilgrimMapView.swift` — observe app lifecycle + `isMeditating` binding in Coordinator; set `preferredFramesPerSecond` accordingly; skip `applyRouteSource` while paused; flush on resume
+- `Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift` — pass `isMeditating` binding into `PilgrimMapView`
+- `Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift` — `isFileAvailable` returns false for empty relativePath
+
+**New test files:**
+- `UnitTests/VoiceRecordingCheckpointTests.swift`
+- `UnitTests/WalkSessionGuardRecoveryTests.swift`
+- `UnitTests/VoiceRecordingCallInterruptionTests.swift`
+
+New test files require manual `Pilgrim.xcodeproj/project.pbxproj` registration in the `UnitTests` group (UnitTests is NOT a synchronized root group — follow the pattern from commit `96ae8e4`).
+
+---
+
+## Task 1: VoiceRecordingManagement exposes checkpoint snapshot
+
+**Files:**
+- Modify: `Pilgrim/Models/Walk/WalkBuilder/Components/VoiceRecordingManagement.swift`
+- Create: `UnitTests/VoiceRecordingCheckpointTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `UnitTests/VoiceRecordingCheckpointTests.swift`:
+
+```swift
+import XCTest
+@testable import Pilgrim
+
+final class VoiceRecordingCheckpointTests: XCTestCase {
+
+    func test_checkpointVoiceRecording_returnsNil_whenNotRecording() {
+        let builder = WalkBuilder()
+        let mgmt = VoiceRecordingManagement(builder: builder)
+
+        XCTAssertNil(mgmt.checkpointVoiceRecording())
+    }
+
+    func test_checkpointVoiceRecording_returnsSnapshot_whenRecording() {
+        let builder = WalkBuilder()
+        let mgmt = VoiceRecordingManagement(builder: builder)
+        builder.setStatus(.recording)
+
+        // Simulate the internal state an active recording would set.
+        // startRecording() requires AVAudioSession permission which isn't
+        // available in unit tests, so we test the snapshot surface
+        // assuming the state was set by the real startRecording path.
+        mgmt._test_setActiveRecording(
+            start: Date(timeIntervalSinceNow: -30),
+            relativePath: "Recordings/ABC/rec.m4a"
+        )
+
+        guard let snapshot = mgmt.checkpointVoiceRecording() else {
+            XCTFail("expected a provisional recording snapshot")
+            return
+        }
+        XCTAssertEqual(snapshot.fileRelativePath, "Recordings/ABC/rec.m4a")
+        XCTAssertEqual(snapshot.duration, 30, accuracy: 1.0)
+        XCTAssertNotNil(snapshot.startDate)
+    }
+}
+```
+
+- [ ] **Step 2: Register the new test file in pbxproj**
+
+Add `UnitTests/VoiceRecordingCheckpointTests.swift` to the UnitTests target by editing `Pilgrim.xcodeproj/project.pbxproj` manually (follow the pattern from commit `96ae8e4`).
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/VoiceRecordingCheckpointTests
+```
+
+Expected: compilation failure — `checkpointVoiceRecording` and `_test_setActiveRecording` don't exist yet.
+
+- [ ] **Step 4: Implement `checkpointVoiceRecording()` and the test hook**
+
+Add to `Pilgrim/Models/Walk/WalkBuilder/Components/VoiceRecordingManagement.swift`, after the public `toggleRecording()` method:
+
+```swift
+    /// Returns a provisional `TempVoiceRecording` capturing the currently-active
+    /// recording's start + elapsed duration so far, or `nil` if no recording is
+    /// active. Mirrors the meditation-interval provisional pattern in
+    /// `ActiveWalkViewModel.checkpointActivityIntervals()`. The returned recording
+    /// has the real in-flight file path; on recovery, the file may or may not be
+    /// playable depending on whether AVAudioRecorder wrote its moov atom before
+    /// the process died.
+    public func checkpointVoiceRecording() -> TempVoiceRecording? {
+        guard isRecording,
+              let start = currentRecordingStart,
+              let relativePath = currentRecordingRelativePath else {
+            return nil
+        }
+        let now = Date()
+        return TempVoiceRecording(
+            uuid: nil,
+            startDate: start,
+            endDate: now,
+            duration: now.timeIntervalSince(start),
+            fileRelativePath: relativePath,
+            isEnhanced: false
+        )
+    }
+
+    #if DEBUG
+    /// Test-only hook. Sets the internal state that `startRecording()` would set
+    /// without requiring AVAudioSession permission in the unit-test environment.
+    func _test_setActiveRecording(start: Date, relativePath: String) {
+        currentRecordingStart = start
+        currentRecordingRelativePath = relativePath
+        recordingStartDate = start
+        isRecording = true
+    }
+    #endif
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/VoiceRecordingCheckpointTests
+```
+
+Expected: both tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Pilgrim/Models/Walk/WalkBuilder/Components/VoiceRecordingManagement.swift UnitTests/VoiceRecordingCheckpointTests.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat(walk): expose in-flight voice-recording snapshot for checkpoints"
+```
+
+---
+
+## Task 2: WalkSessionGuard writes talk metadata to checkpoint
+
+**Files:**
+- Modify: `Pilgrim/Models/Walk/WalkSessionGuard.swift:116-147`
+- Create: `UnitTests/WalkSessionGuardRecoveryTests.swift`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `UnitTests/WalkSessionGuardRecoveryTests.swift`:
+
+```swift
+import XCTest
+@testable import Pilgrim
+
+final class WalkSessionGuardRecoveryTests: XCTestCase {
+
+    func test_checkpoint_includes_in_flight_talk_metadata() {
+        let vm = ActiveWalkViewModel()
+        let builder = vm.builder
+        builder.setStatus(.recording)
+
+        vm.voiceRecordingManagement._test_setActiveRecording(
+            start: Date(timeIntervalSinceNow: -42),
+            relativePath: "Recordings/DEADBEEF/rec.m4a"
+        )
+
+        // Force a start date on the builder so createCheckpointSnapshot returns non-nil.
+        builder._test_setStartDate(Date(timeIntervalSinceNow: -60))
+
+        let snapshot = builder.createCheckpointSnapshot()
+        XCTAssertNotNil(snapshot)
+
+        if let inflight = vm.voiceRecordingManagement.checkpointVoiceRecording() {
+            snapshot?.appendVoiceRecordings([inflight])
+        }
+
+        XCTAssertEqual(snapshot?.voiceRecordings.count, 1)
+        XCTAssertEqual(snapshot?.voiceRecordings.first?.fileRelativePath,
+                       "Recordings/DEADBEEF/rec.m4a")
+        XCTAssertEqual(snapshot?.voiceRecordings.first?.duration ?? 0, 42, accuracy: 1.0)
+    }
+}
+```
+
+- [ ] **Step 2: Register the new test file in pbxproj**
+
+Add `UnitTests/WalkSessionGuardRecoveryTests.swift` to the UnitTests target in `Pilgrim.xcodeproj/project.pbxproj`.
+
+- [ ] **Step 3: Add the builder test hook**
+
+Add to `Pilgrim/Models/Walk/WalkBuilder/WalkBuilder.swift`, in an `#if DEBUG` block near the other test-only helpers:
+
+```swift
+    #if DEBUG
+    func _test_setStartDate(_ date: Date) {
+        startDateRelay.accept(date)
+    }
+    #endif
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/WalkSessionGuardRecoveryTests
+```
+
+Expected: PASS (the wiring is in test code, not production — this is a whiteboard test to lock in the shape).
+
+- [ ] **Step 5: Wire it into the production checkpoint path**
+
+Modify `Pilgrim/Models/Walk/WalkSessionGuard.swift`. Find the `checkpointNow()` method and change the section after `snapshot.replaceActivityIntervals(intervals)`:
+
+Before (lines 116-132):
+```swift
+    func checkpointNow() {
+        guard let builder, let snapshot = builder.createCheckpointSnapshot() else {
+            print("\(Self.tag) CHECKPOINT SKIPPED — no builder or no start date")
+            return
+        }
+
+        if let viewModel {
+            let intervals = viewModel.checkpointActivityIntervals()
+            snapshot.replaceActivityIntervals(intervals)
+        }
+
+        if walkUUID == nil {
+            walkUUID = Self.extractRecordingDirectoryUUID(from: snapshot) ?? UUID()
+        }
+```
+
+After:
+```swift
+    func checkpointNow() {
+        guard let builder, let snapshot = builder.createCheckpointSnapshot() else {
+            print("\(Self.tag) CHECKPOINT SKIPPED — no builder or no start date")
+            return
+        }
+
+        if let viewModel {
+            let intervals = viewModel.checkpointActivityIntervals()
+            snapshot.replaceActivityIntervals(intervals)
+
+            if let inflightTalk = viewModel.voiceRecordingManagement.checkpointVoiceRecording() {
+                snapshot.appendVoiceRecordings([inflightTalk])
+            }
+        }
+
+        if walkUUID == nil {
+            walkUUID = Self.extractRecordingDirectoryUUID(from: snapshot) ?? UUID()
+        }
+```
+
+Also update the checkpoint log at line 143 to include a flag for whether an in-flight talk was captured, for easier debugging:
+
+Before:
+```swift
+            print("\(Self.tag) CHECKPOINT #\(checkpointCount) — tier: \(currentTier), routes: \(snapshot.routeData.count), pauses: \(snapshot.pauses.count), recordings: \(snapshot.voiceRecordings.count), intervals: \(snapshot.activityIntervals.count), size: \(ByteCountFormatter.string(fromByteCount: Int64(data.count), countStyle: .file))")
+```
+
+After:
+```swift
+            let talkFlag = snapshot.voiceRecordings.contains { $0.uuid == nil } ? " (inflight)" : ""
+            print("\(Self.tag) CHECKPOINT #\(checkpointCount) — tier: \(currentTier), routes: \(snapshot.routeData.count), pauses: \(snapshot.pauses.count), recordings: \(snapshot.voiceRecordings.count)\(talkFlag), intervals: \(snapshot.activityIntervals.count), size: \(ByteCountFormatter.string(fromByteCount: Int64(data.count), countStyle: .file))")
+```
+
+- [ ] **Step 6: Run the full test suite**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Pilgrim/Models/Walk/WalkSessionGuard.swift Pilgrim/Models/Walk/WalkBuilder/WalkBuilder.swift UnitTests/WalkSessionGuardRecoveryTests.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat(walk): persist in-flight talk metadata in SessionGuard checkpoints"
+```
+
+---
+
+## Task 3: Sanitize unplayable recordings during recovery
+
+**Files:**
+- Modify: `Pilgrim/Models/Walk/WalkSessionGuard.swift` (recoverIfNeeded path)
+
+Recording files written by AVAudioRecorder have no valid MP4 `moov` atom until `recorder.stop()` runs. A SIGKILL mid-recording leaves the `.m4a` with a `duration` of `0` (or `.indefinite`) when read via `AVURLAsset`. We detect this at recovery time and convert the entry to metadata-only (preserve duration from our provisional snapshot, clear the file path so playback UI gracefully shows "unavailable").
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `UnitTests/WalkSessionGuardRecoveryTests.swift`:
+
+```swift
+    func test_sanitizeUnplayableRecordings_clearsPath_forMoovLessFile() throws {
+        // Write a zero-byte .m4a to simulate a SIGKILL'd AVAudioRecorder output.
+        let tmpDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("WalkSessionGuardRecoveryTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: tmpDir, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: tmpDir) }
+
+        let brokenFile = tmpDir.appendingPathComponent("broken.m4a")
+        try Data().write(to: brokenFile)
+
+        let recording = TempVoiceRecording(
+            uuid: nil,
+            startDate: Date(timeIntervalSinceNow: -30),
+            endDate: Date(),
+            duration: 30,
+            fileRelativePath: "ignored/broken.m4a",
+            isEnhanced: false
+        )
+
+        let sanitized = WalkSessionGuard.sanitizeRecording(
+            recording,
+            fileURL: brokenFile
+        )
+        XCTAssertEqual(sanitized.fileRelativePath, "")
+        XCTAssertEqual(sanitized.duration, 30, accuracy: 0.1,
+                       "duration must be preserved for the Talk timer")
+    }
+
+    func test_sanitizeUnplayableRecordings_preservesPath_whenFilePlayable() throws {
+        // A regular finalized .m4a from a finished recording — we can't produce
+        // one cheaply in tests, so instead verify the sanitize function passes
+        // through any recording whose file reports duration > 0. We use a made-up
+        // path pointing nowhere and a duration-preserving stub helper.
+        let playable = TempVoiceRecording(
+            uuid: nil,
+            startDate: Date(),
+            endDate: Date().addingTimeInterval(5),
+            duration: 5,
+            fileRelativePath: "Recordings/ABC/rec.m4a",
+            isEnhanced: false
+        )
+
+        // Swap in a probe that reports > 0 so we exercise the pass-through branch.
+        let sanitized = WalkSessionGuard.sanitizeRecording(
+            playable,
+            fileURL: nil,  // nil => pass-through (no file check performed)
+            durationProbe: { _ in 5.0 }
+        )
+        XCTAssertEqual(sanitized.fileRelativePath, "Recordings/ABC/rec.m4a")
+    }
+```
+
+- [ ] **Step 2: Run test to verify failure**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/WalkSessionGuardRecoveryTests
+```
+
+Expected: compilation failure — `WalkSessionGuard.sanitizeRecording` doesn't exist.
+
+- [ ] **Step 3: Implement sanitizeRecording + wire into recoverIfNeeded**
+
+Add to `Pilgrim/Models/Walk/WalkSessionGuard.swift`, in the `// MARK: - Recovery` section, before `recoverIfNeeded`:
+
+```swift
+    /// Replaces a recording's file path with `""` (metadata-only) when the
+    /// underlying `.m4a` is unplayable — the canonical signature of an
+    /// AVAudioRecorder that was SIGKILL'd before `stop()` wrote its moov atom.
+    /// Duration is preserved so the Talk timer still reads correctly after
+    /// recovery; the walk summary row will show "Recording unavailable" and
+    /// suppress playback controls.
+    ///
+    /// Parameters:
+    /// - recording: the provisional recording from the checkpoint
+    /// - fileURL: absolute URL of the on-disk file. Pass `nil` to skip the
+    ///   disk check entirely (used in tests with the `durationProbe` param).
+    /// - durationProbe: returns the playable duration for a file. In
+    ///   production, defaults to `AVURLAsset(url:).duration` seconds.
+    ///   Override in tests to avoid AVFoundation dependencies.
+    static func sanitizeRecording(
+        _ recording: TempVoiceRecording,
+        fileURL: URL?,
+        durationProbe: (URL) -> Double = Self.defaultDurationProbe
+    ) -> TempVoiceRecording {
+        guard let fileURL else { return recording }
+
+        let playableSeconds = durationProbe(fileURL)
+        guard playableSeconds <= 0 else {
+            return recording
+        }
+
+        // File is unplayable: clear path + delete the on-disk corpse.
+        try? FileManager.default.removeItem(at: fileURL)
+
+        return TempVoiceRecording(
+            uuid: recording.uuid,
+            startDate: recording.startDate,
+            endDate: recording.endDate,
+            duration: recording.duration,
+            fileRelativePath: "",
+            transcription: nil,
+            wordsPerMinute: nil,
+            isEnhanced: false
+        )
+    }
+
+    private static func defaultDurationProbe(_ url: URL) -> Double {
+        let asset = AVURLAsset(url: url)
+        let seconds = CMTimeGetSeconds(asset.duration)
+        return seconds.isFinite ? seconds : 0
+    }
+```
+
+Then modify `recoverIfNeeded` to run sanitization over all recordings before saving. Find the block around line 255 (after `reconnectOrphanedRecordings(walk: walk, walkUUID: recordingDirUUID)`) and add:
+
+```swift
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let sanitized = walk.voiceRecordings.map { recording -> TempVoiceRecording in
+            guard !recording.fileRelativePath.isEmpty else { return recording }
+            let url = docs.appendingPathComponent(recording.fileRelativePath)
+            return sanitizeRecording(recording, fileURL: url)
+        }
+        walk.replaceVoiceRecordings(sanitized)
+```
+
+If `TempWalk` has no `replaceVoiceRecordings` method yet, add one to `Pilgrim/Models/Data/Temp/Versions/TempV4.swift` next to `replaceActivityIntervals` (line 155):
+
+```swift
+        public func replaceVoiceRecordings(_ recordings: [TempV4.VoiceRecording]) {
+            self._voiceRecordings = recordings
+        }
+```
+
+- [ ] **Step 4: Run the tests**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/WalkSessionGuardRecoveryTests
+```
+
+Expected: both new tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Models/Walk/WalkSessionGuard.swift Pilgrim/Models/Data/Temp/Versions/TempV4.swift UnitTests/WalkSessionGuardRecoveryTests.swift
+git commit -m "feat(walk): sanitize unplayable recordings during session recovery"
+```
+
+---
+
+## Task 4: Guard empty path in WalkSummary file-availability check
+
+**Files:**
+- Modify: `Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift:767-770`
+
+`FileManager.fileExists(atPath:)` returns `true` for directories. An empty `fileRelativePath` resolves to the Documents directory itself, which exists, which would cause the metadata-only row to try (and fail) to play. Guard the empty case explicitly.
+
+- [ ] **Step 1: Locate the current implementation**
+
+Read `Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift:765-772`. Expect something like:
+
+```swift
+    private func isFileAvailable(_ relativePath: String) -> Bool {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        return FileManager.default.fileExists(atPath: docs.appendingPathComponent(relativePath).path)
+    }
+```
+
+- [ ] **Step 2: Add the empty-string guard**
+
+Change to:
+
+```swift
+    private func isFileAvailable(_ relativePath: String) -> Bool {
+        guard !relativePath.isEmpty else { return false }
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask).first!
+        return FileManager.default.fileExists(atPath: docs.appendingPathComponent(relativePath).path)
+    }
+```
+
+- [ ] **Step 3: Manual UI verification**
+
+Enable demo mode and inject a metadata-only recording:
+
+1. Open a walk in the simulator's summary view.
+2. Use the debugger (`po`) to insert a `TempVoiceRecording` with `fileRelativePath = ""` into the walk's `voiceRecordings`, or temporarily wire a DEBUG-only seed.
+3. Verify the row renders with the `waveform.slash` icon and text "Recording unavailable", and that the duration still formats correctly.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+git commit -m "fix(summary): treat empty recording path as unavailable"
+```
+
+---
+
+## 🚨 CHECKPOINT: Ship Tasks 1–4, reproduce, verify
+
+Before starting Task 5, do this:
+
+1. Merge Tasks 1–4 to a TestFlight build.
+2. Install on the SE3 backup phone.
+3. Reproduce the crash: start a walk, tap Talk, lock the phone, walk for ~2 minutes until the CPU watchdog kills the app. Confirm via `Settings → Privacy → Analytics → Analytics Data` that a fresh `cpu_resource_fatal` was logged.
+4. Reopen the app. Verify:
+   - The walk is recovered (orange "Walk recovered" banner appears)
+   - The **Talk timer on the recovered walk reads the full duration** (e.g. 2:00, not 0:00) — this proves the checkpoint captured the in-flight talk
+   - The voice recording row in the walk summary shows "Recording unavailable" (expected — audio is unrecoverable without rotation) but the duration on the row is correct
+
+If recovery works as described, proceed to Task 5. If duration is still 0:00 or the row is missing entirely, diagnose before moving on.
+
+---
+
+## Task 5: Pause Mapbox when the user can't see it
+
+**Files:**
+- Modify: `Pilgrim/Views/PilgrimMapView.swift`
+- Modify: `Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift:537` (pass a new binding)
+
+Map should render at 30 FPS only when the user can plausibly see it. Two signals: app is in foreground AND no full-screen meditation overlay is up. Both come together through the `Coordinator`.
+
+- [ ] **Step 1: Add an `isMeditating` Binding parameter to PilgrimMapView**
+
+In `Pilgrim/Views/PilgrimMapView.swift`, add a new stored property near the other bindings (`@Binding var cameraCenter: CLLocationCoordinate2D?`):
+
+```swift
+    @Binding var isMeditating: Bool
+```
+
+Add it to the initializer parameter list with a default of `.constant(false)` so the other (non-active-walk) call sites don't break:
+
+```swift
+        isMeditating: Binding<Bool> = .constant(false),
+```
+
+And assign it in `init`:
+
+```swift
+        self._isMeditating = isMeditating
+```
+
+- [ ] **Step 2: Teach the Coordinator about "paused" state**
+
+In the `Coordinator` class at the bottom of `PilgrimMapView.swift`, add:
+
+```swift
+        /// True when the app is backgrounded (screen locked, home button, etc.)
+        fileprivate var isAppInBackground: Bool = false
+
+        /// True when a meditation full-screen cover is up.
+        var isMeditating: Bool = false {
+            didSet { refreshRenderState() }
+        }
+
+        /// Computes whether the map should be rendering now. `fileprivate` so
+        /// that `updateUIView` can read it to decide whether to defer a route
+        /// update.
+        fileprivate var shouldRender: Bool {
+            !isAppInBackground && !isMeditating
+        }
+
+        func startObservingAppLifecycle() {
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(handleDidEnterBackground),
+                name: UIApplication.didEnterBackgroundNotification,
+                object: nil
+            )
+            NotificationCenter.default.addObserver(
+                self,
+                selector: #selector(handleWillEnterForeground),
+                name: UIApplication.willEnterForegroundNotification,
+                object: nil
+            )
+        }
+
+        @objc private func handleDidEnterBackground() {
+            isAppInBackground = true
+            refreshRenderState()
+        }
+
+        @objc private func handleWillEnterForeground() {
+            isAppInBackground = false
+            refreshRenderState()
+        }
+
+        private func refreshRenderState() {
+            guard let mapView else { return }
+            mapView.preferredFramesPerSecond = shouldRender ? 30 : 0
+        }
+```
+
+Make sure the `Coordinator` removes its observers on deinit:
+
+```swift
+        deinit {
+            NotificationCenter.default.removeObserver(self)
+        }
+```
+
+(If the coordinator already has a `deinit`, add `NotificationCenter.default.removeObserver(self)` to it rather than creating a second one.)
+
+- [ ] **Step 3: Wire coordinator observers in `makeUIView` and mirror `isMeditating` in `updateUIView`**
+
+At the end of `makeUIView` (around line 136), after `context.coordinator.mapView = mapView`, call:
+
+```swift
+        context.coordinator.startObservingAppLifecycle()
+        context.coordinator.isMeditating = isMeditating
+```
+
+And at the top of `updateUIView` (line 139), propagate the binding:
+
+```swift
+    func updateUIView(_ mapView: MBMapView, context: Context) {
+        if context.coordinator.isMeditating != isMeditating {
+            context.coordinator.isMeditating = isMeditating
+        }
+        // ...existing body...
+    }
+```
+
+- [ ] **Step 4: Pass the binding from ActiveWalkView**
+
+In `Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift`, find the `PilgrimMapView(...)` call around line 537 and add the `isMeditating` binding. If `ActiveWalkView` already has `@ObservedObject var viewModel: ActiveWalkViewModel`, use:
+
+```swift
+        return PilgrimMapView(
+            // ...existing args...,
+            isMeditating: $viewModel.isMeditating
+        )
+```
+
+(`$viewModel.isMeditating` exposes a `Binding<Bool>` because `isMeditating` is `@Published`.)
+
+- [ ] **Step 5: Manual verification — background pause**
+
+1. Run the app on the SE3 backup phone, start a walk.
+2. Attach Xcode Instruments (CPU template).
+3. Lock the phone. Observe in Instruments that Pilgrim's CPU drops to near-zero within ~1 second.
+4. Unlock. Observe CPU returns to normal walk-rendering levels.
+5. Walk for 2+ minutes locked. Confirm NO `cpu_resource_fatal` is logged.
+
+- [ ] **Step 6: Manual verification — meditation pause**
+
+1. Start a walk in the foreground.
+2. Open Instruments (CPU template), note baseline Pilgrim CPU usage.
+3. Tap the meditation button to open the meditation full-screen cover.
+4. Confirm CPU drops noticeably (the Mapbox render loop should stop contributing).
+5. Exit meditation. Confirm CPU returns to baseline.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Pilgrim/Views/PilgrimMapView.swift Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift
+git commit -m "perf(map): pause Mapbox render loop when backgrounded or meditating"
+```
+
+---
+
+## Task 6: Skip GeoJSON source rebuilds while paused, catch up on resume
+
+**Files:**
+- Modify: `Pilgrim/Views/PilgrimMapView.swift` (Coordinator + `applyRouteSource`)
+
+Mapbox's `updateGeoJSONSourceFeatures` still triggers C++ tile invalidation work on the worker thread even when `preferredFramesPerSecond = 0`. When paused, queue the latest segments and flush on resume.
+
+- [ ] **Step 1: Queue pending segments on the Coordinator**
+
+In the `Coordinator` class, add alongside `pendingSegments`:
+
+```swift
+        /// True when we deferred at least one `applyRouteSource` call while paused.
+        fileprivate var hasDeferredRouteUpdate: Bool = false
+```
+
+- [ ] **Step 2: Gate `applyRouteSource` on render state**
+
+Find the static `applyRouteSource` function (around line 231) and the `updateUIView` call site that invokes it. Change `updateUIView` to check `context.coordinator.shouldRender` before applying:
+
+The `updateUIView` section that handles `pendingSegments` currently looks roughly like:
+```swift
+        context.coordinator.pendingSegments = routeSegments
+        // ...
+        Self.applyRouteSource(routeSegments, on: mapView, coordinator: context.coordinator)
+```
+
+Change it to:
+```swift
+        context.coordinator.pendingSegments = routeSegments
+        // ...
+        if context.coordinator.shouldRender {
+            Self.applyRouteSource(routeSegments, on: mapView, coordinator: context.coordinator)
+        } else {
+            context.coordinator.hasDeferredRouteUpdate = true
+        }
+```
+
+`shouldRender` is already `fileprivate` (from Task 5 Step 2), so `updateUIView` on the enclosing `PilgrimMapView` struct can read it directly without an extra accessor.
+
+- [ ] **Step 3: Flush on resume**
+
+In `refreshRenderState()` (from Task 5), after the `preferredFramesPerSecond` assignment, add a flush when transitioning from paused to rendering:
+
+```swift
+        private func refreshRenderState() {
+            guard let mapView else { return }
+            let previouslyRendering = mapView.preferredFramesPerSecond > 0
+            mapView.preferredFramesPerSecond = shouldRender ? 30 : 0
+
+            if shouldRender && !previouslyRendering && hasDeferredRouteUpdate {
+                PilgrimMapView.applyRouteSource(pendingSegments, on: mapView, coordinator: self)
+                hasDeferredRouteUpdate = false
+            }
+        }
+```
+
+- [ ] **Step 4: Manual verification — colors correct on resume**
+
+1. Start a walk.
+2. Walk a short distance in the foreground. Verify the route polyline draws as you go.
+3. Lock the phone. Walk for 30+ seconds (enough to generate new route samples).
+4. Mid-walk, tap the meditation button from lock screen — no, simpler: while locked, just keep walking.
+5. Unlock. The polyline should snap-update to include the entire locked-walk segment, colored correctly as "walking" (since you weren't meditating or talking).
+6. Repeat with an active Talk session: start Talk, lock phone, walk, unlock → polyline segment during lock period should be "talking" colored (based on whatever the design palette specifies).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Views/PilgrimMapView.swift
+git commit -m "perf(map): skip GeoJSON source rebuilds while renderer is paused"
+```
+
+---
+
+## 🚨 CHECKPOINT: Confirm crash is gone
+
+After Tasks 5–6 ship:
+
+1. Deploy to the SE3 backup phone.
+2. Start a walk + Talk, lock, walk for 5+ minutes.
+3. Confirm NO `cpu_resource_fatal` report appears in `Settings → Privacy → Analytics`.
+4. Confirm the walk completes normally (no SIGKILL, no recovery banner on reopen).
+
+Only after this checkpoint proceed to Task 7.
+
+---
+
+## Task 7: Stop recorder when the user answers a phone call
+
+**Files:**
+- Modify: `Pilgrim/Models/Walk/WalkBuilder/Components/VoiceRecordingManagement.swift`
+- Create: `UnitTests/VoiceRecordingCallInterruptionTests.swift`
+
+Rely on `CXCallObserver.hasConnected` (true only when a call is actively answered) rather than the generic audio-session interruption, so declined/missed calls and Siri don't end the recording.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `UnitTests/VoiceRecordingCallInterruptionTests.swift`:
+
+```swift
+import XCTest
+import CallKit
+@testable import Pilgrim
+
+final class VoiceRecordingCallInterruptionTests: XCTestCase {
+
+    func test_callChanged_stopsRecording_whenCallConnects() {
+        let builder = WalkBuilder()
+        let mgmt = VoiceRecordingManagement(builder: builder)
+        builder.setStatus(.recording)
+
+        mgmt._test_setActiveRecording(
+            start: Date(timeIntervalSinceNow: -10),
+            relativePath: "Recordings/X/rec.m4a"
+        )
+        XCTAssertTrue(mgmt.isRecording, "precondition: recording is active")
+
+        mgmt._test_simulateCallChanged(hasConnected: true, hasEnded: false)
+
+        XCTAssertFalse(mgmt.isRecording,
+                       "recording should stop the moment a call connects")
+    }
+
+    func test_callChanged_doesNothing_whenCallNotConnected() {
+        let builder = WalkBuilder()
+        let mgmt = VoiceRecordingManagement(builder: builder)
+        builder.setStatus(.recording)
+
+        mgmt._test_setActiveRecording(
+            start: Date(timeIntervalSinceNow: -10),
+            relativePath: "Recordings/X/rec.m4a"
+        )
+
+        // Incoming call ringing, not yet answered.
+        mgmt._test_simulateCallChanged(hasConnected: false, hasEnded: false)
+
+        XCTAssertTrue(mgmt.isRecording,
+                      "ringing / declined call must NOT end the recording")
+    }
+
+    func test_callChanged_doesNothing_whenNotRecording() {
+        let builder = WalkBuilder()
+        let mgmt = VoiceRecordingManagement(builder: builder)
+
+        // No active recording — this should never touch state or crash.
+        mgmt._test_simulateCallChanged(hasConnected: true, hasEnded: false)
+
+        XCTAssertFalse(mgmt.isRecording)
+    }
+}
+```
+
+- [ ] **Step 2: Register the test file in pbxproj**
+
+Add `UnitTests/VoiceRecordingCallInterruptionTests.swift` to the UnitTests target.
+
+- [ ] **Step 3: Run tests to verify compilation failure**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/VoiceRecordingCallInterruptionTests
+```
+
+Expected: compile error — `_test_simulateCallChanged` and the delegate hook don't exist.
+
+- [ ] **Step 4: Implement CXCallObserver integration**
+
+In `Pilgrim/Models/Walk/WalkBuilder/Components/VoiceRecordingManagement.swift`:
+
+Add to the top:
+
+```swift
+import CallKit
+```
+
+Inside the class body, add a `CXCallObserver` property and initializer hook. Because `VoiceRecordingManagement` already has `required init(builder:)`, extend it:
+
+```swift
+    private let callObserver: CXCallObserver = CXCallObserver()
+```
+
+At the end of `init(builder:)` (after `builder.registerPreSnapshotFlush { ... }`):
+
+```swift
+        callObserver.setDelegate(self, queue: .main)
+```
+
+Conform the class to `CXCallObserverDelegate` via an extension at the bottom of the file:
+
+```swift
+extension VoiceRecordingManagement: CXCallObserverDelegate {
+    public func callObserver(_ observer: CXCallObserver, callChanged call: CXCall) {
+        handleCallStateChange(hasConnected: call.hasConnected, hasEnded: call.hasEnded)
+    }
+
+    private func handleCallStateChange(hasConnected: Bool, hasEnded: Bool) {
+        guard hasConnected, !hasEnded, isRecording else { return }
+        stopRecording()
+    }
+
+    #if DEBUG
+    func _test_simulateCallChanged(hasConnected: Bool, hasEnded: Bool) {
+        handleCallStateChange(hasConnected: hasConnected, hasEnded: hasEnded)
+    }
+    #endif
+}
+```
+
+- [ ] **Step 5: Run tests to verify pass**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/VoiceRecordingCallInterruptionTests
+```
+
+Expected: all three tests pass.
+
+- [ ] **Step 6: Manual verification — real phone call**
+
+1. Install on a physical device (required — CXCallObserver doesn't observe simulator calls).
+2. Start a walk, tap Talk.
+3. Have someone call the device. Watch the UI: the Talk button should flip back to idle immediately when you tap answer. The walk continues.
+4. Hang up. Confirm the walk is still running and the previous recording is saved (visible on summary if you stop the walk).
+5. Tap Talk again to resume recording. Confirm a second recording starts cleanly.
+6. Repeat but this time *decline* the call. Confirm the recording continues uninterrupted (the few seconds of ringing are auto-paused by iOS; recording resumes cleanly when the ringing ends).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Pilgrim/Models/Walk/WalkBuilder/Components/VoiceRecordingManagement.swift UnitTests/VoiceRecordingCallInterruptionTests.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat(walk): stop recording when a phone call is answered"
+```
+
+---
+
+## Self-Review Checklist (for the implementer)
+
+After completing all tasks:
+
+- [ ] Every new method on `VoiceRecordingManagement` has a matching unit test
+- [ ] `WalkCheckpoint.schemaVersion` was NOT bumped (we reused existing fields — deliberate)
+- [ ] `Pilgrim.xcodeproj/project.pbxproj` was updated for all 3 new test files
+- [ ] CPU crash repro on SE3 no longer produces `cpu_resource_fatal` after Tasks 5–6
+- [ ] Talk timer shows correct duration after forced SIGKILL (e.g. `kill -9` via `lldb` during a debug-attached walk)
+- [ ] Phone call handling tested on a physical device, both answer and decline paths
+- [ ] No new background timers added (rotation was rejected — verify)
+- [ ] `willTerminate` observer NOT added (rejected — verify)
+- [ ] Memory profile in Instruments during a 10-minute walk+talk+lock is flat (no leaks introduced)
+
+---
+
+## Out of Scope (Deliberately Rejected)
+
+These were considered and rejected during planning:
+
+- **30-second recorder rotation** — audio-gap UX cost at every boundary not worth the resilience gain; user prioritized walk preservation over audio recovery
+- **`UIApplication.willTerminateNotification` observer** — fires for essentially zero of our termination paths (CPU watchdog, jetsam, swipe-kill all bypass it); near-zero ROI for a real maintenance surface
+- **Generic `AVAudioSession.interruptionNotification` handling for recording** — too aggressive; would stop recording on every Siri trigger, banner notification, or declined call. CXCallObserver is the discriminating signal we want.
+- **`WalkCheckpoint` schema bump / new fields** — not needed; the provisional `TempVoiceRecording` we append already encodes everything we need via its existing fields (path + start + duration)
+- **Rebuilding Mapbox route polyline on every GPS sample while backgrounded** — Task 6 is explicitly the decision to *not* do this

--- a/docs/superpowers/specs/2026-04-22-four-turnings-design.md
+++ b/docs/superpowers/specs/2026-04-22-four-turnings-design.md
@@ -1,0 +1,225 @@
+# Four Turnings — Design Spec
+
+## Summary
+
+Acknowledge the four astronomical turning points of the year — the two solstices and two equinoxes — with quiet, distributed touches across Pilgrim: a banner on the home ink-scroll, a permanent scroll-margin glyph marking today forever, a faint kanji watermark during the walk itself, a walking-segment route color, a sunrise-azimuth ray on the live map, and a kanji suffix on the walk summary's date title.
+
+No badges. No push notifications. No achievements. The app simply knows when the sun stands still or balance returns, and marks the day lightly.
+
+## Motivation
+
+Pilgrim is a walking-as-practice app. The solstices and equinoxes are the oldest spiritual walking days in human history — Stonehenge alignments, Newgrange's dawn chamber, Camino peaks at Mid-Summer, Shinto equinox visits to ancestral graves. The app already has the vocabulary for celestial time (lunar markers in the ink scroll, a `CelestialCalculator`, a seasonal color palette for the ink). It has been quietly waiting for this.
+
+The goal is *not* to call attention to itself on these four days. The goal is for the user — if they happen to walk on a turning — to sense that the day matters, through peripheral visual details that feel like the app has always known. Users who walk every turning accumulate a permanent, beautiful marked history over years.
+
+## Non-Goals (for v1)
+
+- The Four Seals / goshuin-style collection for completing all four turnings in a year (deferred)
+- Turning of the Wheel annual mandala visualization (deferred)
+- Sunrise-alignment challenge or walking-window suggestions (deferred)
+- Collective global simultaneous-walk feature on solstice (deferred)
+- Weather-aware whisper variants on turning days (deferred)
+- Year-in-walks compendium artifact (deferred)
+- Day-of special whispers from the R2 catalog (deferred — possible v1.1 add)
+- User-facing hemisphere setting (v1 auto-detects from walk history)
+
+## Design
+
+### Date Computation
+
+A turning day is the **local calendar date** containing the astronomical moment of that year's solstice or equinox. The moment varies year to year (e.g., December solstices fall between Dec 20–22).
+
+Pilgrim already has `CelestialCalculator` in the codebase (referenced by `CelestialCalculatorTests` in the unit test target). It must support — or be extended to support — these two queries:
+
+- `solsticesAndEquinoxes(forYear: Int) -> [Date]` — returns the 4 astronomical moments for a given Gregorian year. Used to determine whether today is a turning day.
+- `sunriseAzimuth(at: CLLocationCoordinate2D, on: Date) -> CLLocationDirection?` — the compass azimuth (degrees from true north) where the sun rises on a given date at a given location. Nil at poles where the sun doesn't rise. Used for the sunrise-azimuth ray on the active walk map.
+
+Detection happens at runtime each time the feature is queried: "does today's local date contain one of the 4 astronomical moments for this year?" If yes, we know which turning it is.
+
+### Hemisphere Handling
+
+The kanji 冬至 literally means *winter solstice*. For a user in Sydney, the December solstice is their *summer* solstice — so mapping the December astronomical moment to 冬至 is wrong for them.
+
+The app detects the user's hemisphere from their **most recent walk's starting coordinate**. If the latitude is negative, hemisphere is southern; otherwise northern. If no walks exist yet (new user), default to northern.
+
+For southern-hemisphere users, the kanji and seasonal labels are mirrored:
+
+| Astronomical moment | Northern-hemisphere kanji & label | Southern-hemisphere kanji & label |
+|---|---|---|
+| March equinox | 春分 / Spring equinox | 秋分 / Autumn equinox |
+| June solstice | 夏至 / Summer solstice | 冬至 / Winter solstice |
+| September equinox | 秋分 / Autumn equinox | 春分 / Spring equinox |
+| December solstice | 冬至 / Winter solstice | 夏至 / Summer solstice |
+
+The color palette maps to the *seasonal* kanji, not the astronomical month. So a southern-hemisphere user on December solstice sees the **summer-solstice gold**, not the winter blue.
+
+No user-facing hemisphere setting is exposed in v1. The auto-detect is good enough for shipping; if it misfires, users can course-correct by walking once in their current location.
+
+### Color Palette
+
+Four new colors, all tuned to match the existing wabi-sabi muted palette (saturations comparable to `moss`, `rust`, `dawn`):
+
+| Turning (kanji) | Color name | Approximate hex | Character |
+|---|---|---|---|
+| **春分** Spring equinox | `turningJade` | `#74B495` | muted jade — thaw, balance |
+| **夏至** Summer solstice | `turningGold` | `~#C9A646` | dusty honey-gold — peak light |
+| **秋分** Autumn equinox | `turningClaret` | `~#8B4455` | muted wine — harvest, moon festival |
+| **冬至** Winter solstice | `turningIndigo` | `#2377A4` | dusty blue — longest night |
+
+Final hex values are to be fine-tuned during implementation against the rendered parchment background and the existing activity colors. The spec-level commitment is the *character* and *saturation level* — each color must sit at or below the saturation of `moss`/`rust`/`dawn` to preserve the wabi-sabi restraint.
+
+**Autumn's claret** is intentionally chosen over the instinctive "orange" to avoid collision with `rust` (talking) and `dawn` (meditating), both of which are orange-family warms.
+
+### Home: InkScrollView
+
+Two additions to `InkScrollView`:
+
+1. **Turning-day banner** inside `journeySummaryHeader` (the existing top-of-scroll summary). On a turning day, a single line appears above the existing summary content:
+
+   > *Today the sun stands still · 冬至*
+
+   The copy varies per turning:
+   - Solstices: *"Today the sun stands still · [kanji]"*
+   - Equinoxes: *"Today, day equals night · [kanji]"*
+
+   The kanji is rendered in the turning's color. The text uses `Constants.Typography.body` or `.caption` (implementation choice; probably body). The banner fades out at local midnight when the turning day ends.
+
+2. **Scroll-margin glyph** — a new extension file `InkScrollView+TurningMarkers.swift`, mirroring the pattern of `InkScrollView+LunarMarkers.swift`. For every day in the user's walk history that was a turning day, a faint kanji glyph is drawn in the scroll's margin at that row's vertical position. Permanent. A user scrolling through 3 years of history sees 12 kanji glyphs scattered through their scroll — a visual timeline of the turnings they were present for.
+
+3. **Segment/dot color override** — the existing `pathSegmentColor(index:)` logic gains a conditional: if the segment's walk fell on a turning day, the color is overridden to that turning's color (at slightly softened opacity so it blends into the scroll's overall palette rather than popping).
+
+### Active Walk
+
+Three layered changes to the active walk scene:
+
+1. **Kanji watermark** — a faint character positioned at bottom-center of the map, just above where the collapsed stats sheet peeks. `Color.stone.opacity(0.15–0.2)`, approximately 12pt, using the kanji for today's turning. Renders only on turning days. Placed as an overlay on the map, does not interact, does not scroll.
+
+2. **Walking-route color override** — the Mapbox route layer at `PilgrimMapView.swift:273–281` currently uses a match expression on `activityType`: `meditating` → `dawn`, `talking` → `rust`, default → `moss`. On turning days, the default (walking) branch is replaced with the turning's color. Meditation and talking colors are unchanged, preserving activity-type legibility.
+
+3. **Sunrise-azimuth ray** — a faint line drawn from the user's location puck outward in the compass direction of today's sunrise. Length approximately 150pt in screen space (rendered in map-projection coordinates so it scales with zoom), opacity ~0.15, fading to transparent at the tip. Uses `CelestialCalculator.sunriseAzimuth(at:on:)` with the user's current coordinate and today's date.
+
+   The ray is static for the whole turning day (doesn't rotate with time — the azimuth is a daily fact, not a moment-to-moment one). If the user moves to a meaningfully different latitude mid-walk (rare), it could be recomputed; for v1, compute once at walk start and leave fixed.
+
+   The ray should use the turning's color at higher transparency, so it coheres with the route color visually.
+
+### Post-Walk Summary
+
+Two additions to `WalkSummaryView`:
+
+1. **Date title kanji suffix** — the existing `dateTitleFormatted` string becomes:
+
+   > *March 20, 2026 · 春分*
+
+   when the walk fell on a turning day. Kanji rendered in the turning's color, same font size as the rest of the title (Constants.Typography.heading, probably).
+
+2. **Route color** — the summary map uses the same route-layer expression as the active walk, so walking segments on a turning-day walk are already drawn in the turning color. No separate wiring needed beyond the `PilgrimMapView` change; the summary view reuses the same component.
+
+**Not in the summary**: the sunrise-azimuth ray. The ray is a live-walk feature — it orients the user in the moment. The archival summary doesn't need it.
+
+### Shared HTML Page (pilgrim-worker handoff)
+
+Out of scope for this iOS spec, but flagging the handoff contract so the worker PR can follow cleanly:
+
+- The walk share payload gets a new optional field: `turningDay: "winter-solstice" | "spring-equinox" | "summer-solstice" | "autumn-equinox" | null`.
+- The iOS app populates it when calling `ShareService.share(...)` using the same detection logic as the rest of the feature.
+- The worker's HTML template checks for the field. If present, renders the route color using a matching palette and places the kanji near the date header on the hosted page.
+- Worker-side changes tracked as a follow-up; iOS ships the payload field even if the worker doesn't consume it yet (forward-compatibility).
+
+## Technical Architecture
+
+### New Types
+
+- **`TurningDay`** — enum in `Pilgrim/Models/` with cases `.springEquinox`, `.summerSolstice`, `.autumnEquinox`, `.winterSolstice`. Methods:
+  - `static func forDate(_ date: Date, hemisphere: Hemisphere) -> TurningDay?` — returns the turning if the date is one, accounting for hemisphere (the same astronomical moment maps to different turnings in north vs south).
+  - `var kanji: String` — "春分" / "夏至" / "秋分" / "冬至"
+  - `var label: String` — "Spring equinox" / "Summer solstice" / etc.
+  - `var bannerText: String` — *"Today, day equals night"* or *"Today the sun stands still"*
+  - `var color: Color` — the walking-segment color for this turning
+
+- **`Hemisphere`** — simple enum `.northern / .southern`, derived from `CLLocationCoordinate2D.latitude`.
+
+- **`TurningDayService`** (or similar helper) — caches the 4 astronomical moments for the current year so we don't recompute on every view body evaluation. Invalidates at year boundary.
+
+### CelestialCalculator Extensions
+
+Two new public methods (add to the existing class):
+
+- `solsticesAndEquinoxes(forYear year: Int) -> [Date]` — uses standard astronomical formulas (Jean Meeus *Astronomical Algorithms* chapter 27 for equinox/solstice times). Returns 4 dates in UTC.
+- `sunriseAzimuth(at coordinate: CLLocationCoordinate2D, on date: Date) -> CLLocationDirection?` — computes the compass bearing of sunrise. Combines the sun's declination on the date with the observer's latitude using the sunrise-azimuth formula. Returns nil at extreme latitudes where the sun doesn't rise.
+
+### File Touch List
+
+**New files:**
+- `Pilgrim/Models/TurningDay.swift` — the enum + helpers
+- `Pilgrim/Models/TurningDayService.swift` — caching + hemisphere detection
+- `Pilgrim/Scenes/Home/InkScrollView+TurningMarkers.swift` — scroll-margin glyph rendering
+- `Pilgrim/Support Files/Assets.xcassets/turningJade.colorset/` (and three more) — the 4 new color assets, each with light and dark variants
+- `UnitTests/TurningDayTests.swift` — date detection, hemisphere mapping, edge cases
+- `UnitTests/CelestialCalculatorSolsticeTests.swift` — accuracy of solstice/equinox dates and sunrise azimuth within reasonable tolerance against known reference data
+
+**Modified files:**
+- `Pilgrim/Scenes/Home/InkScrollView.swift` — `journeySummaryHeader` gets the conditional banner; `pathSegmentColor(index:)` gains turning-day override
+- `Pilgrim/Scenes/Home/HomeView.swift` — may need to thread the turning info into InkScrollView (if the service lives higher up)
+- `Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift` — adds kanji watermark + sunrise-ray overlay
+- `Pilgrim/Views/PilgrimMapView.swift` — route color match expression gains turning-day branch; new overlay layer for the sunrise ray
+- `Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift` — date title suffix
+- `Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift` + `ShareService.swift` — adds `turningDay` to the share payload (forward-compatible)
+- `Pilgrim/Models/Astronomy/CelestialCalculator.swift` (or wherever it lives) — the two new methods
+
+## Accessibility
+
+- **VoiceOver**: the home banner reads the full label ("Today, day equals night. Autumn equinox."). The kanji watermark and scroll-margin glyphs are marked `.accessibilityHidden(true)` — they're decorative. The date title suffix *is* read, rendering as "March 20, 2026, Spring equinox" for VoiceOver rather than the raw kanji.
+- **Dynamic Type**: the home banner and date suffix scale with Dynamic Type; the kanji watermark is a fixed decorative element (scaling it would break layout).
+- **Reduce Motion**: no motion in this feature to reduce. The banner fade at midnight is a date-based state change, not an animation.
+- **Color contrast**: each of the 4 turning colors will be verified against the parchment background for WCAG AA contrast in both light and dark modes. Dark-mode variants of each color are required in the Asset Catalog.
+
+## Test Plan
+
+### Unit tests
+
+1. `TurningDay.forDate(_:hemisphere:)` — returns the correct turning for known historical dates (e.g., 2024-06-20 is summer solstice in Northern, winter in Southern).
+2. `TurningDay.forDate(_:hemisphere:)` returns nil for non-turning dates.
+3. Hemisphere detection: positive latitude → .northern, negative → .southern, zero → .northern (arbitrary but consistent).
+4. `CelestialCalculator.solsticesAndEquinoxes(forYear:)` — each returned date falls within ±1 day of published astronomical references for that year.
+5. `CelestialCalculator.sunriseAzimuth(at:on:)` — returns ~90° (due east) at the equator on equinox, returns extreme values at high latitudes on solstice, returns nil above the arctic circle on winter solstice.
+6. Cross-year: a year boundary during a walk does not crash the service; cache invalidates cleanly.
+
+### Manual checks
+
+1. Launch on a non-turning day — no banner, no watermark, no margin glyph, default route color. Regression check.
+2. Simulate a turning day by stubbing the system date (or a debug launch arg) — verify:
+   - Home screen shows the banner and margin glyph at today's scroll position
+   - Starting a walk shows the kanji watermark at bottom-center and the sunrise-azimuth ray from the puck
+   - Walking segments render in the turning color; meditation stays dawn, talking stays rust
+   - Finishing the walk shows the kanji-suffixed date in the summary and the turning-color route
+3. Hemisphere test: simulate a walk at latitude -33 (Sydney), then simulate June solstice — verify the app shows 冬至 (winter) not 夏至 (summer). Reset.
+4. Dark mode: each of the 4 colors renders correctly against dark parchment; no halo/inversion issues.
+5. VoiceOver: banner, date title, and scroll-margin glyphs read as expected.
+6. A walk that *crosses* local midnight from a turning day into a non-turning day: the walk is recorded as a turning-day walk because the walk's start date was the turning day. Verify this tie-breaker in the helper.
+
+### Edge cases
+
+- Polar user on winter solstice: sunrise azimuth is nil — the sunrise-azimuth ray simply isn't drawn. No crash.
+- Year boundary: a walk starting at 23:55 on December 31 of a turning year should still register the turning-day classification even though most of the walk is in the following year.
+- User with no walk history: hemisphere defaults to northern. First walk anywhere establishes hemisphere going forward.
+- User who moves hemispheres (traveler): hemisphere updates based on most-recent-walk coordinate. Their next turning-day walk in the new hemisphere shows the correct kanji. No backfill of historical walks (those stay as they were classified at the time).
+
+## Decisions & Tradeoffs
+
+- **No push notifications.** Requires permission, risks noise. The home-screen banner rewards users who open the app; users who don't, don't miss anything bad (the turning day just passes quietly — which is arguably true to the contemplative nature).
+- **Hemisphere auto-detect from walk history over user-facing setting.** Fewer settings = less friction. If it misfires, users course-correct by walking once in their actual location. A hemisphere setting can be added in v1.1 if the auto-detect proves unreliable in practice.
+- **Kanji over western text.** 春分/夏至/秋分/冬至 are visually elegant and part of a long walking-meditation tradition. VoiceOver reads the English label, so accessibility is preserved.
+- **Claret for autumn, not orange.** Deliberately avoids hue-collision with `rust` (talking) and `dawn` (meditating). East Asian autumn-moon-festival motifs support wine/purple; the app's existing vocabulary accepts it.
+- **Walking-segment color override only.** Meditation and talking keep their existing colors so activity-type legibility survives. The turning is carried by walking — which is most of a walk — which is enough signal.
+- **Scroll-margin glyph is permanent.** Users who walk many turnings accumulate a long-term artifact in their history. This is the feature's long-tail reward.
+- **Sunrise azimuth, not sunset.** Only one ray to avoid visual clutter. Sunrise is the more-walked time (especially in summer). Sunset rays could be added in v1.1 as an enhancement if users want them.
+- **Turning-color applies to shared HTML too.** Preserves visual continuity across surfaces (active walk → summary → shared page). Requires a small payload change and worker-side follow-up.
+- **No achievement/badge/streak framing.** Pilgrim is not that kind of app.
+
+## Open Questions (for implementation)
+
+- Exact hex values for the 4 colors (light + dark mode variants) — tune against the rendered parchment background during implementation.
+- Exact font size and position of the kanji watermark on the active walk — depends on the stats sheet's current peek height, which varies. Position relative to the sheet, not absolute.
+- Sunrise-azimuth ray rendering: Mapbox line annotation vs. custom `MapOverlay` vs. a SwiftUI overlay that does its own projection — implementation choice. The line annotation approach is probably simplest.
+- Caching strategy for `solsticesAndEquinoxes(forYear:)` — in-memory is fine; 4 dates per year is trivial. Invalidate on year boundary.
+- Whether the home banner copy should vary year to year or stay static — v1: static per-turning copy is fine.

--- a/docs/superpowers/specs/2026-04-22-four-turnings-design.md
+++ b/docs/superpowers/specs/2026-04-22-four-turnings-design.md
@@ -2,7 +2,7 @@
 
 ## Summary
 
-Acknowledge the four astronomical turning points of the year — the two solstices and two equinoxes — with quiet, distributed touches across Pilgrim: a banner on the home ink-scroll, a permanent scroll-margin glyph marking today forever, a faint kanji watermark during the walk itself, a walking-segment route color, a sunrise-azimuth ray on the live map, and a kanji suffix on the walk summary's date title.
+Acknowledge the four astronomical turning points of the year — the two solstices and two equinoxes — with quiet, distributed touches across Pilgrim: a banner on the home ink-scroll, a permanent inline kanji marker on the user's walk history, a faint kanji watermark during the walk itself, a walking-segment route color, a sunrise-azimuth ray on the live map, a kanji suffix on the walk summary's date title, and a matching seal color so the goshuin collection encodes the rhythm of turnings walked.
 
 No badges. No push notifications. No achievements. The app simply knows when the sun stands still or balance returns, and marks the day lightly.
 
@@ -136,6 +136,33 @@ Two additions to `WalkSummaryView`:
 
 **Not in the summary**: the sunrise-azimuth ray. The ray is a live-walk feature — it orients the user in the moment. The archival summary doesn't need it.
 
+### Goshuin Seal Color
+
+For walks that fell on a turning day, the goshuin seal's color is locked to that turning's color — the **same hex values** used for the route. This creates a color thread running from the live route → the summary route → the shared page route → the seal revealed post-walk → the seal in the goshuin collection → the exported PNG.
+
+The seal palette at `SealColorPalette.swift` currently picks from 4 curated categories (warm/cool/accent/neutral) based on the walk's favicon + a hash byte. The turning check is a **pre-check that bypasses that curation** on turning days:
+
+```swift
+static func uiColor(for input: SealInput) -> UIColor {
+    if let turning = TurningDayService.turning(
+        for: input.startDate,
+        at: input.routePoints.first.map { CLLocationCoordinate2D(latitude: $0.lat, longitude: $0.lon) }
+    ), let sealColor = turning.sealColor {
+        return sealColor.resolvedColor(for: currentTrait)
+    }
+    return uiColor(for: favicon, hashByte: bytes[30])  // existing logic
+}
+```
+
+Four new `SealColor` entries are added to `SealColorPalette`, with the same hex values as the route palette (jade / gold / claret / indigo) plus their dark-mode variants. They are **not** included in the `warmColors` / `coolColors` / `accentColors` / `neutralColors` arrays — they exist only as turning-day overrides. New CSS vars (`--seal-turning-jade`, etc.) are declared so the hosted share page can render matching-colored seals after the worker follow-up.
+
+**Touchpoints where the seal color is seen:**
+- `SealRevealView` — post-walk reveal animation uses the turning color
+- `GoshuinView` — the collection view renders turning-day seals in their turning color
+- `SealGenerator.generate(from:size:)` — the exported PNG bakes the color in, so a seal shared via the Goshuin social-share button carries the turning color outside the app
+
+Because `SealInput` already carries `startDate` and `routePoints` (first point = starting coordinate for hemisphere), no new data needs to flow into `SealGenerator` — the turning override is computed from existing input.
+
 ### Shared HTML Page (pilgrim-worker handoff)
 
 Out of scope for this iOS spec, but flagging the handoff contract so the worker PR can follow cleanly:
@@ -166,7 +193,8 @@ In a new file `Pilgrim/Models/Astrology/SeasonalMarker+Turnings.swift`:
 
 - `var kanji: String?` — "春分" / "夏至" / "秋分" / "冬至" for the 4 turnings; nil for the cross-quarter days (which this feature doesn't surface).
 - `var bannerText: String?` — *"Today, day equals night"* (equinoxes) or *"Today the sun stands still"* (solstices); nil for cross-quarter. Localized via `LS.swift`.
-- `var color: Color?` — the walking-segment override color; nil for cross-quarter.
+- `var color: Color?` — the walking-segment override color (jade / gold / claret / indigo); nil for cross-quarter.
+- `var sealColor: SealColor?` — the `SealColorPalette.SealColor` entry to use for the goshuin seal on this turning, matching the route color exactly (same hex); nil for cross-quarter.
 - `var isTurning: Bool` — true iff the case is one of the 4 main turnings.
 
 VoiceOver-accessible label uses the existing `name` property ("Spring Equinox" etc.), which needs to flow through `LS.swift` for localization.
@@ -195,6 +223,8 @@ VoiceOver-accessible label uses the existing `name` property ("Spring Equinox" e
 - `Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift` — `dateTitleFormatted` appends kanji for turning-day walks
 - `Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift` + `ShareService.swift` — adds `turningDay` to the share payload (forward-compatible; worker doesn't need to consume it immediately)
 - `Pilgrim/Models/LS.swift` — new localized strings for banner copy and VoiceOver labels
+- `Pilgrim/Models/Seal/SealColorPalette.swift` — 4 new `SealColor` entries (`turningJade`, `turningGold`, `turningClaret`, `turningIndigo`) with matching CSS vars; new `uiColor(for input: SealInput)` entry point that pre-checks for turning day before falling back to the existing favicon/hash selection
+- `Pilgrim/Models/Seal/SealGenerator.swift:44` — call site updated from `uiColor(for: favicon, hashByte:)` to `uiColor(for: input)` so turning detection runs automatically
 
 **Unchanged (but noted):**
 - `Pilgrim/Models/LightReading/LightReadingGenerator.swift` — already surfaces seasonal-marker readings on turning days. No changes needed. The Four Turnings feature layers visual acknowledgments on top of this existing textual one.
@@ -216,6 +246,8 @@ VoiceOver-accessible label uses the existing `name` property ("Spring Equinox" e
 4. `SeasonalMarker.kanji` / `.bannerText` / `.color` return correct values for the 4 turnings and nil for cross-quarter cases.
 5. `CelestialCalculator.sunriseAzimuth(at:on:)` — returns ~90° (due east) at the equator on equinox, returns extreme values at high latitudes on solstice (e.g., ~128° summer solstice at 60° N), returns nil above the arctic circle on winter solstice.
 6. Walk spanning local midnight: a walk starting at 23:55 on a turning day remains classified as a turning-day walk even though most of its route is recorded the next day (classification uses start date).
+7. `SealColorPalette.uiColor(for: SealInput)` — on a turning-day input, returns the turning's seal color regardless of the walk's favicon or hash byte. Same input without a turning-day date returns the existing favicon/hash color (regression check).
+8. Seal color dark-mode variant: each of the 4 new `SealColor` entries returns the correct dark-mode hex when resolved against a dark trait collection.
 
 ### Manual checks
 
@@ -247,6 +279,7 @@ VoiceOver-accessible label uses the existing `name` property ("Spring Equinox" e
 - **Scroll-margin glyph is permanent.** Users who walk many turnings accumulate a long-term artifact in their history. This is the feature's long-tail reward.
 - **Sunrise azimuth, not sunset.** Only one ray to avoid visual clutter. Sunrise is the more-walked time (especially in summer). Sunset rays could be added in v1.1 as an enhancement if users want them.
 - **Turning-color applies to shared HTML too.** Preserves visual continuity across surfaces (active walk → summary → shared page). Requires a small payload change and worker-side follow-up.
+- **Goshuin seal color matches the route color on turning days.** The seal is the most distilled artifact of a walk; locking its color to the turning extends the color thread all the way to the user's accumulated goshuin collection. Over years, a user's collection visually encodes the rhythm of the turnings they walked. This deliberately **bypasses the seal palette's favicon-character curation** — on a turning day the cosmic event trumps the walk's personal character. Non-turning walks still use the existing favicon/hash logic unchanged.
 - **No achievement/badge/streak framing.** Pilgrim is not that kind of app.
 
 ## Open Questions (for implementation)

--- a/docs/superpowers/specs/2026-04-22-four-turnings-design.md
+++ b/docs/superpowers/specs/2026-04-22-four-turnings-design.md
@@ -27,24 +27,34 @@ The goal is *not* to call attention to itself on these four days. The goal is fo
 
 ### Date Computation
 
-A turning day is the **local calendar date** containing the astronomical moment of that year's solstice or equinox. The moment varies year to year (e.g., December solstices fall between Dec 20–22).
+A turning day is a day on which the sun's ecliptic longitude passes one of the four cardinal angles (0°, 90°, 180°, 270°).
 
-Pilgrim already has `CelestialCalculator` in the codebase (referenced by `CelestialCalculatorTests` in the unit test target). It must support — or be extended to support — these two queries:
+**The existing codebase already has what we need.** `Pilgrim/Models/Astrology/CelestialCalculator.swift` exposes:
 
-- `solsticesAndEquinoxes(forYear: Int) -> [Date]` — returns the 4 astronomical moments for a given Gregorian year. Used to determine whether today is a turning day.
-- `sunriseAzimuth(at: CLLocationCoordinate2D, on: Date) -> CLLocationDirection?` — the compass azimuth (degrees from true north) where the sun rises on a given date at a given location. Nil at poles where the sun doesn't rise. Used for the sunrise-azimuth ray on the active walk map.
+- `CelestialCalculator.seasonalMarker(sunLongitude: Double) -> SeasonalMarker?` — returns a case of the existing `SeasonalMarker` enum (`.springEquinox`, `.summerSolstice`, `.autumnEquinox`, `.winterSolstice`, plus 4 cross-quarter days we won't use) if the sun's longitude is within 1.5° of a cardinal angle, else nil.
+- `CelestialCalculator.snapshot(for: Date) -> CelestialSnapshot` — returns a snapshot whose `seasonalMarker: SeasonalMarker?` field is already populated. This is how existing code (`LightReadingGenerator`) detects turning days.
 
-Detection happens at runtime each time the feature is queried: "does today's local date contain one of the 4 astronomical moments for this year?" If yes, we know which turning it is.
+**Detection is already a one-liner:** `CelestialCalculator.snapshot(for: date).seasonalMarker`. We don't need a new `solsticesAndEquinoxes(forYear:)` method.
+
+**Only one new `CelestialCalculator` method is required:**
+
+- `sunriseAzimuth(at: CLLocationCoordinate2D, on: Date) -> CLLocationDirection?` — the compass azimuth (degrees from true north) where the sun rises on a given date at a given location. Nil at polar latitudes where the sun doesn't rise. Used only for the sunrise-azimuth ray on the active walk map.
+
+**Note on existing user-facing touchpoint:** the app already surfaces seasonal markers via the `LightReading` system (see `LightReadingGenerator.swift:91–95`) — a ~4% chance of a seasonal-marker-themed reading on turning days. That feature continues unchanged. The Four Turnings visual language (banner, inline markers, route color, ray, kanji) stacks on top of it; the two channels are independent and complementary.
 
 ### Hemisphere Handling
 
 The kanji 冬至 literally means *winter solstice*. For a user in Sydney, the December solstice is their *summer* solstice — so mapping the December astronomical moment to 冬至 is wrong for them.
 
-The app detects the user's hemisphere from their **most recent walk's starting coordinate**. If the latitude is negative, hemisphere is southern; otherwise northern. If no walks exist yet (new user), default to northern.
+**Hemisphere is determined per-context, not globally:**
 
-For southern-hemisphere users, the kanji and seasonal labels are mirrored:
+- **For today's banner** (and any "right now" query): use the hemisphere of the user's **most recent walk's starting coordinate**. Positive latitude → northern, negative → southern. If no walks exist (new user), default to northern.
+- **For a historical walk** (inline scroll marker, summary date-suffix, route color on archived walks): use the hemisphere of **that specific walk's starting coordinate**. This way, a user who walks in Bogotá two years ago then moves to Sydney still sees their Bogotá walks classified as northern-hemisphere at the time, and new Sydney walks as southern. No re-writing history.
+- **For the active walk mid-session**: use the hemisphere of the walk's first captured location sample. If the user somehow crosses the equator mid-walk (rare), the classification doesn't change.
 
-| Astronomical moment | Northern-hemisphere kanji & label | Southern-hemisphere kanji & label |
+The Astronomical Moment → Hemisphere-Specific Turning mapping:
+
+| Astronomical moment | Northern hemisphere | Southern hemisphere |
 |---|---|---|
 | March equinox | 春分 / Spring equinox | 秋分 / Autumn equinox |
 | June solstice | 夏至 / Summer solstice | 冬至 / Winter solstice |
@@ -53,7 +63,9 @@ For southern-hemisphere users, the kanji and seasonal labels are mirrored:
 
 The color palette maps to the *seasonal* kanji, not the astronomical month. So a southern-hemisphere user on December solstice sees the **summer-solstice gold**, not the winter blue.
 
-No user-facing hemisphere setting is exposed in v1. The auto-detect is good enough for shipping; if it misfires, users can course-correct by walking once in their current location.
+Because `SeasonalMarker` returned by `CelestialCalculator.seasonalMarker(sunLongitude:)` is the astronomical marker (always northern-hemisphere-named), the hemisphere-aware mapping is applied as a view-level translation. A helper — see `TurningDayService` below — takes the astronomical `SeasonalMarker` plus a hemisphere and returns the seasonally-correct turning.
+
+No user-facing hemisphere setting is exposed in v1. The per-walk classification is good enough for shipping; if it misfires, users can course-correct by walking once in their current location.
 
 ### Color Palette
 
@@ -72,9 +84,11 @@ Final hex values are to be fine-tuned during implementation against the rendered
 
 ### Home: InkScrollView
 
-Two additions to `InkScrollView`:
+Three additions to `InkScrollView`:
 
-1. **Turning-day banner** inside `journeySummaryHeader` (the existing top-of-scroll summary). On a turning day, a single line appears above the existing summary content:
+1. **Turning-day banner** rendered at the top of `scrollContent`, **independent of walk history** (critical — the existing `journeySummaryHeader` is gated by `if !snapshots.isEmpty`, which would hide the banner from new users on their first turning day). The banner appears whenever today is a turning day, regardless of how many walks the user has.
+
+   On a turning day, a single line reads:
 
    > *Today the sun stands still · 冬至*
 
@@ -82,11 +96,17 @@ Two additions to `InkScrollView`:
    - Solstices: *"Today the sun stands still · [kanji]"*
    - Equinoxes: *"Today, day equals night · [kanji]"*
 
-   The kanji is rendered in the turning's color. The text uses `Constants.Typography.body` or `.caption` (implementation choice; probably body). The banner fades out at local midnight when the turning day ends.
+   The kanji is rendered in the turning's color. Typography and exact placement to be tuned during implementation (likely `Constants.Typography.body` or `.caption`, placed with enough breathing room above `journeySummaryHeader` to feel like a distinct element). The banner fades out at local midnight when the turning day ends.
 
-2. **Scroll-margin glyph** — a new extension file `InkScrollView+TurningMarkers.swift`, mirroring the pattern of `InkScrollView+LunarMarkers.swift`. For every day in the user's walk history that was a turning day, a faint kanji glyph is drawn in the scroll's margin at that row's vertical position. Permanent. A user scrolling through 3 years of history sees 12 kanji glyphs scattered through their scroll — a visual timeline of the turnings they were present for.
+2. **Inline turning marker at walk-dot position** — a new extension file `InkScrollView+TurningMarkers.swift`, mirroring `InkScrollView+LunarMarkers.swift`. The lunar pattern renders small (10×10) annotations **inline on the scroll at each walk's dot position** (not in a side margin). The turning marker mirrors that: for every walk in the user's history whose start date was a turning day, a faint kanji glyph is drawn at that walk's dot position.
 
-3. **Segment/dot color override** — the existing `pathSegmentColor(index:)` logic gains a conditional: if the segment's walk fell on a turning day, the color is overridden to that turning's color (at slightly softened opacity so it blends into the scroll's overall palette rather than popping).
+   Permanent. A user scrolling through 3 years of history sees up to 12 kanji glyphs scattered inline through their scroll — a visual timeline of the turnings they walked.
+
+   The glyph uses the turning's color (per-walk hemisphere) and is marked `.accessibilityHidden(true)` (VoiceOver navigates via the dot itself).
+
+3. **Segment/dot color override** — the existing `pathSegmentColor(index:)` currently takes only an integer index and has no direct access to the walk's snapshot or date. To honor turning-day coloring, the simplest path is to extend its access: either change the signature to `pathSegmentColor(index:snapshot:)` (small refactor) or pre-compute a `[Int: Color]` override map in `scrollContent(width:height:)` where the snapshot is available. Either way, the end state is: if the segment's walk falls on a turning day, the color is the turning's color at slightly softened opacity so it blends with the scroll palette rather than popping.
+
+   Uses the per-walk hemisphere classification (not the user's current hemisphere).
 
 ### Active Walk
 
@@ -127,44 +147,57 @@ Out of scope for this iOS spec, but flagging the handoff contract so the worker 
 
 ## Technical Architecture
 
+### Existing Types (Reused)
+
+- **`SeasonalMarker`** — already exists at `Pilgrim/Models/Astrology/AstrologyModels.swift:139` with cases `.springEquinox`, `.summerSolstice`, `.autumnEquinox`, `.winterSolstice` (plus 4 cross-quarter days we ignore for this feature). Already has a `name` property. We add computed properties via extension — see "New Extensions" below.
+
 ### New Types
 
-- **`TurningDay`** — enum in `Pilgrim/Models/` with cases `.springEquinox`, `.summerSolstice`, `.autumnEquinox`, `.winterSolstice`. Methods:
-  - `static func forDate(_ date: Date, hemisphere: Hemisphere) -> TurningDay?` — returns the turning if the date is one, accounting for hemisphere (the same astronomical moment maps to different turnings in north vs south).
-  - `var kanji: String` — "春分" / "夏至" / "秋分" / "冬至"
-  - `var label: String` — "Spring equinox" / "Summer solstice" / etc.
-  - `var bannerText: String` — *"Today, day equals night"* or *"Today the sun stands still"*
-  - `var color: Color` — the walking-segment color for this turning
+- **`Hemisphere`** — simple enum `.northern / .southern`, derived from `CLLocationCoordinate2D.latitude`. Negative → southern; otherwise northern.
 
-- **`Hemisphere`** — simple enum `.northern / .southern`, derived from `CLLocationCoordinate2D.latitude`.
+- **`TurningDayService`** — helper (likely `enum` with static methods, given stateless nature) that wraps detection with hemisphere-aware mapping:
+  - `static func turning(for date: Date, at coordinate: CLLocationCoordinate2D?) -> SeasonalMarker?` — takes a date and optional coordinate, returns the seasonally-correct marker for that context. Used by historical walks (coordinate from the walk itself), by today's banner (coordinate from most-recent walk), and by the active walk (coordinate from first location sample). If coordinate is nil, assumes northern hemisphere.
+  - Internally translates the astronomical `SeasonalMarker` returned by `CelestialCalculator.snapshot(for:).seasonalMarker` through the hemisphere mapping in the Hemisphere Handling section.
+  - Caching: the per-date snapshot call is cheap; trivially memoize by date if profiling shows it matters.
 
-- **`TurningDayService`** (or similar helper) — caches the 4 astronomical moments for the current year so we don't recompute on every view body evaluation. Invalidates at year boundary.
+### New Extensions on `SeasonalMarker`
+
+In a new file `Pilgrim/Models/Astrology/SeasonalMarker+Turnings.swift`:
+
+- `var kanji: String?` — "春分" / "夏至" / "秋分" / "冬至" for the 4 turnings; nil for the cross-quarter days (which this feature doesn't surface).
+- `var bannerText: String?` — *"Today, day equals night"* (equinoxes) or *"Today the sun stands still"* (solstices); nil for cross-quarter. Localized via `LS.swift`.
+- `var color: Color?` — the walking-segment override color; nil for cross-quarter.
+- `var isTurning: Bool` — true iff the case is one of the 4 main turnings.
+
+VoiceOver-accessible label uses the existing `name` property ("Spring Equinox" etc.), which needs to flow through `LS.swift` for localization.
 
 ### CelestialCalculator Extensions
 
-Two new public methods (add to the existing class):
+**One new public method** (existing detection is already sufficient):
 
-- `solsticesAndEquinoxes(forYear year: Int) -> [Date]` — uses standard astronomical formulas (Jean Meeus *Astronomical Algorithms* chapter 27 for equinox/solstice times). Returns 4 dates in UTC.
-- `sunriseAzimuth(at coordinate: CLLocationCoordinate2D, on date: Date) -> CLLocationDirection?` — computes the compass bearing of sunrise. Combines the sun's declination on the date with the observer's latitude using the sunrise-azimuth formula. Returns nil at extreme latitudes where the sun doesn't rise.
+- `static func sunriseAzimuth(at coordinate: CLLocationCoordinate2D, on date: Date) -> CLLocationDirection?` — computes the compass bearing (degrees from true north) of sunrise. Combines the sun's declination on the date with the observer's latitude using the standard sunrise-azimuth formula (`cos(azimuth) = sin(declination) / cos(latitude)` adjusted for hemisphere and atmospheric refraction). Returns nil at extreme latitudes where the sun doesn't rise that day.
 
 ### File Touch List
 
 **New files:**
-- `Pilgrim/Models/TurningDay.swift` — the enum + helpers
-- `Pilgrim/Models/TurningDayService.swift` — caching + hemisphere detection
-- `Pilgrim/Scenes/Home/InkScrollView+TurningMarkers.swift` — scroll-margin glyph rendering
-- `Pilgrim/Support Files/Assets.xcassets/turningJade.colorset/` (and three more) — the 4 new color assets, each with light and dark variants
-- `UnitTests/TurningDayTests.swift` — date detection, hemisphere mapping, edge cases
-- `UnitTests/CelestialCalculatorSolsticeTests.swift` — accuracy of solstice/equinox dates and sunrise azimuth within reasonable tolerance against known reference data
+- `Pilgrim/Models/Astrology/SeasonalMarker+Turnings.swift` — extensions on the existing enum (kanji / bannerText / color / isTurning)
+- `Pilgrim/Models/Astrology/TurningDayService.swift` — hemisphere-aware detection helper
+- `Pilgrim/Scenes/Home/InkScrollView+TurningMarkers.swift` — inline kanji glyphs at turning-day dot positions, mirroring `InkScrollView+LunarMarkers.swift`
+- `Pilgrim/Support Files/Assets.xcassets/turningJade.colorset/` (and `turningGold`, `turningClaret`, `turningIndigo`) — 4 new color assets, each with light + dark variants
+- `UnitTests/SeasonalMarkerTurningTests.swift` — extension properties, hemisphere mapping, edge cases (date ±1 day, cross-quarter returns nil)
+- `UnitTests/CelestialCalculatorSunriseAzimuthTests.swift` — azimuth accuracy vs published reference data; polar return nil
 
 **Modified files:**
-- `Pilgrim/Scenes/Home/InkScrollView.swift` — `journeySummaryHeader` gets the conditional banner; `pathSegmentColor(index:)` gains turning-day override
-- `Pilgrim/Scenes/Home/HomeView.swift` — may need to thread the turning info into InkScrollView (if the service lives higher up)
-- `Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift` — adds kanji watermark + sunrise-ray overlay
-- `Pilgrim/Views/PilgrimMapView.swift` — route color match expression gains turning-day branch; new overlay layer for the sunrise ray
-- `Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift` — date title suffix
-- `Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift` + `ShareService.swift` — adds `turningDay` to the share payload (forward-compatible)
-- `Pilgrim/Models/Astronomy/CelestialCalculator.swift` (or wherever it lives) — the two new methods
+- `Pilgrim/Models/Astrology/CelestialCalculator.swift` — adds `sunriseAzimuth(at:on:)`
+- `Pilgrim/Scenes/Home/InkScrollView.swift` — adds turning banner (at top of `scrollContent`, outside the `if !snapshots.isEmpty` gate); `pathSegmentColor` adjusts to accept snapshot access for turning-day override
+- `Pilgrim/Scenes/ActiveWalk/ActiveWalkView.swift` — adds kanji watermark at bottom-center over the map + sunrise-ray overlay
+- `Pilgrim/Views/PilgrimMapView.swift` — route color match expression's default (walking) branch becomes conditional on turning-day classification for that walk; adds line annotation for the sunrise-azimuth ray
+- `Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift` — `dateTitleFormatted` appends kanji for turning-day walks
+- `Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift` + `ShareService.swift` — adds `turningDay` to the share payload (forward-compatible; worker doesn't need to consume it immediately)
+- `Pilgrim/Models/LS.swift` — new localized strings for banner copy and VoiceOver labels
+
+**Unchanged (but noted):**
+- `Pilgrim/Models/LightReading/LightReadingGenerator.swift` — already surfaces seasonal-marker readings on turning days. No changes needed. The Four Turnings feature layers visual acknowledgments on top of this existing textual one.
 
 ## Accessibility
 
@@ -177,12 +210,12 @@ Two new public methods (add to the existing class):
 
 ### Unit tests
 
-1. `TurningDay.forDate(_:hemisphere:)` — returns the correct turning for known historical dates (e.g., 2024-06-20 is summer solstice in Northern, winter in Southern).
-2. `TurningDay.forDate(_:hemisphere:)` returns nil for non-turning dates.
-3. Hemisphere detection: positive latitude → .northern, negative → .southern, zero → .northern (arbitrary but consistent).
-4. `CelestialCalculator.solsticesAndEquinoxes(forYear:)` — each returned date falls within ±1 day of published astronomical references for that year.
-5. `CelestialCalculator.sunriseAzimuth(at:on:)` — returns ~90° (due east) at the equator on equinox, returns extreme values at high latitudes on solstice, returns nil above the arctic circle on winter solstice.
-6. Cross-year: a year boundary during a walk does not crash the service; cache invalidates cleanly.
+1. `TurningDayService.turning(for:at:)` — returns the correct hemisphere-mapped turning for known historical dates (e.g., June solstice 2024 at a northern coordinate returns `.summerSolstice`; same date at a southern coordinate returns `.winterSolstice`).
+2. `TurningDayService.turning(for:at:)` returns nil for non-turning dates and for the cross-quarter astronomical markers (imbolc / beltane / lughnasadh / samhain are out of scope).
+3. `Hemisphere` derivation: positive latitude → `.northern`, negative → `.southern`, zero and nil coordinate → `.northern` (consistent default).
+4. `SeasonalMarker.kanji` / `.bannerText` / `.color` return correct values for the 4 turnings and nil for cross-quarter cases.
+5. `CelestialCalculator.sunriseAzimuth(at:on:)` — returns ~90° (due east) at the equator on equinox, returns extreme values at high latitudes on solstice (e.g., ~128° summer solstice at 60° N), returns nil above the arctic circle on winter solstice.
+6. Walk spanning local midnight: a walk starting at 23:55 on a turning day remains classified as a turning-day walk even though most of its route is recorded the next day (classification uses start date).
 
 ### Manual checks
 

--- a/docs/superpowers/specs/2026-04-22-rubberduck-walk-design.md
+++ b/docs/superpowers/specs/2026-04-22-rubberduck-walk-design.md
@@ -22,15 +22,18 @@ The spec does not cover `chiefrubberduck.com` (deferred; not load-bearing) or th
 
 ```
 ~/GitHub/rubberduck/walk/          pilgrim-landing              chiefrubberduck.com
-│                                   │                            │
-├── CLAUDE.md (character bible)     ├── /walk (new page)         └── (deferred)
-├── entries/*.md                    │     static HTML/CSS/JS
-├── state.json                      │     fetches feed.json
-├── routes/                         │     on load
-│   ├── queue.json                  │
-│   └── shikoku-88.json             ├── footer.png (new)
-├── feed.json  ◄────── built ──┐    │     tiny duck icon,
-└── scripts/                    │   │     linked → /walk
+  (remote:                          │                            │
+   walktalkmeditate/                ├── /walk (new page)         └── (deferred)
+   rubberduck-walk)                 │     static HTML/CSS/JS
+│                                   │     fetches feed.json
+├── CLAUDE.md (character bible)     │     on load
+├── entries/*.md                    │
+├── state.json                      │
+├── routes/                         ├── footer.png (new)
+│   ├── queue.json                  │     tiny duck icon,
+│   └── shikoku-88.json             │     linked → /walk
+├── feed.json  ◄────── built ──┐    │
+└── scripts/                    │   │
     ├── advance.ts              │   │
     ├── build-feed.ts           │   │
     ├── purge.sh                │   │
@@ -40,23 +43,26 @@ The spec does not cover `chiefrubberduck.com` (deferred; not load-bearing) or th
 ~/GitHub/rubberduck/walk ──────►│   │
                                 ▼   │
                       jsDelivr CDN ─┘
-                      cdn.jsdelivr.net/gh/<owner>/walk@main/feed.json
+          cdn.jsdelivr.net/gh/walktalkmeditate/rubberduck-walk@main/feed.json
 ```
+
+**Paths and URLs:**
+
+- Local working directory: `/Users/rubberduck/GitHub/rubberduck/walk/`
+- GitHub remote: `https://github.com/walktalkmeditate/rubberduck-walk` (public — required by jsDelivr)
+- Feed URL: `https://cdn.jsdelivr.net/gh/walktalkmeditate/rubberduck-walk@main/feed.json`
+- Purge URL: `https://purge.jsdelivr.net/gh/walktalkmeditate/rubberduck-walk@main/feed.json`
 
 **Two flows write the repo:**
 
 1. **Daily `/schedule`** — Claude Code runs once per day. Reads `state.json`, advances position, generates a draft entry, self-reviews against CLAUDE.md, either publishes or emits a silence entry. Commits, pushes, purges.
 
-2. **Local CLI** (`./duck <subcommand>`) — optional human entrypoints:
-   - `./duck offer` — write an entry by hand (bypasses LLM)
-   - `./duck next <route-id>` — when duck is resting, begin the next route
-   - `./duck status` — print current state
-   - `./duck preview` — render feed locally
+2. **Local CLI** (`./duck <subcommand>`) — optional human entrypoints. Full list in the "Local CLI" section below; principal commands: `offer` (hand-written short entry), `letter` (longer human-authored writing), `next <route-id>` (begin the next route after resting).
 
 **pilgrim-landing consumes jsDelivr:**
 
 - `/walk` is a new static page (HTML/CSS/JS, no build step)
-- On load: `fetch('https://cdn.jsdelivr.net/gh/<owner>/walk@main/feed.json')`
+- On load: `fetch('https://cdn.jsdelivr.net/gh/walktalkmeditate/rubberduck-walk@main/feed.json')`
 - Renders map + trail of past entries + journal-styled entry list
 - Footer of all pilgrim-landing pages gets a small static duck .png linked to `/walk`
 
@@ -233,7 +239,7 @@ A single Claude Code invocation per day. The `/schedule` skill already installed
    ```
    git commit -am "the duck walks"
    git push
-   curl https://purge.jsdelivr.net/gh/<owner>/walk@main/feed.json
+   curl https://purge.jsdelivr.net/gh/walktalkmeditate/rubberduck-walk@main/feed.json
    ```
 
 ### Local CLI
@@ -330,6 +336,19 @@ Entry files are deleted from `entries/` after 365 days (the daily build script p
 - Links to `/walk`
 - No hover effect, no label, no explanation
 
+### Duck assets
+
+Source files (provided, to be committed to `rubberduck-walk/assets/` and optimized/resized as needed):
+
+- `~/Downloads/chiefrubberduck.png` — static duck (used for footer icon, resized to 24–32px)
+- `~/Downloads/chiefrubberduck-transparent.gif` — animated duck (used as current-position marker on the `/walk` map)
+
+Both are already transparent-background. At ship time:
+
+- Generate PNG variants at 24px, 32px, and 48px (Retina) for the footer
+- Keep the GIF at its native size for the map marker (may need alpha optimization if the file is heavier than needed on mobile)
+- Commit optimized variants to `pilgrim-landing/assets/duck/`
+
 ## Character bible (lives in repo `CLAUDE.md`)
 
 This is the authoritative voice document loaded on every cron run. It governs `kind: offering`, `kind: notice`, `kind: silence`, and `kind: threshold` entries. It does **not** apply to `kind: letter` — letters are human-authored and intentionally unconstrained.
@@ -402,11 +421,39 @@ Before publishing any generated entry, verify:
 
 ## Weather integration
 
-- Source: [Open-Meteo](https://open-meteo.com/) — free, no API key, good global coverage
-- Request: current conditions at `state.coords`
-- Feeds into generation as context (*"current weather: light rain, 14°C"*)
-- Not surfaced directly in entries; just influences mood
-- If the API is down, skip — generation proceeds without weather context
+Source: [Open-Meteo](https://open-meteo.com/) — free, no API key, good global coverage.
+
+**Endpoint:**
+
+```
+GET https://api.open-meteo.com/v1/forecast
+    ?latitude={state.coords[0]}
+    &longitude={state.coords[1]}
+    &current=temperature_2m,weather_code,precipitation
+```
+
+**Response shape (consumed fields):**
+
+```json
+{
+  "current": {
+    "temperature_2m": 15.5,
+    "weather_code": 1,
+    "precipitation": 0.0
+  }
+}
+```
+
+`weather_code` is a WMO code (0 = clear, 1–3 = mainly clear to overcast, 45/48 = fog, 51–67 = rain/drizzle, 71–77 = snow, 80–82 = showers, 95–99 = thunderstorm). Map it to a short English string (*"clear"*, *"overcast"*, *"light rain"*, *"fog"*) before feeding into the generation prompt.
+
+**Usage rules:**
+
+- Fetch once per daily cron run, at the duck's current coords
+- Pass into generation as a single-line context string (*"weather: light rain, 14°C"*)
+- Do not surface weather directly in the entry body; it only influences mood
+- Do not store weather in `state.json` (it's a transient input, not state)
+- On API failure, skip silently — generation proceeds without weather context
+- Store the final string in the entry's `weather` frontmatter field for archival reference
 
 ## Non-goals / YAGNI
 
@@ -424,11 +471,9 @@ Before publishing any generated entry, verify:
 
 ## Open decisions (to resolve during implementation)
 
-- **GitHub repo name/org.** `chiefrubberduck/walk`? `jivxjp/walk`? Something else? Must be public (jsDelivr only serves public repos).
-- **Which `.png` and `.gif` assets** from chiefrubberduck.com to reuse as footer icon and current-position indicator. Need to be small and work at 24–32px for footer.
-- **Exact silence-entry visual treatment** on `/walk` — what "(silence)" looks like typographically.
-- **Weather API integration details** — which Open-Meteo endpoint, what fields to pass into generation context.
-- **Closure sites for future routes** (Kumano, Caminos) — research and populate at route activation time; don't block Shikoku work.
+- **Exact silence-entry visual treatment** on `/walk` — what "(silence)" looks like typographically; settled during CSS authoring.
+- **Closure sites for future routes** (Kumano Kodo → Nachi Falls is tentative; Caminos → Fisterra is tentative for Francés but other Camino variants are TBD) — research and populate at route activation time; don't block Shikoku work.
+- **Asset size optimization budget** — at what point does the GIF file size become a mobile concern on `/walk`; settled during asset pipeline work.
 
 ## Implementation order (rough)
 

--- a/docs/superpowers/specs/2026-04-22-rubberduck-walk-design.md
+++ b/docs/superpowers/specs/2026-04-22-rubberduck-walk-design.md
@@ -97,7 +97,7 @@ date: 2026-04-22
 route: shikoku-88
 stage: 12
 stageName: Shōzanji
-coords: [33.8851, 134.0342]
+coords: [134.0342, 33.8851]
 kind: offering           # offering | notice | silence | threshold | letter
 glyph: 🪨
 weather: clear           # pulled from Open-Meteo at generation time
@@ -122,7 +122,7 @@ date: 2026-05-02
 route: shikoku-88
 stage: 13
 stageName: Dainichiji
-coords: [33.9124, 134.1207]
+coords: [134.1207, 33.9124]
 kind: letter
 glyph: 🕯️
 author: — the pilgrim
@@ -144,7 +144,7 @@ had a frayed rope. I rang it anyway.
   "route": "shikoku-88",
   "stage": 12,
   "stageName": "Shōzanji",
-  "coords": [33.8851, 134.0342],
+  "coords": [134.0342, 33.8851],
   "mode": "walking",
   "modeEnteredAt": "2026-03-15",
   "lastAdvancedAt": "2026-04-22"
@@ -179,7 +179,7 @@ Human-editable. When the duck enters `beginning` mode via `./duck next`, the spe
     "routeName": "Shikoku Henro",
     "stage": 12,
     "stageName": "Shōzanji",
-    "coords": [33.8851, 134.0342],
+    "coords": [134.0342, 33.8851],
     "mode": "walking",
     "progress": 0.136
   },
@@ -189,7 +189,7 @@ Human-editable. When the duck enters `beginning` mode via `./duck next`, the spe
       "route": "shikoku-88",
       "stage": 12,
       "stageName": "Shōzanji",
-      "coords": [33.8851, 134.0342],
+      "coords": [134.0342, 33.8851],
       "kind": "offering",
       "glyph": "🪨",
       "body_html": "<p>A stone by the door. No one had moved it. No one needed to.</p>",
@@ -197,7 +197,7 @@ Human-editable. When the duck enters `beginning` mode via `./duck next`, the spe
     }
   ],
   "routePath": {
-    "shikoku-88": [[34.085, 134.553], [33.958, 134.412], ...]
+    "shikoku-88": [[134.553, 34.085], [134.412, 33.958], ...]
   }
 }
 ```
@@ -427,8 +427,8 @@ Source: [Open-Meteo](https://open-meteo.com/) — free, no API key, good global 
 
 ```
 GET https://api.open-meteo.com/v1/forecast
-    ?latitude={state.coords[0]}
-    &longitude={state.coords[1]}
+    ?latitude={state.coords[1]}
+    &longitude={state.coords[0]}
     &current=temperature_2m,weather_code,precipitation
 ```
 

--- a/docs/superpowers/specs/2026-04-22-rubberduck-walk-design.md
+++ b/docs/superpowers/specs/2026-04-22-rubberduck-walk-design.md
@@ -1,0 +1,451 @@
+# The Rubber Duck Walk — Design Spec
+
+## Overview
+
+A tiny, unbranded rubber duck walks real pilgrimage routes over long spans of time, speaking rarely and briefly. Its journal is a static JSON feed consumed by pilgrim-landing's new `/walk` page, which renders in the app's Journal-screen aesthetic. The duck is an easter egg — a footer icon on pilgrim-landing is the only entry point.
+
+The duck is a meme, not a marketing channel. It is primarily for fun and secondarily for quiet brand lore. It must not look, sound, or feel like marketing content.
+
+The duck's voice is deliberately distinct — part child, part fool, part sage — and inherits its signature from [chiefrubberduck.com](https://chiefrubberduck.com) without ever being publicly named. Readers meet a rubber duck, not a brand.
+
+## Scope
+
+This spec covers three surfaces:
+
+1. **A new repo** `rubberduck/walk/` — data, scripts, character bible
+2. **Daily automation** via Claude Code `/schedule` + a small local CLI
+3. **A new page** `/walk` on pilgrim-landing, plus a tiny footer icon
+
+The spec does not cover `chiefrubberduck.com` (deferred; not load-bearing) or the iOS app (no app changes).
+
+## Architecture
+
+```
+~/GitHub/rubberduck/walk/          pilgrim-landing              chiefrubberduck.com
+│                                   │                            │
+├── CLAUDE.md (character bible)     ├── /walk (new page)         └── (deferred)
+├── entries/*.md                    │     static HTML/CSS/JS
+├── state.json                      │     fetches feed.json
+├── routes/                         │     on load
+│   ├── queue.json                  │
+│   └── shikoku-88.json             ├── footer.png (new)
+├── feed.json  ◄────── built ──┐    │     tiny duck icon,
+└── scripts/                    │   │     linked → /walk
+    ├── advance.ts              │   │
+    ├── build-feed.ts           │   │
+    ├── purge.sh                │   │
+    └── duck (CLI)              │   │
+                                │   │
+           git push             │   │
+~/GitHub/rubberduck/walk ──────►│   │
+                                ▼   │
+                      jsDelivr CDN ─┘
+                      cdn.jsdelivr.net/gh/<owner>/walk@main/feed.json
+```
+
+**Two flows write the repo:**
+
+1. **Daily `/schedule`** — Claude Code runs once per day. Reads `state.json`, advances position, generates a draft entry, self-reviews against CLAUDE.md, either publishes or emits a silence entry. Commits, pushes, purges.
+
+2. **Local CLI** (`./duck <subcommand>`) — optional human entrypoints:
+   - `./duck offer` — write an entry by hand (bypasses LLM)
+   - `./duck next <route-id>` — when duck is resting, begin the next route
+   - `./duck status` — print current state
+   - `./duck preview` — render feed locally
+
+**pilgrim-landing consumes jsDelivr:**
+
+- `/walk` is a new static page (HTML/CSS/JS, no build step)
+- On load: `fetch('https://cdn.jsdelivr.net/gh/<owner>/walk@main/feed.json')`
+- Renders map + trail of past entries + journal-styled entry list
+- Footer of all pilgrim-landing pages gets a small static duck .png linked to `/walk`
+
+## Repo layout: `rubberduck/walk/`
+
+```
+walk/
+├── CLAUDE.md                    ← character bible (see "Character" section)
+├── entries/
+│   ├── 2026-04-22-shozanji.md
+│   ├── 2026-04-29-jorurji.md
+│   └── ...
+├── routes/
+│   ├── queue.json               ← ordered list; human-editable
+│   └── shikoku-88.json          ← snapshotted from ../open-pilgrimages
+├── state.json                   ← current route, stage, mode, timestamps
+├── feed.json                    ← generated; what jsDelivr serves
+├── scripts/
+│   ├── advance.ts               ← advance duck position
+│   ├── build-feed.ts            ← regenerate feed.json from entries + state
+│   ├── purge.sh                 ← curl jsdelivr purge endpoint
+│   └── duck                     ← CLI wrapper (tsx-based)
+├── README.md
+└── package.json
+```
+
+### Entry file format (markdown + YAML frontmatter)
+
+```markdown
+---
+date: 2026-04-22
+route: shikoku-88
+stage: 12
+stageName: Shōzanji
+coords: [33.8851, 134.0342]
+kind: offering           # offering | notice | silence | threshold | letter
+glyph: 🪨
+weather: clear           # pulled from Open-Meteo at generation time
+---
+
+A stone by the door. No one had moved it. No one needed to.
+```
+
+**Entry kinds:**
+
+- `kind: offering` — written at a stage (temple, landmark). Duck voice. LLM-generated or `./duck offer`.
+- `kind: notice` — written between stages. Duck voice.
+- `kind: silence` — body is empty; only the glyph shows. Auto-emitted when 3 draft regenerations fail self-review, or manual via `./duck silence`.
+- `kind: threshold` — reserved for route-completion entries. Exactly one per route, written at the closure site. Duck voice, visually distinct on /walk.
+- `kind: letter` — **longer human-crafted writing.** Unconstrained by duck voice rules; no word cap; first-person OK; written only via `./duck letter`; **never LLM-generated**. Frontmatter includes an optional `author` field (defaults to `— the pilgrim` if omitted). Visually distinct on /walk (paragraph form, wider prose, different typography). Rare by nature.
+
+**Letter example:**
+
+```markdown
+---
+date: 2026-05-02
+route: shikoku-88
+stage: 13
+stageName: Dainichiji
+coords: [33.9124, 134.1207]
+kind: letter
+glyph: 🕯️
+author: — the pilgrim
+---
+
+Walking behind the duck today, I kept losing it on the narrow path
+between the trees. Every time I thought it had fallen behind, there it
+was, three steps ahead. I don't know what to make of this, except that
+it might not be worth making anything of it.
+
+There was a small shrine off the main trail. Nobody was there. The bell
+had a frayed rope. I rang it anyway.
+```
+
+### `state.json`
+
+```json
+{
+  "route": "shikoku-88",
+  "stage": 12,
+  "stageName": "Shōzanji",
+  "coords": [33.8851, 134.0342],
+  "mode": "walking",
+  "modeEnteredAt": "2026-03-15",
+  "lastAdvancedAt": "2026-04-22"
+}
+```
+
+`mode` is one of: `walking` | `completing` | `resting` | `beginning`.
+
+### `routes/queue.json`
+
+```json
+[
+  "shikoku-88",
+  "kumano-kodo",
+  "camino-frances",
+  "camino-portugues",
+  "camino-norte",
+  "camino-primitivo",
+  "camino-ingles"
+]
+```
+
+Human-editable. When the duck enters `beginning` mode via `./duck next`, the specified route-id is removed from the queue (if present) and written to `state.route`. `./duck next` accepts any valid route-id — not restricted to the queue head — but the queue provides a default suggestion when the duck is resting.
+
+### `feed.json` (what jsDelivr serves)
+
+```json
+{
+  "generatedAt": "2026-04-22T06:00:00Z",
+  "duck": {
+    "route": "shikoku-88",
+    "routeName": "Shikoku Henro",
+    "stage": 12,
+    "stageName": "Shōzanji",
+    "coords": [33.8851, 134.0342],
+    "mode": "walking",
+    "progress": 0.136
+  },
+  "entries": [
+    {
+      "date": "2026-04-22",
+      "route": "shikoku-88",
+      "stage": 12,
+      "stageName": "Shōzanji",
+      "coords": [33.8851, 134.0342],
+      "kind": "offering",
+      "glyph": "🪨",
+      "body_html": "<p>A stone by the door. No one had moved it. No one needed to.</p>",
+      "ageDays": 0
+    }
+  ],
+  "routePath": {
+    "shikoku-88": [[34.085, 134.553], [33.958, 134.412], ...]
+  }
+}
+```
+
+`body_html` is pre-rendered at build time — `/walk` doesn't ship a markdown parser.
+
+## Automation
+
+### Daily `/schedule` run
+
+A single Claude Code invocation per day. The `/schedule` skill already installed on the system handles the cron. The run loads `CLAUDE.md` (the character bible) automatically.
+
+**Sequence:**
+
+1. **Advance position** — `./scripts/advance.ts` reads `state.json` and the current route, moves stage forward by 1. If final stage of route reached, flip `mode` to `completing`. If `completing` route reached closure point, flip to `resting`.
+
+2. **Decide whether to write** — not every day. Probability roughly `0.5` when `mode == walking`, `0.8` when stage has narrative weight (threshold, closure), `0.0` when `mode == resting`.
+
+3. **Generate draft** (if writing) — Claude Code drafts an entry using:
+   - Current stage data (name, coords, terrain if available)
+   - Current weather from Open-Meteo (free, keyless)
+   - Last 3 entries as voice-consistency context
+   - The character bible in `CLAUDE.md`
+
+4. **Self-review pass** — draft is re-read against an explicit checklist in `CLAUDE.md`:
+   - No "I" or "me"
+   - ≤20 words
+   - Present tense
+   - Concrete nouns over abstractions
+   - No advice / lessons / "today I learned"
+   - Glyph from the 27-symbol palette
+   - Matches child/fool/sage register, not generic mindfulness slop
+
+5. **Publish, revise, or fall silent** — if draft passes, commit. If fails, attempt up to 2 regenerations. If still failing, emit a `kind: silence` entry (date + glyph, no prose). **Failure to speak is a feature, not a bug.**
+
+6. **Rebuild feed** — `./scripts/build-feed.ts` regenerates `feed.json` from `entries/`, `state.json`, and route data.
+
+7. **Commit, push, purge** (in that order):
+   ```
+   git commit -am "the duck walks"
+   git push
+   curl https://purge.jsdelivr.net/gh/<owner>/walk@main/feed.json
+   ```
+
+### Local CLI
+
+```
+./duck offer               # prompt for human-written short entry (duck voice), bypass LLM
+./duck letter              # open editor for a longer human-written letter
+./duck next <route-id>     # when mode=resting, begin next route
+./duck status              # print current state
+./duck preview             # render feed.json locally
+./duck advance             # manually run the daily advance (for testing)
+./duck silence             # manually emit a silence entry
+```
+
+### Route transitions (state machine)
+
+```
+walking  ──(final stage reached)──►  completing
+                                     │
+                                     (closure site reached — e.g. Kōya-san for Shikoku)
+                                     ▼
+beginning  ◄──(./duck next <id>)──  resting
+     │                                ▲
+     │                                (user doesn't respond — duck stays resting)
+     ▼
+walking
+```
+
+**Route-specific closures** (from open-pilgrimages + tradition):
+
+- `shikoku-88` → orei-mairi to **Kōya-san** (~5-10 stages of transit)
+- `kumano-kodo` → **Nachi Falls**
+- `camino-frances` → **Fisterra** (walking to the Atlantic)
+- Others: TBD at route activation time, stored as `closureSite` field in route data
+
+**One intentional rule-break:** at each closure site, the duck writes a single `kind: threshold` entry. This is the only "event" the feed acknowledges. It is deliberately small.
+
+```
+2026-12-14 · Kōya-san · 🕯️
+The path ended. The path did not end.
+```
+
+Then silence. `mode = resting`. Feed shows no new entries. Footer gif stays at closure site.
+
+### Resting period
+
+- No fixed duration. Minimum 7 days before `./duck next` can be run.
+- Until user runs `./duck next <route-id>`, duck remains resting forever.
+- Silence is not a failure state.
+
+## pilgrim-landing changes
+
+### `/walk` page (new)
+
+Static HTML/CSS/JS. No build step. No framework.
+
+**Layout (top to bottom):**
+
+1. **Map** — static SVG showing the duck's current route. Past-entry coords are small dots along the route. Current position is marked with the animated duck .gif. Minimal, muted, matches pilgrim-landing's style.
+
+2. **Current state line** — a single muted sentence below the map: *"The duck is at Shōzanji, Temple 12 of the Shikoku Henro."* Updates from `feed.duck`.
+
+3. **Entry feed** — Journal-screen-styled list. Each entry card:
+   - Date (small, muted)
+   - Stage name (slightly more prominent)
+   - Large glyph (centered or leading)
+   - Prose (serif, generous line-height, short)
+   - For `kind: silence`: date + stage + glyph only, italicized "(silence)"
+   - For `kind: threshold`: visually distinct (thin rule above/below, slightly larger glyph)
+   - For `kind: letter`: wider prose column, paragraph form, narrower line-height; glyph appears as a small drop-cap or header mark rather than a large block glyph; `author` line rendered as a muted signature below the prose
+
+4. **Footer tagline** — from chiefrubberduck.com, quietly rendered in very small muted type at the bottom of `/walk`:
+   > *"a question cannot be asked unless there is already the potentiality of the answer"*
+
+No "About the duck" page. No bio. No navigation to lore. Mystery is the point.
+
+### Impermanence (fade & delete)
+
+Client-side rendering applies visual decay based on `ageDays`:
+
+| Age (days) | Visual treatment |
+|------------|------------------|
+| 0–30       | full contrast |
+| 31–90      | 70% opacity, slightly smaller |
+| 91–365     | 40% opacity, prose hidden — only date + stage + glyph shown |
+| 366+       | removed from feed entirely at build time |
+
+Entry files are deleted from `entries/` after 365 days (the daily build script prunes them). This is deliberate: the pilgrimage is not an archive. The duck's offerings pass through.
+
+### Footer duck icon (all pilgrim-landing pages)
+
+- Tiny static .png duck icon (~24-32px), placed in the site footer
+- `alt="a question cannot be asked unless there is already the potentiality of the answer"`
+- Links to `/walk`
+- No hover effect, no label, no explanation
+
+## Character bible (lives in repo `CLAUDE.md`)
+
+This is the authoritative voice document loaded on every cron run. It governs `kind: offering`, `kind: notice`, `kind: silence`, and `kind: threshold` entries. It does **not** apply to `kind: letter` — letters are human-authored and intentionally unconstrained.
+
+### Who the duck is
+
+A small yellow rubber duck, walking the Shikoku henro. Can float, walk, fly. A pilgrim through illusion. Never named. Never explained.
+
+Inherits from [chiefrubberduck.com](https://chiefrubberduck.com): *part child, part fool, part sage.* The existing voice on that site is the baseline. The walking duck is the same rubber duck, now on foot.
+
+### Voice rules (hard)
+
+- **Never "I", "me", "my", or "we".** Subject-less or third-person only. Use "the duck," "the path," "no one," or elide subject entirely. (Does not apply to `kind: letter`.)
+- **≤20 words per entry.** Usually far fewer. Haiku-adjacent.
+- **Present tense.**
+- **No exclamation marks** (existing chiefrubberduck voice allows, but the walking duck is quieter).
+- **No numbers in prose.** (Frontmatter only.)
+- **Concrete nouns over abstractions.** Stones, bells, rain — not "presence," "mindfulness," "journey," "path" (metaphorically).
+- **No advice, no lessons, no "today I learned".** The duck does not teach.
+- **No self-congratulation.**
+
+### Voice modes (pick one per entry)
+
+- **Child** — direct, literal, no irony.
+  *"The bell rang. No one had asked for it."*
+- **Fool** — misses the obvious in a way that reveals it.
+  *"The gate was open. The duck went through it anyway."*
+- **Sage** — accidental wisdom; never knowing.
+  *"A stone by the door. No one had moved it. No one needed to."*
+
+### Rare modes (sparingly)
+
+- **Tech-koan** — *"The mountain's memory buffer is `null`. Still, it remembered rain."* — Once every 10–15 entries max. Do not overuse.
+- **Earnest** — *"Rain. Be the rain."* — Allowed occasionally; do not make a pattern of it.
+- **Self-looping koan** — *"The path is not the map. The map is the path."* — Sparingly.
+
+### What the duck notices
+
+Stones, rooftiles, lichens, shadows, bells, rain, the turn of a path, a heron that did not move, an old woman's shoes by a door, steam from a kettle, moss on a torii post, a cat that ignored everything.
+
+### What the duck does not do
+
+Explain. Judge. Seek. Conclude. Teach. Summarize. Tell the reader how to feel. Reference itself by name. Refer to "pilgrims" as a concept.
+
+### Glyph palette (27 symbols)
+
+**Chiefrubberduck signature:** ⚇ ❂
+**Buddhist/zen:** ⛩️ 🔔 🪷 🕯️ 🌙
+**Shikoku nature:** 🪨 🌿 🍃 💧 🌧️ ☁️ 🗻 🪵 🐚 🌾 🌫️ 🕊️
+**Geometric/koan:** ◯ △ ☰ ∅ ∞ ≡ 〰️ 🌀
+
+Pick one per entry. The palette is deliberately small so each use feels intentional.
+
+### Self-review checklist (used by Claude Code on each draft)
+
+Applies to LLM-generated duck entries (`offering`, `notice`). Does not apply to `letter` (human-authored) or `silence` (no body).
+
+Before publishing any generated entry, verify:
+
+- [ ] Does not contain "I", "me", "my", "we"
+- [ ] Word count ≤ 20 (body only; frontmatter doesn't count)
+- [ ] Present tense throughout
+- [ ] No numbers in body prose
+- [ ] No exclamation marks
+- [ ] No words from the banned-abstraction list: *presence, mindfulness, journey, path* (literal), *peaceful, serene, grateful, blessed*
+- [ ] No advice verbs: *remember, notice, try, consider, learn*
+- [ ] Glyph is from the 27-symbol palette
+- [ ] Reads as child/fool/sage — not generic mindfulness bot
+- [ ] If 3 drafts fail the checklist, emit silence entry instead
+
+## Weather integration
+
+- Source: [Open-Meteo](https://open-meteo.com/) — free, no API key, good global coverage
+- Request: current conditions at `state.coords`
+- Feeds into generation as context (*"current weather: light rain, 14°C"*)
+- Not surfaced directly in entries; just influences mood
+- If the API is down, skip — generation proceeds without weather context
+
+## Non-goals / YAGNI
+
+- **No chiefrubberduck.com build-out** — deferred entirely
+- **No Anthropic SDK usage** — Claude Code IS the runtime; no API keys needed
+- **No Mapbox or interactive maps** — static SVG with dots is sufficient for v0
+- **No user accounts, comments, or interactivity** on `/walk`
+- **No social sharing widgets** — if visitors want to share, they share the URL
+- **No push notifications**, RSS feed, or email subscriptions
+- **No "About the duck" page**
+- **No recurring characters** (foxes, bells, etc. that reappear across entries)
+- **No hand-drawn illustrations**
+- **No analytics on `/walk`** beyond pilgrim-landing's existing setup
+- **No duck backstory or lore page** — mystery is load-bearing
+
+## Open decisions (to resolve during implementation)
+
+- **GitHub repo name/org.** `chiefrubberduck/walk`? `jivxjp/walk`? Something else? Must be public (jsDelivr only serves public repos).
+- **Which `.png` and `.gif` assets** from chiefrubberduck.com to reuse as footer icon and current-position indicator. Need to be small and work at 24–32px for footer.
+- **Exact silence-entry visual treatment** on `/walk` — what "(silence)" looks like typographically.
+- **Weather API integration details** — which Open-Meteo endpoint, what fields to pass into generation context.
+- **Closure sites for future routes** (Kumano, Caminos) — research and populate at route activation time; don't block Shikoku work.
+
+## Implementation order (rough)
+
+1. Create `rubberduck/walk/` repo with layout, `CLAUDE.md`, and deterministic scripts
+2. Snapshot `shikoku-88.json` from open-pilgrimages into `routes/`
+3. Implement `advance.ts` + `build-feed.ts` + `duck` CLI
+4. Write first handful of entries by hand (`./duck offer`) to seed voice and validate feed shape
+5. Wire up Claude Code generation + self-review
+6. Set up `/schedule` to run daily
+7. Create `/walk` page in pilgrim-landing (fetch, render, impermanence fading)
+8. Add footer duck icon to pilgrim-landing
+9. Quietly ship. No announcement.
+
+## Success criteria
+
+- The duck posts irregularly (sometimes daily, sometimes weekly, sometimes silent for stretches) without human intervention
+- A stranger reading the feed cannot tell it was written by an LLM
+- pilgrim-landing's `/walk` page loads fast and looks like a quieter sibling of the app's Journal screen
+- The meme propagates by word of mouth; no one writes a post titled "Look at this AI pilgrimage mascot"
+- After a year, at least one unprompted reference to the duck shows up somewhere (Slack, Reddit, a tweet) not by anyone on this project


### PR DESCRIPTION
## Summary

Three-part fix for `cpu_resource_fatal` kills during locked walk+talk sessions on memory-constrained devices (reproducible on iPhone SE3):

1. **Mapbox render pause (the real crash fix).** The map was rendering at 30 FPS and feeding GeoJSON updates even when backgrounded or behind a full-screen meditation overlay, burning ~90% CPU on a worker thread and hitting iOS's 60-second background-CPU budget. Now pauses rendering and gates GeoJSON source rebuilds when the user can't see the map; one-shot catch-up on resume.

2. **Talk-metadata persistence + recovery.** Before, any SIGKILL during Talk lost the entire in-flight recording. Now the SessionGuard checkpoint captures a provisional `TempVoiceRecording`, and recovery sanitizes unplayable `.m4a` files (missing moov atom) to metadata-only entries while preserving duration. Talk timer survives any unplanned termination. Audio file is lost by design — recorder rotation was considered and rejected for audio-gap UX reasons.

3. **Phone-call handling.** `CXCallObserver.hasConnected` stops the recorder when a call is actually answered, not on generic audio-session interruptions. Declined/missed calls and Siri triggers let iOS's auto-pause/resume handle the brief blip cleanly, so a fleeting ring doesn't end the recording.

Plus hardening for downstream consumers of metadata-only recordings (`RecordingsListView`, `TranscriptionService`, `PodcastSubmissionService` — all now guard empty paths) and a `schemaVersion`-mismatch guard in recovery so future schema bumps fail-safe on older builds.

## Architecture notes

- `WalkCheckpoint.currentSchemaVersion` is the single writer-side constant; `WalkSessionGuard.supportedSchemaVersion` derives from it. Changing schema at one site automatically narrows what older builds accept.
- Provisional-recording invariant: `uuid == nil` identifies the in-flight entry from `checkpointVoiceRecording()`. Centralized as `WalkSessionGuard.isProvisional(_:)` so the checkpoint log and recovery sanitization share one definition.
- `PilgrimMapView.Coordinator` observes `UIApplication.didEnterBackgroundNotification` / `willEnterForegroundNotification` + an `isMeditating` binding. `shouldRender = !isAppInBackground && !isMeditating` gates both `preferredFramesPerSecond` and `applyRouteSource` calls.
- `Walk.talkDuration` is computed via `NewWalk.init` summing `voiceRecordings.reduce { $0 + $1.duration }`, so our sanitized metadata-only rows (duration preserved, path cleared) correctly feed the persisted `talkDuration` field used by walk summary, home dot, share payload, seal, and podcast.

## Verification

- **Phase 1 (Talk recovery):** Verified 2026-04-22 on iPhone SE3 via TestFlight build — walked + talked + locked, `cpu_resource_fatal` reproduced, Talk duration survived on recovery (shown correctly on summary + home screen).
- **Phase 2 (Mapbox pause):** Verified 2026-04-23 on iPhone SE3 via local Xcode build — walked + talked + locked for **37 minutes** with no `cpu_resource_fatal` (previously crashed within ~1 minute reliably).
- **Task 7 (CallKit):** Unit tests cover the delegate + guard logic. Manual phone-call test skipped; implementation surface is narrow.
- **UnitTests:** 457 tests passing (0 failures).

## Out of scope (tracked for future work)

- Auto-transcribe trigger for recovered walks (pre-existing gap — recovery path doesn't call `triggerAutoTranscription`)
- Local archival of failed-recovery checkpoints for support debugging
- Integration test for the full recovery round-trip (write checkpoint → kill → recover → verify)
- `AVURLAsset.duration` → `load(.duration)` async migration

## Notes on branch contents

Two unrelated docs commits landed on this branch during development (not part of this feature):

- `fc47570 docs(plan): rubberduck walk implementation plan` (2,728-line separate planning doc)
- `0267355 docs(coords): use GeoJSON [lon, lat] convention in spec + plan` (tweak to the above)

They inflate the diff line count but touch no code. Safe to merge through; cherry-pick separately if you'd rather keep this PR narrower.

## Test plan

- [x] `UnitTests` target passing — 457 tests, 0 failures
- [x] Phase 1 recovery verified on SE3 (forced `cpu_resource_fatal`, reopened, confirmed Talk duration preserved on summary)
- [x] Phase 2 crash fix verified on SE3 — 37-minute locked walk+talk, no kill
- [ ] Manual phone-call test on physical device (skipped by author — unit tests cover the logic)
- [ ] Optional: verify on a non-SE3 device model before the next TestFlight push

🤖 Generated with [Claude Code](https://claude.com/claude-code)