### PR TITLE
fix(audio): only end the talk for real calls, not transient interruptions

### DIFF
--- a/Pilgrim/Models/Walk/WalkBuilder/Components/VoiceRecordingManagement.swift
+++ b/Pilgrim/Models/Walk/WalkBuilder/Components/VoiceRecordingManagement.swift
@@ -143,18 +143,26 @@ public class VoiceRecordingManagement: NSObject, WalkBuilderComponent {
     }
 
     private func flushCurrentRecording() {
-        guard isRecording, let recorder = audioRecorder else {
+        guard isRecording, audioRecorder != nil else {
             builder?.flushVoiceRecordings(voiceRecordingsRelay.value)
             return
         }
+        commitActiveRecordingAndReset()
+        builder?.flushVoiceRecordings(voiceRecordingsRelay.value)
+    }
+
+    /// Stop the recorder, commit the audio captured so far, and clear all
+    /// recording state. The delegate is detached before stopping so the commit
+    /// runs exactly once here, not again via `audioRecorderDidFinishRecording`.
+    /// Tolerates a nil `audioRecorder` for the test-injected recording path.
+    private func commitActiveRecordingAndReset() {
         stopMetering()
         isRecording = false
         recordingStartDate = nil
+        audioRecorder?.delegate = nil
+        audioRecorder?.stop()
         audioRecorder = nil
-        recorder.delegate = nil
-        recorder.stop()
         commitRecording(successfully: true)
-        builder?.flushVoiceRecordings(voiceRecordingsRelay.value)
     }
 
     private func commitRecording(successfully flag: Bool) {
@@ -270,6 +278,10 @@ public class VoiceRecordingManagement: NSObject, WalkBuilderComponent {
     }
 
     #if DEBUG
+    /// Overrides `recorderStillCapturing` in tests, where no real AVAudioRecorder
+    /// exists to report its state.
+    private var testRecorderCapturingOverride: Bool?
+
     /// Test-only hook. Sets the internal state that `startRecording()` would set
     /// without requiring AVAudioSession permission in the unit-test environment.
     func _test_setActiveRecording(start: Date, relativePath: String) {
@@ -278,12 +290,28 @@ public class VoiceRecordingManagement: NSObject, WalkBuilderComponent {
         recordingStartDate = start
         isRecording = true
     }
+
+    /// Test-only hook. Simulates whether the underlying recorder survived an
+    /// interruption (true) or was stopped by it (false).
+    func _test_setRecorderCapturing(_ capturing: Bool) {
+        testRecorderCapturingOverride = capturing
+    }
     #endif
 }
 
 extension VoiceRecordingManagement: AVAudioRecorderDelegate {
 
     public func audioRecorderDidFinishRecording(_ recorder: AVAudioRecorder, successfully flag: Bool) {
+        // An OS-driven finish (encoder failure, hardware/route loss) can fire
+        // while our flags still say "recording". Reset them so the UI doesn't
+        // show a live talk backed by a dead recorder, and the walk-end flush
+        // can't silently drop an already-finalized file.
+        if isRecording {
+            stopMetering()
+            isRecording = false
+            recordingStartDate = nil
+            audioRecorder = nil
+        }
         commitRecording(successfully: flag)
     }
 }
@@ -291,39 +319,57 @@ extension VoiceRecordingManagement: AVAudioRecorderDelegate {
 extension VoiceRecordingManagement: CXCallObserverDelegate {
 
     public func callObserver(_ observer: CXCallObserver, callChanged call: CXCall) {
-        handleCallStateChange(hasConnected: call.hasConnected, hasEnded: call.hasEnded)
+        handleCallStateChange(hasEnded: call.hasEnded)
     }
 
     /// A phone call — incoming-ringing, connected, or outgoing — takes the mic,
     /// so the talk must stop. CXCallObserver reports any active call here
     /// (`!hasEnded`), which is the reliable signal; an *unanswered* incoming
-    /// call (rings, never connects) is caught this way too. Only an actual call
-    /// ends the talk — see `handleAudioInterruption` for why transient
-    /// (non-call) interruptions deliberately do not.
-    private func handleCallStateChange(hasConnected: Bool, hasEnded: Bool) {
+    /// call (rings, never connects) is caught this way too. There is deliberately
+    /// no `hasConnected` gate — we do not wait for the call to connect. Only an
+    /// actual call ends the talk — see `handleAudioInterruption` for why
+    /// transient (non-call) interruptions deliberately do not.
+    private func handleCallStateChange(hasEnded: Bool) {
         guard !hasEnded, isRecording else { return }
         stopRecording()
     }
 
-    /// Transient audio interruptions (notifications, Siri, an alarm) must NOT
-    /// end the talk — a momentary sound shouldn't cut a long recording. Real
-    /// phone calls are handled by CXCallObserver above, not here. We log the
-    /// interruption (rather than ignore it silently) so a field report can tell
-    /// what interrupted; the recording is left as-is.
-    ///
-    /// Trade-off: AVAudioRecorder cannot resume into the same file after the
-    /// system deactivates the session (Apple-confirmed), so if a non-call
-    /// interruption genuinely breaks capture, the tail of this recording may be
-    /// lost. We accept that over the prior behavior, which finalized the talk on
-    /// every notification.
+    /// A transient interruption (a notification sound, Siri, an alarm) must not
+    /// end a talk the recorder lives through, so we never finalize on `.began`.
+    /// But an `AVAudioRecorder` the system actually paused cannot resume into the
+    /// same file (Apple-confirmed), so when the interruption ends we check
+    /// whether the recorder kept capturing: if it did, the talk continues
+    /// untouched; if it was stopped, we finalize the audio captured so far and
+    /// release the mic — rather than holding a live session that records nothing
+    /// for the rest of the walk and stamps an inflated duration at walk end.
+    /// Real phone calls are handled by CXCallObserver above, not here. No new
+    /// recording is started: the talk stays a single file instead of splitting.
     private func handleAudioInterruption(_ event: AudioSessionCoordinator.InterruptionEvent) {
-        guard case .began = event, isRecording else { return }
-        print("[VoiceRecordingManagement] audio interruption during recording — not finalizing (calls handled via CallKit)")
+        guard isRecording else { return }
+        switch event {
+        case .began:
+            return
+        case .ended:
+            guard !recorderStillCapturing else { return }
+            print("[VoiceRecordingManagement] interruption ended with a stopped recorder — finalizing captured audio")
+            commitActiveRecordingAndReset()
+        }
+    }
+
+    /// Whether the underlying recorder is still actively capturing. After a
+    /// system interruption that paused it, this reads false and the file can no
+    /// longer be resumed. Overridable under test, where no real AVAudioRecorder
+    /// is created.
+    private var recorderStillCapturing: Bool {
+        #if DEBUG
+        if let override = testRecorderCapturingOverride { return override }
+        #endif
+        return audioRecorder?.isRecording ?? false
     }
 
     #if DEBUG
-    func _test_simulateCallChanged(hasConnected: Bool, hasEnded: Bool) {
-        handleCallStateChange(hasConnected: hasConnected, hasEnded: hasEnded)
+    func _test_simulateCallChanged(hasEnded: Bool) {
+        handleCallStateChange(hasEnded: hasEnded)
     }
 
     func _test_simulateAudioInterruption(_ event: AudioSessionCoordinator.InterruptionEvent) {

--- a/Pilgrim/Models/Walk/WalkBuilder/Components/VoiceRecordingManagement.swift
+++ b/Pilgrim/Models/Walk/WalkBuilder/Components/VoiceRecordingManagement.swift
@@ -294,20 +294,31 @@ extension VoiceRecordingManagement: CXCallObserverDelegate {
         handleCallStateChange(hasConnected: call.hasConnected, hasEnded: call.hasEnded)
     }
 
+    /// A phone call — incoming-ringing, connected, or outgoing — takes the mic,
+    /// so the talk must stop. CXCallObserver reports any active call here
+    /// (`!hasEnded`), which is the reliable signal; an *unanswered* incoming
+    /// call (rings, never connects) is caught this way too. Only an actual call
+    /// ends the talk — see `handleAudioInterruption` for why transient
+    /// (non-call) interruptions deliberately do not.
     private func handleCallStateChange(hasConnected: Bool, hasEnded: Bool) {
-        guard hasConnected, !hasEnded, isRecording else { return }
+        guard !hasEnded, isRecording else { return }
         stopRecording()
     }
 
-    /// Non-call interruptions (declined call, Siri, alarm) pause the
-    /// AVAudioRecorder with no resume path — finalize immediately so the
-    /// captured audio is committed instead of silently truncating while the
-    /// UI keeps showing an active recording. Connected calls also arrive
-    /// here via CXCallObserver; the isRecording guard makes the overlap a
-    /// no-op for whichever fires second.
+    /// Transient audio interruptions (notifications, Siri, an alarm) must NOT
+    /// end the talk — a momentary sound shouldn't cut a long recording. Real
+    /// phone calls are handled by CXCallObserver above, not here. We log the
+    /// interruption (rather than ignore it silently) so a field report can tell
+    /// what interrupted; the recording is left as-is.
+    ///
+    /// Trade-off: AVAudioRecorder cannot resume into the same file after the
+    /// system deactivates the session (Apple-confirmed), so if a non-call
+    /// interruption genuinely breaks capture, the tail of this recording may be
+    /// lost. We accept that over the prior behavior, which finalized the talk on
+    /// every notification.
     private func handleAudioInterruption(_ event: AudioSessionCoordinator.InterruptionEvent) {
         guard case .began = event, isRecording else { return }
-        stopRecording()
+        print("[VoiceRecordingManagement] audio interruption during recording — not finalizing (calls handled via CallKit)")
     }
 
     #if DEBUG

--- a/UnitTests/VoiceRecordingCallInterruptionTests.swift
+++ b/UnitTests/VoiceRecordingCallInterruptionTests.swift
@@ -21,7 +21,7 @@ final class VoiceRecordingCallInterruptionTests: XCTestCase {
                        "recording should stop the moment a call connects")
     }
 
-    func test_callChanged_doesNothing_whenCallNotConnected() {
+    func test_callChanged_stopsRecording_whenCallRinging() {
         let builder = WalkBuilder()
         let mgmt = VoiceRecordingManagement(builder: builder)
         settleCombineSchedulers()
@@ -31,10 +31,11 @@ final class VoiceRecordingCallInterruptionTests: XCTestCase {
             relativePath: "Recordings/X/rec.m4a"
         )
 
+        // An incoming call that rings but is never answered still takes the mic.
         mgmt._test_simulateCallChanged(hasConnected: false, hasEnded: false)
 
-        XCTAssertTrue(mgmt.isRecording,
-                      "ringing / declined call must NOT end the recording")
+        XCTAssertFalse(mgmt.isRecording,
+                       "an active (ringing/unanswered) call must end the recording, not just a connected one")
     }
 
     func test_callChanged_doesNothing_whenNotRecording() {
@@ -65,7 +66,7 @@ final class VoiceRecordingCallInterruptionTests: XCTestCase {
 
     // MARK: - Non-call audio interruptions (declined call, Siri, alarm)
 
-    func test_audioInterruptionBegan_finalizesActiveRecording() {
+    func test_audioInterruptionBegan_doesNotFinalize_transientNonCall() {
         let builder = WalkBuilder()
         let mgmt = VoiceRecordingManagement(builder: builder)
         settleCombineSchedulers()
@@ -77,12 +78,12 @@ final class VoiceRecordingCallInterruptionTests: XCTestCase {
 
         mgmt._test_simulateAudioInterruption(.began)
 
-        XCTAssertFalse(mgmt.isRecording,
-                       "a non-call interruption pauses the recorder with no resume — the recording must finalize, not silently truncate")
-        XCTAssertNil(mgmt.recordingStartDate)
+        XCTAssertTrue(mgmt.isRecording,
+                      "a transient non-call interruption (notification, Siri, alarm) must NOT end the talk — only a real call does")
+        XCTAssertNotNil(mgmt.recordingStartDate)
     }
 
-    func test_audioInterruptionEnded_doesNotRestartRecording() {
+    func test_audioInterruption_beginThenEnd_keepsRecording() {
         let builder = WalkBuilder()
         let mgmt = VoiceRecordingManagement(builder: builder)
         settleCombineSchedulers()
@@ -95,8 +96,8 @@ final class VoiceRecordingCallInterruptionTests: XCTestCase {
 
         mgmt._test_simulateAudioInterruption(.ended(shouldResume: true))
 
-        XCTAssertFalse(mgmt.isRecording,
-                       "the interrupted recording was finalized — .ended must not spontaneously restart capture")
+        XCTAssertTrue(mgmt.isRecording,
+                      "a transient interruption that begins and ends must leave the talk recording untouched")
     }
 
     func test_audioInterruptionBegan_doesNothing_whenNotRecording() {

--- a/UnitTests/VoiceRecordingCallInterruptionTests.swift
+++ b/UnitTests/VoiceRecordingCallInterruptionTests.swift
@@ -4,7 +4,7 @@ import CallKit
 
 final class VoiceRecordingCallInterruptionTests: XCTestCase {
 
-    func test_callChanged_stopsRecording_whenCallConnects() {
+    func test_callChanged_stopsRecording_forAnyActiveCall() {
         let builder = WalkBuilder()
         let mgmt = VoiceRecordingManagement(builder: builder)
         settleCombineSchedulers()
@@ -15,27 +15,13 @@ final class VoiceRecordingCallInterruptionTests: XCTestCase {
         )
         XCTAssertTrue(mgmt.isRecording, "precondition: recording is active")
 
-        mgmt._test_simulateCallChanged(hasConnected: true, hasEnded: false)
+        // Any active call (`!hasEnded`) takes the mic — a connected call and an
+        // unanswered incoming ring are treated identically.
+        mgmt._test_simulateCallChanged(hasEnded: false)
 
         XCTAssertFalse(mgmt.isRecording,
-                       "recording should stop the moment a call connects")
-    }
-
-    func test_callChanged_stopsRecording_whenCallRinging() {
-        let builder = WalkBuilder()
-        let mgmt = VoiceRecordingManagement(builder: builder)
-        settleCombineSchedulers()
-
-        mgmt._test_setActiveRecording(
-            start: Date(timeIntervalSinceNow: -10),
-            relativePath: "Recordings/X/rec.m4a"
-        )
-
-        // An incoming call that rings but is never answered still takes the mic.
-        mgmt._test_simulateCallChanged(hasConnected: false, hasEnded: false)
-
-        XCTAssertFalse(mgmt.isRecording,
-                       "an active (ringing/unanswered) call must end the recording, not just a connected one")
+                       "an active call (connected or unanswered ring) must end the recording")
+        XCTAssertNil(mgmt.recordingStartDate)
     }
 
     func test_callChanged_doesNothing_whenNotRecording() {
@@ -43,7 +29,7 @@ final class VoiceRecordingCallInterruptionTests: XCTestCase {
         let mgmt = VoiceRecordingManagement(builder: builder)
         settleCombineSchedulers()
 
-        mgmt._test_simulateCallChanged(hasConnected: true, hasEnded: false)
+        mgmt._test_simulateCallChanged(hasEnded: false)
 
         XCTAssertFalse(mgmt.isRecording)
     }
@@ -58,13 +44,35 @@ final class VoiceRecordingCallInterruptionTests: XCTestCase {
             relativePath: "Recordings/X/rec.m4a"
         )
 
-        mgmt._test_simulateCallChanged(hasConnected: true, hasEnded: true)
+        mgmt._test_simulateCallChanged(hasEnded: true)
 
         XCTAssertTrue(mgmt.isRecording,
-                      "a call-ended transition after disconnect must not flip recording state")
+                      "a call-ended transition must not flip recording state")
+        XCTAssertNotNil(mgmt.recordingStartDate)
     }
 
-    // MARK: - Non-call audio interruptions (declined call, Siri, alarm)
+    func test_realCall_callThenAudioInterruption_stopsExactlyOnce() {
+        let builder = WalkBuilder()
+        let mgmt = VoiceRecordingManagement(builder: builder)
+        settleCombineSchedulers()
+
+        mgmt._test_setActiveRecording(
+            start: Date(timeIntervalSinceNow: -10),
+            relativePath: "Recordings/X/rec.m4a"
+        )
+
+        // A real call fires BOTH CXCallObserver and a session interruption. The
+        // call stops the talk; the trailing interruption must be a clean no-op.
+        mgmt._test_simulateCallChanged(hasEnded: false)
+        mgmt._test_setRecorderCapturing(false)
+        mgmt._test_simulateAudioInterruption(.began)
+        mgmt._test_simulateAudioInterruption(.ended(shouldResume: false))
+
+        XCTAssertFalse(mgmt.isRecording)
+        XCTAssertNil(mgmt.recordingStartDate)
+    }
+
+    // MARK: - Non-call audio interruptions (notification, Siri, alarm)
 
     func test_audioInterruptionBegan_doesNotFinalize_transientNonCall() {
         let builder = WalkBuilder()
@@ -79,11 +87,11 @@ final class VoiceRecordingCallInterruptionTests: XCTestCase {
         mgmt._test_simulateAudioInterruption(.began)
 
         XCTAssertTrue(mgmt.isRecording,
-                      "a transient non-call interruption (notification, Siri, alarm) must NOT end the talk — only a real call does")
+                      "a transient non-call interruption (notification, Siri, alarm) must NOT end the talk on .began")
         XCTAssertNotNil(mgmt.recordingStartDate)
     }
 
-    func test_audioInterruption_beginThenEnd_keepsRecording() {
+    func test_audioInterruptionEnded_keepsRecording_whenRecorderSurvived() {
         let builder = WalkBuilder()
         let mgmt = VoiceRecordingManagement(builder: builder)
         settleCombineSchedulers()
@@ -92,12 +100,33 @@ final class VoiceRecordingCallInterruptionTests: XCTestCase {
             start: Date(timeIntervalSinceNow: -10),
             relativePath: "Recordings/X/rec.m4a"
         )
-        mgmt._test_simulateAudioInterruption(.began)
+        mgmt._test_setRecorderCapturing(true)
 
+        mgmt._test_simulateAudioInterruption(.began)
         mgmt._test_simulateAudioInterruption(.ended(shouldResume: true))
 
         XCTAssertTrue(mgmt.isRecording,
-                      "a transient interruption that begins and ends must leave the talk recording untouched")
+                      "a recorder that lived through a transient interruption must keep recording — no split")
+        XCTAssertNotNil(mgmt.recordingStartDate)
+    }
+
+    func test_audioInterruptionEnded_finalizes_whenRecorderStopped() {
+        let builder = WalkBuilder()
+        let mgmt = VoiceRecordingManagement(builder: builder)
+        settleCombineSchedulers()
+
+        mgmt._test_setActiveRecording(
+            start: Date(timeIntervalSinceNow: -10),
+            relativePath: "Recordings/X/rec.m4a"
+        )
+        mgmt._test_setRecorderCapturing(false)
+
+        mgmt._test_simulateAudioInterruption(.began)
+        mgmt._test_simulateAudioInterruption(.ended(shouldResume: false))
+
+        XCTAssertFalse(mgmt.isRecording,
+                       "a recorder the interruption stopped must be finalized on .ended, not left capturing nothing")
+        XCTAssertNil(mgmt.recordingStartDate)
     }
 
     func test_audioInterruptionBegan_doesNothing_whenNotRecording() {

--- a/docs/solutions/avaudiorecorder-cannot-resume-across-interruption.md
+++ b/docs/solutions/avaudiorecorder-cannot-resume-across-interruption.md
@@ -54,7 +54,11 @@ For transient non-call interruptions, don't finalize on `.began`; instead probe
 the recorder on `.ended` (option 3 above). That keeps a survivable interruption
 seamless (one continuous file) while still finalizing cleanly — correct
 duration, mic released, no zombie capture — when the system actually stopped the
-recorder. Watch two related lifecycle traps the no-finalize path exposes:
+recorder. **Confirmed on device** (iPhone SE3): an alarm interruption stops the
+recorder, `audioRecorder.isRecording` reads `false` on `.ended`, the probe
+fires, and the talk finalizes as one file with the captured audio intact and the
+mic released — so the `false`-reading assumption the probe depends on holds on
+real hardware (unit tests inject this state and cannot prove it). Watch two related lifecycle traps the no-finalize path exposes:
 `AVAudioRecorder`'s finish delegate firing `successfully: false` can delete the
 whole file and leave stale `isRecording` state (reset it), and a coordinator
 that re-activates the session on `.ended` will hold a live mic recording nothing

--- a/docs/solutions/avaudiorecorder-cannot-resume-across-interruption.md
+++ b/docs/solutions/avaudiorecorder-cannot-resume-across-interruption.md
@@ -25,14 +25,20 @@ single non-obvious framework fact that is worth not rediscovering.
 after `AVAudioSession.interruptionNotification` `.began` does not append — it
 discards the pre-interruption audio. There is no "pause and continue in place."
 
-Your only real choices when an interruption begins are therefore:
+Your real choices when an interruption begins are therefore:
 
 1. **Finalize** the current file and treat the interruption as a hard stop, or
 2. **Segment-and-merge** — finalize the current file, start a new one when the
-   interruption ends, and stitch the segments together afterward.
+   interruption ends, and stitch the segments together afterward, or
+3. **Probe and finalize only if the recorder died** — don't act on `.began`; on
+   `.ended`, read `audioRecorder.isRecording`. If it survived the interruption,
+   let it keep going (seamless); if it was stopped, finalize the audio captured
+   so far *then* (correct duration, mic released) instead of leaving it nominally
+   "recording" with a dead recorder.
 
-"Keep the recorder running and let it pick back up" is not an option, no matter
-how brief the interruption.
+"Keep the recorder running and let it pick back up after the system stopped it"
+is not an option, no matter how brief the interruption — once stopped, the file
+is sealed.
 
 ## Why This Matters
 Conflating these two facts causes both failure modes we hit:
@@ -44,10 +50,15 @@ Conflating these two facts causes both failure modes we hit:
 The right split is by **interruption source**, not by the `.began` event alone:
 detect real phone calls via `CXCallObserver` (which fires for any active call,
 `!hasEnded` — including unanswered rings) and stop the talk only for those.
-Leave the recorder running on transient non-call interruptions; accept the
-documented tail-loss risk rather than finalizing on every system sound. If
-that tail-loss ever proves common in the field, the principled upgrade is
-segment-and-merge — not "resume in place," which does not exist.
+For transient non-call interruptions, don't finalize on `.began`; instead probe
+the recorder on `.ended` (option 3 above). That keeps a survivable interruption
+seamless (one continuous file) while still finalizing cleanly — correct
+duration, mic released, no zombie capture — when the system actually stopped the
+recorder. Watch two related lifecycle traps the no-finalize path exposes:
+`AVAudioRecorder`'s finish delegate firing `successfully: false` can delete the
+whole file and leave stale `isRecording` state (reset it), and a coordinator
+that re-activates the session on `.ended` will hold a live mic recording nothing
+unless the dead-recorder case releases it.
 
 ## When to Apply
 - Any time you add or change `AVAudioSession` interruption handling around an

--- a/docs/solutions/avaudiorecorder-cannot-resume-across-interruption.md
+++ b/docs/solutions/avaudiorecorder-cannot-resume-across-interruption.md
@@ -1,0 +1,61 @@
+---
+title: AVAudioRecorder cannot resume into the same file after a system interruption
+date: 2026-06-30
+category: audio
+module: VoiceRecordingManagement
+problem_type: best_practice
+component: service_object
+severity: medium
+applies_when:
+  - "Handling AVAudioSession interruptions while AVAudioRecorder is capturing"
+  - "Deciding what to do when a call, Siri, alarm, or notification interrupts a recording"
+tags: [avaudiorecorder, audio-interruption, avaudiosession, voice-recording, callkit, ios]
+---
+
+# AVAudioRecorder cannot resume into the same file after a system interruption
+
+## Context
+A "talk" recording was being cut short by transient audio interruptions (a
+notification, Siri, an alarm) — not just phone calls. The fix turned on a
+single non-obvious framework fact that is worth not rediscovering.
+
+## Guidance
+**Once the system deactivates the audio session for an interruption, an
+`AVAudioRecorder` cannot resume into the same file.** Calling `record()` again
+after `AVAudioSession.interruptionNotification` `.began` does not append — it
+discards the pre-interruption audio. There is no "pause and continue in place."
+
+Your only real choices when an interruption begins are therefore:
+
+1. **Finalize** the current file and treat the interruption as a hard stop, or
+2. **Segment-and-merge** — finalize the current file, start a new one when the
+   interruption ends, and stitch the segments together afterward.
+
+"Keep the recorder running and let it pick back up" is not an option, no matter
+how brief the interruption.
+
+## Why This Matters
+Conflating these two facts causes both failure modes we hit:
+- Assuming you *can* resume → silent tail loss (recorder looks alive, captures
+  nothing after the interruption).
+- Treating *every* `.began` as a hard stop → a one-second notification ding
+  ends a 40-minute talk (this was the v1.7.0 AF11 regression, pilgrim-worker#15).
+
+The right split is by **interruption source**, not by the `.began` event alone:
+detect real phone calls via `CXCallObserver` (which fires for any active call,
+`!hasEnded` — including unanswered rings) and stop the talk only for those.
+Leave the recorder running on transient non-call interruptions; accept the
+documented tail-loss risk rather than finalizing on every system sound. If
+that tail-loss ever proves common in the field, the principled upgrade is
+segment-and-merge — not "resume in place," which does not exist.
+
+## When to Apply
+- Any time you add or change `AVAudioSession` interruption handling around an
+  active `AVAudioRecorder`.
+- Before writing code that assumes a recording survives an interruption.
+
+## Related
+- `Pilgrim/Models/Walk/WalkBuilder/Components/VoiceRecordingManagement.swift`
+  (`handleCallStateChange`, `handleAudioInterruption`)
+- pilgrim-worker#15 (real-world split-recording report)
+- PR #47 (fix), follow-up to PR #45 (v1.7.0, where AF11 introduced the regression)


### PR DESCRIPTION
## Only end the talk for real calls, not transient interruptions

### Problem
A voice "talk" recording was getting cut short by **non-call** audio interruptions — a notification, Siri, an alarm — not just phone calls. Real-world report: [pilgrim-worker#15](https://github.com/walktalkmeditate/pilgrim-worker/issues/15) — a 40:48 talk split into two recordings, the second cut short (~15 min in) while the user was still talking, with no call involved.

### Root cause
v1.7.0's audit fix **AF11** added `VoiceRecordingManagement.handleAudioInterruption`, which finalized the recording on **any** `AVAudioSession` `.began` interruption. That treated a 1-second notification ding identically to a phone call. (`CXCallObserver` only stops on *connected* calls, so the unanswered-call and notification cuts both came through this `.began` path.)

### Why not just "resume the recording"
A `/ce-debug` pass (with framework-docs research) confirmed an **Apple-acknowledged limitation**: `AVAudioRecorder` cannot resume into the same file after the system deactivates the session — calling `record()` again discards the pre-interruption audio. So "pause and resume in place" is a dead end; AF11's instinct to not rely on resume was correct, but finalizing on *every* interruption was too blunt.

### Fix
- **`handleCallStateChange`** now stops the talk for **any active call** (`!hasEnded`) — incoming-ringing and unanswered calls included, not just connected ones — via the reliable CallKit signal. "A call ends the talk" is preserved (including the unanswered-call case).
- **`handleAudioInterruption`** no longer finalizes on a transient non-call interruption. It logs (for field diagnosis) and leaves the recording running, so a momentary sound no longer cuts a talk.

### Trade-off (documented in code)
If a non-call interruption *genuinely* breaks capture, the tail of that recording may be silently lost (the recorder can't be resumed). This is accepted over finalizing the talk on every notification, and matches the pre-AF11 behavior. The added log line means a future field report can identify exactly what interrupted.

### Tests
`VoiceRecordingCallInterruptionTests` updated to assert the corrected behavior: a ringing/unanswered call stops the recording; a transient non-call interruption (begin, or begin+end) leaves it running. Full suite green, lint clean.

Follow-up to #45 (v1.7.0). Addresses pilgrim-worker#15 (cross-repo — referenced, not auto-closed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
