### PR TITLE
fix(seek): seek controls appear on the pre-walk options sheet

### DIFF
--- a/Pilgrim/Scenes/ActiveWalk/WalkOptionsSheet.swift
+++ b/Pilgrim/Scenes/ActiveWalk/WalkOptionsSheet.swift
@@ -70,8 +70,15 @@ struct WalkOptionsSheet: View {
                         }
                     }
 
+                    // The seek is already alive on the ready screen — the
+                    // engine boots at the gateway, fog and crescent are on
+                    // the map — so its controls appear as soon as the engine
+                    // exists (self-gated via isSeekActive), letting the
+                    // walker check the sonar or reroll before stepping off.
+                    // Wander pre-walk renders nothing here.
+                    seekSection
+
                     if isRecording {
-                        seekSection
                         traceSection
                         audioSection
                     }


### PR DESCRIPTION
## What

Pre-walk (ready screen), the options sheet showed only **Set Intention** for a seek. But the seek is already alive there — the engine boots at the gateway, the fog and crescent are on the map — so the seek section (sonar toggle, volume, Seek anew) now appears as soon as the engine exists instead of waiting for recording to start.

## Why it's right

- The pocket-or-hand decision happens **before** Start — that's when you want to check the ping and its volume.
- If the crescent already points somewhere you know is closed, rerolling before stepping off is the cheapest "Seek anew" of all.
- The section self-gates on `isSeekActive` (`seekEngine != nil`), so wander pre-walk renders exactly as before and the row can never dead-tap during the GPS-lock window. Trace and audio sections stay recording-only.

## Verification

- 898 unit tests green, lint at baseline.
- Installed on the SE 3 for field check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
