### PR TITLE
feat(seek): the accumulation package — glyphs, seeded ways, hour-light halos, keepsake, seals

### DIFF
--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -180,6 +180,7 @@
 		3D254F3D8D18F5FF91F89330 /* WhisperPlacementSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3542AA50A2E8FA62E52758C7 /* WhisperPlacementSheet.swift */; };
 		3DF4B121DEE87CA7EBB26207 /* VoiceGuideSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFDE354370A5891DF5C3F183 /* VoiceGuideSettingsView.swift */; };
 		3E99F36DBCDB461C99F60DA5 /* SolarHorizon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A98AEE09143482AA1EFE5DC /* SolarHorizon.swift */; };
+		3F0FA8A403AAC29DE24EB134 /* SeekSeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FBACFFF80A407D7E01411E8 /* SeekSeedTests.swift */; };
 		3F8E37CD28D541C1838F01BD /* PilgrimV2.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2722224F049B455DB473E7C9 /* PilgrimV2.swift */; };
 		44B04EE19F844EACEBD0DB0F /* CelestialCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0BF12667E7A1DF70EA195B19 /* CelestialCalculator.swift */; };
 		45ECE5D78ADACF7F238277C4 /* AudioManifestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 390BFBA7B83028EA625B0CF9 /* AudioManifestService.swift */; };
@@ -316,6 +317,7 @@
 		AEEE78F348F94AFAE50C2CCA /* CachedWhisper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3023392A906A22FDA4E0B84A /* CachedWhisper.swift */; };
 		B0261DB7EE2F64C26CF7A41F /* VoiceGuideFileStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDB41AD9F5C496AE9BC8C260 /* VoiceGuideFileStore.swift */; };
 		B1B77C4B2BCFC984DB3D8244 /* LaunchLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 119C8CECDB3E592FD5E40D38 /* LaunchLoadingView.swift */; };
+		B3521FF9E5891FCB4A570140 /* SeekSeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1B88BDEB24D53EA8138F1F6 /* SeekSeed.swift */; };
 		B3B167A980AE4EF4F8982EAA /* whisper-play-5.aac in Resources */ = {isa = PBXBuildFile; fileRef = 22F5B51BC494516AF77C1861 /* whisper-play-5.aac */; };
 		B3C4D5E6F7A8B9C0D1E2F3A4 /* SealColorPalette.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4B5C6D7E8F9A0B1C2D3E4F5 /* SealColorPalette.swift */; };
 		B3D4E5F6A7B8C9D0E1F2A3B5 /* RecordingsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4E5F6A7B8C9D0E1F2A3B4C6 /* RecordingsListView.swift */; };
@@ -618,6 +620,7 @@
 		1E7778DEF038B34761DEEA84 /* AudioPriorityQueue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioPriorityQueue.swift; sourceTree = "<group>"; };
 		1EA24EC80491999A8B22B044 /* seek-bowl.aac */ = {isa = PBXFileReference; includeInIndex = 1; path = "seek-bowl.aac"; sourceTree = "<group>"; };
 		1F75E3F362FAF3F2F9D174C7 /* CanvasBackground.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CanvasBackground.swift; sourceTree = "<group>"; };
+		1FBACFFF80A407D7E01411E8 /* SeekSeedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SeekSeedTests.swift; sourceTree = "<group>"; };
 		207E5D02B1ED4FF24CCD6F36 /* SeekPersistence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SeekPersistence.swift; sourceTree = "<group>"; };
 		2204A1DC255ACB1100906CFE /* DataTypeProtocol.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataTypeProtocol.swift; sourceTree = "<group>"; };
 		2204E427295DF28C00243FC3 /* SetupCoordinatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetupCoordinatorView.swift; sourceTree = "<group>"; };
@@ -856,6 +859,7 @@
 		A1B2C3D4E5F601020304050A /* PilgrimV3.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV3.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6A7B8C9D0E1F2 /* PermissionStatusViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionStatusViewModel.swift; sourceTree = "<group>"; };
 		A1B2C3D4E5F6A7B8C9D0E1F4 /* PermissionStatusViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PermissionStatusViewModelTests.swift; sourceTree = "<group>"; };
+		A1B88BDEB24D53EA8138F1F6 /* SeekSeed.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SeekSeed.swift; sourceTree = "<group>"; };
 		A1E1CDD84132639F8B1B90D8 /* whisper-play-7.aac */ = {isa = PBXFileReference; includeInIndex = 1; path = "whisper-play-7.aac"; sourceTree = "<group>"; };
 		A1EFC525D5AECBC02A3F6879 /* whisper-wonder-2.aac */ = {isa = PBXFileReference; includeInIndex = 1; path = "whisper-wonder-2.aac"; sourceTree = "<group>"; };
 		A4B5C6D7E8F9A0B1C2D3E4F5 /* SealColorPalette.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SealColorPalette.swift; sourceTree = "<group>"; };
@@ -2003,6 +2007,7 @@
 				BBB2D6A557287CBD051BF314 /* SeekSummaryTests.swift */,
 				891AB02D5C379B14317F9FBA /* SeekDemoSeedTests.swift */,
 				E2851FE86E579A0EE4C0EB98 /* SeekWispVisibilityTests.swift */,
+				1FBACFFF80A407D7E01411E8 /* SeekSeedTests.swift */,
 			);
 			name = Seek;
 			path = Seek;
@@ -2056,6 +2061,7 @@
 				207E5D02B1ED4FF24CCD6F36 /* SeekPersistence.swift */,
 				07DBA20381F115380FCCA8D9 /* SeekGlance.swift */,
 				BFB33487484B5D9579CE62A2 /* SeekFogModel.swift */,
+				A1B88BDEB24D53EA8138F1F6 /* SeekSeed.swift */,
 			);
 			name = Seek;
 			path = Seek;
@@ -3011,6 +3017,7 @@
 				4E67344B8C0A415F1F08BD96 /* SeekFogModel.swift in Sources */,
 				FA3A2A63A5918E8EDA93F05C /* PilgrimMapView+SeekWisp.swift in Sources */,
 				0D932D622CFA1D69337AD28B /* WalkModeFootprints.swift in Sources */,
+				B3521FF9E5891FCB4A570140 /* SeekSeed.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -3113,6 +3120,7 @@
 				26D2A22BA6DF2D3C6508C30F /* SeekSummaryTests.swift in Sources */,
 				B630C01285A745C4C0B04FC5 /* SeekDemoSeedTests.swift in Sources */,
 				188DB055DF097D51DAEE2FA1 /* SeekWispVisibilityTests.swift in Sources */,
+				3F0FA8A403AAC29DE24EB134 /* SeekSeedTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -22,6 +22,7 @@
 		0AF0FF1EDA75BDC6A3A3D2A6 /* PromptAssembler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6EA04337299ABAFFB2644FC /* PromptAssembler.swift */; };
 		0C411D46B6C254451E36DC75 /* whisper-presence-4.aac in Resources */ = {isa = PBXBuildFile; fileRef = 83BD1C5A8539657B3A5EC6BD /* whisper-presence-4.aac */; };
 		0CFF4F227FE28FE0E48BCB44 /* CairnVisualGenerator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 123512C2E2D2088520214836 /* CairnVisualGenerator.swift */; };
+		0D932D622CFA1D69337AD28B /* WalkModeFootprints.swift in Sources */ = {isa = PBXBuildFile; fileRef = F3394422200CBF5C8EB78180 /* WalkModeFootprints.swift */; };
 		0DD491B2F4B55805B322709B /* whisper-compassion-1.aac in Resources */ = {isa = PBXBuildFile; fileRef = 44661BA899955FDD26DFF034 /* whisper-compassion-1.aac */; };
 		0E29E944B6EEAD64EB33151E /* XCTestCase+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 721BF267E7540B2B259806D1 /* XCTestCase+Combine.swift */; };
 		0E9B9341AEF918BA4BB7901C /* PilgrimPackageConverterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EFD52EBCDBB52EAE65C974A0 /* PilgrimPackageConverterTests.swift */; };
@@ -1056,6 +1057,7 @@
 		F1A2B3C4D5E6F7A8B9C0D1E4 /* PilgrimV4.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PilgrimV4.swift; sourceTree = "<group>"; };
 		F1A2B3C4D5E6F7A8B9C0D1E6 /* FaviconSelectorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FaviconSelectorView.swift; sourceTree = "<group>"; };
 		F1A2B3C4D5E6F7A8B9C0D200 /* SealRenderer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SealRenderer.swift; sourceTree = "<group>"; };
+		F3394422200CBF5C8EB78180 /* WalkModeFootprints.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkModeFootprints.swift; sourceTree = "<group>"; };
 		F42B3177F3066393F8828357 /* whisper-play-2.aac */ = {isa = PBXFileReference; includeInIndex = 1; path = "whisper-play-2.aac"; sourceTree = "<group>"; };
 		F578B62CF2FE5D35049BA99E /* PendingPlacement.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PendingPlacement.swift; sourceTree = "<group>"; };
 		F5DBDBA14D74B3061F349DA5 /* whisper-stillness-3.aac */ = {isa = PBXFileReference; includeInIndex = 1; path = "whisper-stillness-3.aac"; sourceTree = "<group>"; };
@@ -1644,6 +1646,7 @@
 				4AD7C7A50CC75536619799F2 /* PilgrimMapView+SeekFog.swift */,
 				B886390B795403D3BB7B3372 /* VolumeSliderRow.swift */,
 				7C094BDB35610B61FBFB8488 /* PilgrimMapView+SeekWisp.swift */,
+				F3394422200CBF5C8EB78180 /* WalkModeFootprints.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -3007,6 +3010,7 @@
 				CED5FDA068F49C88B833F845 /* SeekGatewayView.swift in Sources */,
 				4E67344B8C0A415F1F08BD96 /* SeekFogModel.swift in Sources */,
 				FA3A2A63A5918E8EDA93F05C /* PilgrimMapView+SeekWisp.swift in Sources */,
+				0D932D622CFA1D69337AD28B /* WalkModeFootprints.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Pilgrim/Models/LS.swift
+++ b/Pilgrim/Models/LS.swift
@@ -215,6 +215,24 @@ struct LS {
     )
 
     /// Closing group for signs marked outside every clearing (R19).
+    static let seekSummaryFoundGolden = NSLocalizedString(
+        "seek.summary.found_under.golden",
+        value: "Found in the golden hour",
+        comment: "Walk-summary caption for a clearing reached while the sun was low — dawn or dusk light."
+    )
+
+    static let seekSummaryFoundMidday = NSLocalizedString(
+        "seek.summary.found_under.midday",
+        value: "Found in broad daylight",
+        comment: "Walk-summary caption for a clearing reached with the sun high."
+    )
+
+    static let seekSummaryFoundNight = NSLocalizedString(
+        "seek.summary.found_under.night",
+        value: "Found under the night sky",
+        comment: "Walk-summary caption for a clearing reached after dark."
+    )
+
     static let seekSummaryAlongTheWay = NSLocalizedString(
         "seek.summary.along_the_way",
         value: "Along the way",

--- a/Pilgrim/Models/LS.swift
+++ b/Pilgrim/Models/LS.swift
@@ -233,6 +233,18 @@ struct LS {
         comment: "Walk-summary caption for a clearing reached after dark."
     )
 
+    static let seekSummarySeededFormat = NSLocalizedString(
+        "seek.summary.seeded",
+        value: "The way was shaped by your intention and the moment you set out — %@.",
+        comment: "Closing keepsake line of the seek summary; %@ is the time recording began. States the seed provenance honestly: intention + moment generate the clearings."
+    )
+
+    static let seekSummarySeededQuietFormat = NSLocalizedString(
+        "seek.summary.seeded.quiet",
+        value: "The way was shaped by the moment you set out — %@.",
+        comment: "Keepsake variant for the edge case of a seek without an intention text; %@ is the time recording began."
+    )
+
     static let seekSummaryAlongTheWay = NSLocalizedString(
         "seek.summary.along_the_way",
         value: "Along the way",

--- a/Pilgrim/Models/Seal/SealInput.swift
+++ b/Pilgrim/Models/Seal/SealInput.swift
@@ -16,6 +16,9 @@ struct SealInput {
     let routeTimestamps: [Date]
     let activityIntervals: [(type: ActivityInterval.ActivityType, startDate: Date, endDate: Date)]
     let voiceRecordingStartDates: [Date]
+    /// Seek arrivals recorded on this walk (reserved-icon waypoints), for
+    /// the seeking milestones.
+    let foundPlaceCount: Int
 
     init(walk: WalkInterface) {
         self.uuid = walk.uuid?.uuidString
@@ -35,5 +38,6 @@ struct SealInput {
             (type: $0.activityType, startDate: $0.startDate, endDate: $0.endDate)
         }
         self.voiceRecordingStartDates = walk.voiceRecordings.map(\.startDate)
+        self.foundPlaceCount = walk.waypoints.filter(SeekPersistence.isArrivalWaypoint).count
     }
 }

--- a/Pilgrim/Models/Walk/MapManagement/PilgrimAnnotation.swift
+++ b/Pilgrim/Models/Walk/MapManagement/PilgrimAnnotation.swift
@@ -10,6 +10,11 @@ struct PilgrimAnnotation: Identifiable {
         case meditation(duration: TimeInterval)
         case voiceRecording(label: String)
         case waypoint(label: String, icon: String)
+        /// A seek arrival on the summary map: a dawn halo in the hour's
+        /// light it was found under (fixed hex — the record keeps the sky
+        /// palette), not a pin. Live walks keep `.waypoint` — their halo
+        /// comes from the fog layer.
+        case seekArrival(label: String, lightHex: String)
         case startPoint
         case endPoint
         case whisper(categoryColor: UIColor, isNearby: Bool)

--- a/Pilgrim/Models/Walk/Seek/SeekEngine.swift
+++ b/Pilgrim/Models/Walk/Seek/SeekEngine.swift
@@ -127,8 +127,10 @@ final class SeekEngine: ObservableObject {
     /// R17 reroll. The remaining budget is a v1 estimate — distance walked
     /// is not tracked here, so the budget scales by the fraction of
     /// clearings still ahead, clamped so the regenerated remainder is never
-    /// degenerate.
-    func seekAnew(currentLocation: SeekPoint) {
+    /// degenerate. Callers may pass a SeekSeed so the reroll carries the
+    /// same provenance as the original generation; nil falls back to OS
+    /// entropy (tests, callers without an intention in reach).
+    func seekAnew(currentLocation: SeekPoint, seed: UInt64? = nil) {
         guard phase == .guiding || phase == .arrived else { return }
         if phase == .arrived {
             stopStillnessMachinery()
@@ -139,13 +141,22 @@ final class SeekEngine: ObservableObject {
             chain.budgetMeters * fractionAhead,
             SeekEngineTuning.rerollMinBudgetMeters
         )
-        var rng = SystemRandomNumberGenerator()
-        chain = chain.regeneratingRemainder(
-            fromActiveIndex: activeIndex,
-            current: currentLocation,
-            remainingBudgetMeters: remainingBudget,
-            using: &rng
-        )
+        if var seeded = seed.map(SeekSeededGenerator.init(seed:)) {
+            chain = chain.regeneratingRemainder(
+                fromActiveIndex: activeIndex,
+                current: currentLocation,
+                remainingBudgetMeters: remainingBudget,
+                using: &seeded
+            )
+        } else {
+            var rng = SystemRandomNumberGenerator()
+            chain = chain.regeneratingRemainder(
+                fromActiveIndex: activeIndex,
+                current: currentLocation,
+                remainingBudgetMeters: remainingBudget,
+                using: &rng
+            )
+        }
         consecutiveInsideCount = 0
         rerollPulseDistance = distanceToActiveMeters
         distanceToActiveMeters = nil

--- a/Pilgrim/Models/Walk/Seek/SeekEngine.swift
+++ b/Pilgrim/Models/Walk/Seek/SeekEngine.swift
@@ -142,20 +142,10 @@ final class SeekEngine: ObservableObject {
             SeekEngineTuning.rerollMinBudgetMeters
         )
         if var seeded = seed.map(SeekSeededGenerator.init(seed:)) {
-            chain = chain.regeneratingRemainder(
-                fromActiveIndex: activeIndex,
-                current: currentLocation,
-                remainingBudgetMeters: remainingBudget,
-                using: &seeded
-            )
+            regenerateRemainder(current: currentLocation, budgetMeters: remainingBudget, using: &seeded)
         } else {
             var rng = SystemRandomNumberGenerator()
-            chain = chain.regeneratingRemainder(
-                fromActiveIndex: activeIndex,
-                current: currentLocation,
-                remainingBudgetMeters: remainingBudget,
-                using: &rng
-            )
+            regenerateRemainder(current: currentLocation, budgetMeters: remainingBudget, using: &rng)
         }
         consecutiveInsideCount = 0
         rerollPulseDistance = distanceToActiveMeters
@@ -167,6 +157,19 @@ final class SeekEngine: ObservableObject {
             // haptic, one ring the moment the new clearing exists.
             emitPulse()
         }
+    }
+
+    private func regenerateRemainder<R: RandomNumberGenerator>(
+        current: SeekPoint,
+        budgetMeters: Double,
+        using rng: inout R
+    ) {
+        chain = chain.regeneratingRemainder(
+            fromActiveIndex: activeIndex,
+            current: current,
+            remainingBudgetMeters: budgetMeters,
+            using: &rng
+        )
     }
 
     func stop() {

--- a/Pilgrim/Models/Walk/Seek/SeekSeed.swift
+++ b/Pilgrim/Models/Walk/Seek/SeekSeed.swift
@@ -1,0 +1,61 @@
+import CryptoKit
+import Foundation
+
+/// The seed of a seek: the walker's intention and the moment they crossed
+/// the gateway, folded together with OS entropy — all local (R5), nothing
+/// communal. The intention is one voice in the seed, never the whole of it:
+/// mixed with the moment and fresh entropy so a repeated question never
+/// repeats a way, and it enters only as a one-way hash, so nothing personal
+/// is derivable from the seed. Statistically this changes nothing —
+/// SystemRandomNumberGenerator was already cryptographic — it changes what
+/// the randomness *is*: the way is shaped by what was asked, and when.
+enum SeekSeed {
+
+    static func make(
+        intention: String?,
+        moment: Date = Date(),
+        fix: TempRouteDataSample? = nil,
+        entropy: UInt64 = .random(in: .min ... .max)
+    ) -> UInt64 {
+        var hasher = SHA256()
+        if let intention, !intention.isEmpty {
+            hasher.update(data: Data(intention.utf8))
+        }
+        update(&hasher, with: moment.timeIntervalSince1970)
+        if let fix {
+            update(&hasher, with: fix.latitude)
+            update(&hasher, with: fix.longitude)
+            update(&hasher, with: fix.altitude)
+            update(&hasher, with: fix.horizontalAccuracy)
+        }
+        withUnsafeBytes(of: entropy) { hasher.update(bufferPointer: $0) }
+
+        return hasher.finalize().prefix(8).enumerated().reduce(UInt64(0)) {
+            $0 | (UInt64($1.element) << (8 * UInt64($1.offset)))
+        }
+    }
+
+    private static func update(_ hasher: inout SHA256, with value: Double) {
+        withUnsafeBytes(of: value.bitPattern) { hasher.update(bufferPointer: $0) }
+    }
+}
+
+/// SplitMix64 — a full-period generator whose whole state is the 64-bit
+/// seed, so one seed is one seek. Not for cryptography; the secrecy budget
+/// is spent inside SeekSeed's hash, this only has to be deterministic and
+/// well-mixed.
+struct SeekSeededGenerator: RandomNumberGenerator {
+    private var state: UInt64
+
+    init(seed: UInt64) {
+        state = seed
+    }
+
+    mutating func next() -> UInt64 {
+        state &+= 0x9E3779B97F4A7C15
+        var z = state
+        z = (z ^ (z >> 30)) &* 0xBF58476D1CE4E5B9
+        z = (z ^ (z >> 27)) &* 0x94D049BB133111EB
+        return z ^ (z >> 31)
+    }
+}

--- a/Pilgrim/Scenes/ActiveWalk/ActiveWalkViewModel+Seek.swift
+++ b/Pilgrim/Scenes/ActiveWalk/ActiveWalkViewModel+Seek.swift
@@ -74,7 +74,11 @@ extension ActiveWalkViewModel {
         seekGeneration += 1
 
         let start = SeekPoint(latitude: sample.latitude, longitude: sample.longitude)
-        var rng = SystemRandomNumberGenerator()
+        // The way is shaped by what was asked and when: intention + the
+        // gateway moment + the locking fix seed the generation (SeekSeed).
+        var rng = SeekSeededGenerator(
+            seed: SeekSeed.make(intention: intention, fix: sample)
+        )
         let chain = SeekChainGenerator.generate(
             durationMinutes: seekDurationMinutes ?? UserPreferences.seekLastDurationMinutes.value,
             start: start,
@@ -186,7 +190,9 @@ extension ActiveWalkViewModel {
     }
 
     /// R17 "Seek anew": regenerates the remainder of the chain from the
-    /// walker's current position. Uncapped by design.
+    /// walker's current position. Uncapped by design. A reroll re-asks —
+    /// the same intention, a new moment — so it is seeded like the
+    /// original generation.
     func seekAnewRequested() {
         guard let engine = seekEngine else { return }
         let point: SeekPoint
@@ -197,7 +203,10 @@ extension ActiveWalkViewModel {
         } else {
             return
         }
-        engine.seekAnew(currentLocation: point)
+        engine.seekAnew(
+            currentLocation: point,
+            seed: SeekSeed.make(intention: intention, fix: currentLocation)
+        )
     }
 
     var isSeekComplete: Bool { seekEngine?.phase == .complete }

--- a/Pilgrim/Scenes/Goshuin/GoshuinMilestones.swift
+++ b/Pilgrim/Scenes/Goshuin/GoshuinMilestones.swift
@@ -8,6 +8,29 @@ enum GoshuinMilestones {
         case longestWalk
         case longestMeditation
         case firstOfSeason(String)
+        /// Seeking thresholds: the walk that carried the first found place,
+        /// and the walks whose arrivals crossed a lifetime count.
+        case firstUnknown
+        case unknownsFound(Int)
+    }
+
+    /// Lifetime found-place counts that earn a seal.
+    static let unknownThresholds = [10, 25, 50, 100]
+
+    /// Seeking milestones for a walk, from its own arrivals and the
+    /// lifetime count before it. Awarded to the walk that crosses the
+    /// threshold; a walk with no arrivals never earns one.
+    static func seekingMilestones(arrivalsInWalk: Int, arrivalsBefore: Int) -> Set<Milestone> {
+        guard arrivalsInWalk > 0 else { return [] }
+        var milestones: Set<Milestone> = []
+        if arrivalsBefore == 0 {
+            milestones.insert(.firstUnknown)
+        }
+        let total = arrivalsBefore + arrivalsInWalk
+        for threshold in unknownThresholds where arrivalsBefore < threshold && total >= threshold {
+            milestones.insert(.unknownsFound(threshold))
+        }
+        return milestones
     }
 
     static func detect(
@@ -59,6 +82,16 @@ enum GoshuinMilestones {
 
         if isFirstOfSeason {
             milestones.insert(.firstOfSeason(season))
+        }
+
+        let arrivalsInWalk = walk.waypoints.filter(SeekPersistence.isArrivalWaypoint).count
+        if arrivalsInWalk > 0 {
+            let arrivalsBefore = allWalks
+                .filter { $0.uuid != walk.uuid && $0.startDate < walk.startDate }
+                .reduce(0) { $0 + $1.waypoints.filter(SeekPersistence.isArrivalWaypoint).count }
+            milestones.formUnion(
+                seekingMilestones(arrivalsInWalk: arrivalsInWalk, arrivalsBefore: arrivalsBefore)
+            )
         }
 
         return milestones
@@ -120,6 +153,15 @@ enum GoshuinMilestones {
             milestones.insert(.firstOfSeason(season))
         }
 
+        if input.foundPlaceCount > 0 {
+            let arrivalsBefore = allInputs
+                .filter { $0.uuid != input.uuid && $0.startDate < input.startDate }
+                .reduce(0) { $0 + $1.foundPlaceCount }
+            milestones.formUnion(
+                seekingMilestones(arrivalsInWalk: input.foundPlaceCount, arrivalsBefore: arrivalsBefore)
+            )
+        }
+
         return milestones
     }
 
@@ -130,6 +172,8 @@ enum GoshuinMilestones {
         case .longestWalk: return "Longest Walk"
         case .longestMeditation: return "Longest Meditation"
         case .firstOfSeason(let s): return "First of \(s)"
+        case .firstUnknown: return "First Unknown"
+        case .unknownsFound(let n): return "\(n) Unknowns"
         }
     }
 

--- a/Pilgrim/Scenes/Goshuin/GoshuinMilestones.swift
+++ b/Pilgrim/Scenes/Goshuin/GoshuinMilestones.swift
@@ -17,6 +17,61 @@ enum GoshuinMilestones {
     /// Lifetime found-place counts that earn a seal.
     static let unknownThresholds = [10, 25, 50, 100]
 
+    /// Caption order when a walk earns several milestones at once — Set
+    /// iteration is per-process, so without a stable priority the seal
+    /// caption and the share-image label shuffle between launches.
+    /// Once-ever moments outrank threshold crossings outrank recurring
+    /// and transient records; within threshold crossings the largest
+    /// count is the headline.
+    static func primaryMilestone(of milestones: Set<Milestone>) -> Milestone? {
+        milestones.min { lhs, rhs in
+            (displayPriority(lhs), -intraPriority(lhs)) < (displayPriority(rhs), -intraPriority(rhs))
+        }
+    }
+
+    private static func displayPriority(_ milestone: Milestone) -> Int {
+        switch milestone {
+        case .firstWalk: return 0
+        case .firstUnknown: return 1
+        case .unknownsFound: return 2
+        case .nthWalk: return 3
+        case .firstOfSeason: return 4
+        case .longestWalk: return 5
+        case .longestMeditation: return 6
+        }
+    }
+
+    private static func intraPriority(_ milestone: Milestone) -> Int {
+        switch milestone {
+        case .nthWalk(let n), .unknownsFound(let n): return n
+        default: return 0
+        }
+    }
+
+    /// One waypoint-fault pass for the whole book: callers look up arrival
+    /// counts by uuid instead of re-faulting every prior walk's waypoint
+    /// relationship per seal cell (which was O(walks²) on the main thread).
+    static func arrivalCounts(for walks: [WalkInterface]) -> [UUID: Int] {
+        var counts: [UUID: Int] = [:]
+        for walk in walks {
+            guard let uuid = walk.uuid else { continue }
+            let count = walk.waypoints.filter(SeekPersistence.isArrivalWaypoint).count
+            if count > 0 { counts[uuid] = count }
+        }
+        return counts
+    }
+
+    /// Strictly-before ordering with a stable uuid tie-break, so two walks
+    /// sharing a startDate never both count as "before" each other (a
+    /// crossing seal would double-award) nor neither (it would vanish).
+    static func isOrderedBefore(
+        _ lhsDate: Date, _ lhsID: String?,
+        _ rhsDate: Date, _ rhsID: String?
+    ) -> Bool {
+        if lhsDate != rhsDate { return lhsDate < rhsDate }
+        return (lhsID ?? "") < (rhsID ?? "")
+    }
+
     /// Seeking milestones for a walk, from its own arrivals and the
     /// lifetime count before it. Awarded to the walk that crosses the
     /// threshold; a walk with no arrivals never earns one.
@@ -37,7 +92,8 @@ enum GoshuinMilestones {
         walkCount: Int,
         walkIndex: Int,
         walk: WalkInterface?,
-        allWalks: [WalkInterface]
+        allWalks: [WalkInterface],
+        arrivalCounts: [UUID: Int] = [:]
     ) -> Set<Milestone> {
         var milestones: Set<Milestone> = []
         let walkNumber = walkIndex + 1
@@ -84,11 +140,17 @@ enum GoshuinMilestones {
             milestones.insert(.firstOfSeason(season))
         }
 
-        let arrivalsInWalk = walk.waypoints.filter(SeekPersistence.isArrivalWaypoint).count
+        let arrivalsInWalk = walk.uuid.flatMap { arrivalCounts[$0] } ?? 0
         if arrivalsInWalk > 0 {
-            let arrivalsBefore = allWalks
-                .filter { $0.uuid != walk.uuid && $0.startDate < walk.startDate }
-                .reduce(0) { $0 + $1.waypoints.filter(SeekPersistence.isArrivalWaypoint).count }
+            let arrivalsBefore = allWalks.reduce(0) { sum, other in
+                guard let otherID = other.uuid, otherID != walk.uuid,
+                      isOrderedBefore(
+                        other.startDate, otherID.uuidString,
+                        walk.startDate, walk.uuid?.uuidString
+                      )
+                else { return sum }
+                return sum + (arrivalCounts[otherID] ?? 0)
+            }
             milestones.formUnion(
                 seekingMilestones(arrivalsInWalk: arrivalsInWalk, arrivalsBefore: arrivalsBefore)
             )
@@ -155,7 +217,10 @@ enum GoshuinMilestones {
 
         if input.foundPlaceCount > 0 {
             let arrivalsBefore = allInputs
-                .filter { $0.uuid != input.uuid && $0.startDate < input.startDate }
+                .filter {
+                    $0.uuid != input.uuid
+                        && isOrderedBefore($0.startDate, $0.uuid, input.startDate, input.uuid)
+                }
                 .reduce(0) { $0 + $1.foundPlaceCount }
             milestones.formUnion(
                 seekingMilestones(arrivalsInWalk: input.foundPlaceCount, arrivalsBefore: arrivalsBefore)

--- a/Pilgrim/Scenes/Goshuin/GoshuinPageView.swift
+++ b/Pilgrim/Scenes/Goshuin/GoshuinPageView.swift
@@ -6,6 +6,7 @@ struct GoshuinPageView: View {
     let allWalks: [WalkInterface]
     let totalWalkCount: Int
     let globalStartIndex: Int
+    let arrivalCounts: [UUID: Int]
     let onSelectWalk: (UUID) -> Void
 
     private let columns = [
@@ -32,7 +33,8 @@ struct GoshuinPageView: View {
             walkCount: totalWalkCount,
             walkIndex: walkIndex,
             walk: walk,
-            allWalks: allWalks
+            allWalks: allWalks,
+            arrivalCounts: arrivalCounts
         )
         let isMilestone = !milestones.isEmpty
         let isArchived = walk.uuid.map { UserPreferences.isArchivedWalk(uuid: $0) } ?? false
@@ -61,7 +63,7 @@ struct GoshuinPageView: View {
                 Text("Archived")
                     .font(Constants.Typography.caption)
                     .foregroundStyle(Color.fog.opacity(0.7))
-            } else if let milestone = milestones.first {
+            } else if let milestone = GoshuinMilestones.primaryMilestone(of: milestones) {
                 Text(GoshuinMilestones.label(for: milestone))
                     .font(Constants.Typography.caption)
                     .foregroundStyle(Color.fog)

--- a/Pilgrim/Scenes/Goshuin/GoshuinShareRenderer.swift
+++ b/Pilgrim/Scenes/Goshuin/GoshuinShareRenderer.swift
@@ -96,8 +96,8 @@ enum GoshuinShareRenderer {
                 input: walk,
                 allInputs: allWalks
             )
-            if let first = milestones.first {
-                map[uuid] = GoshuinMilestones.label(for: first)
+            if let primary = GoshuinMilestones.primaryMilestone(of: milestones) {
+                map[uuid] = GoshuinMilestones.label(for: primary)
             }
         }
         return map

--- a/Pilgrim/Scenes/Goshuin/GoshuinView.swift
+++ b/Pilgrim/Scenes/Goshuin/GoshuinView.swift
@@ -4,6 +4,15 @@ struct GoshuinView: View {
 
     let walks: [Walk]
     let onSelectWalk: (UUID) -> Void
+    /// One waypoint-fault pass for the whole book, computed at
+    /// construction; seal cells read arrival counts by uuid.
+    private let arrivalCounts: [UUID: Int]
+
+    init(walks: [Walk], onSelectWalk: @escaping (UUID) -> Void) {
+        self.walks = walks
+        self.onSelectWalk = onSelectWalk
+        self.arrivalCounts = GoshuinMilestones.arrivalCounts(for: walks)
+    }
 
     @State private var activeFilter: WalkFavicon?
     @State private var shareURL: URL?
@@ -95,6 +104,7 @@ struct GoshuinView: View {
                             allWalks: walks,
                             totalWalkCount: walks.count,
                             globalStartIndex: pageIndex * 6,
+                            arrivalCounts: arrivalCounts,
                             onSelectWalk: { uuid in
                                 dismiss()
                                 DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) {

--- a/Pilgrim/Scenes/Home/HomeViewModel.swift
+++ b/Pilgrim/Scenes/Home/HomeViewModel.swift
@@ -104,10 +104,15 @@ class HomeViewModel: ObservableObject {
     /// bulk fetch — the event count equals the seek-walk count — instead of
     /// faulting every walk's event list while building snapshots.
     private func fetchSeekWalkIDs() -> Set<UUID> {
-        let events = (try? DataManager.dataStack.fetchAll(
-            From<WalkEvent>().where(\._eventType == .seekMode)
-        )) ?? []
-        return Set(events.compactMap { $0.workout?.uuid })
+        do {
+            let events = try DataManager.dataStack.fetchAll(
+                From<WalkEvent>().where(\._eventType == .seekMode)
+            )
+            return Set(events.compactMap { $0.workout?.uuid })
+        } catch {
+            print("[HomeViewModel] Failed to fetch seek events:", error.localizedDescription)
+            return []
+        }
     }
 
     private func updateHemisphereIfNeeded() {

--- a/Pilgrim/Scenes/Home/HomeViewModel.swift
+++ b/Pilgrim/Scenes/Home/HomeViewModel.swift
@@ -14,6 +14,7 @@ struct WalkSnapshot: Identifiable {
     let favicon: String?
     let isShared: Bool
     let weatherCondition: String?
+    let isSeek: Bool
 
     var walkOnlyDuration: TimeInterval {
         max(0, duration - talkDuration - meditateDuration)
@@ -69,6 +70,7 @@ class HomeViewModel: ObservableObject {
     }
 
     private func buildSnapshots() {
+        let seekWalkIDs = fetchSeekWalkIDs()
         let reversed = walks.reversed()
         var cumulative: Double = 0
         var snapshots: [WalkSnapshot] = []
@@ -90,11 +92,22 @@ class HomeViewModel: ObservableObject {
                 meditateDuration: walk.meditateDuration,
                 favicon: walk.favicon,
                 isShared: ShareService.cachedShare(for: walk.id).map { !$0.isExpired } ?? false,
-                weatherCondition: walk.weatherCondition
+                weatherCondition: walk.weatherCondition,
+                isSeek: walk.uuid.map(seekWalkIDs.contains) ?? false
             ))
         }
 
         walkSnapshots = snapshots.reversed()
+    }
+
+    /// Seek walks are marked by their `.seekMode` event (origin R18). One
+    /// bulk fetch — the event count equals the seek-walk count — instead of
+    /// faulting every walk's event list while building snapshots.
+    private func fetchSeekWalkIDs() -> Set<UUID> {
+        let events = (try? DataManager.dataStack.fetchAll(
+            From<WalkEvent>().where(\._eventType == .seekMode)
+        )) ?? []
+        return Set(events.compactMap { $0.workout?.uuid })
     }
 
     private func updateHemisphereIfNeeded() {

--- a/Pilgrim/Scenes/Home/InkScrollView.swift
+++ b/Pilgrim/Scenes/Home/InkScrollView.swift
@@ -346,9 +346,10 @@ struct InkScrollView: View {
                                 .stroke(Color.fog, lineWidth: 1)
                                 .frame(width: 12, height: 18)
                         } else {
-                            FootprintShape()
-                                .fill(seasonColor.opacity(0.3))
-                                .frame(width: 12, height: 18)
+                            WalkModeFootprints(
+                                isSeek: snapshot.isSeek,
+                                color: seasonColor.opacity(0.3)
+                            )
                         }
 
                         if !isExpandedArchived {

--- a/Pilgrim/Scenes/WalkSummary/SeekSummarySection.swift
+++ b/Pilgrim/Scenes/WalkSummary/SeekSummarySection.swift
@@ -11,6 +11,9 @@ struct SeekSummaryData: Equatable {
         let label: String
         let center: SeekPoint
         let arrivedAt: Date
+        /// The sky's light at the arrival — golden hour, broad daylight,
+        /// or night — computed from the sun's real elevation there and then.
+        let foundUnder: SeekSkyLight.Daypart
         let photoIDs: [String]
         let voiceRecordingIDs: [String]
         let waypointIDs: [String]
@@ -94,6 +97,7 @@ enum SeekSummaryModel {
                 label: arrival.label,
                 center: arrival.center,
                 arrivedAt: arrival.arrivedAt,
+                foundUnder: foundUnderDaypart(center: arrival.center, arrivedAt: arrival.arrivedAt),
                 photoIDs: ids(of: .photo, in: grouped[index]),
                 voiceRecordingIDs: ids(of: .voiceRecording, in: grouped[index]),
                 waypointIDs: ids(of: .waypoint, in: grouped[index])
@@ -108,6 +112,17 @@ enum SeekSummaryModel {
                 waypointIDs: ids(of: .waypoint, in: strays)
             ),
             unknownsFoundText: unknownsFoundText(arrivalCount: ordered.count)
+        )
+    }
+
+    /// The hour's light at an arrival, from the sun's real elevation at
+    /// that place and moment. Shared by the summary captions and the
+    /// summary map's halo tint.
+    static func foundUnderDaypart(center: SeekPoint, arrivedAt: Date) -> SeekSkyLight.Daypart {
+        SeekSkyLight.daypart(
+            solarElevationDegrees: CelestialCalculator.solarElevationDegrees(
+                at: center.coordinate, on: arrivedAt
+            )
         )
     }
 
@@ -263,6 +278,9 @@ struct SeekSummarySection: View {
                     .font(Constants.Typography.caption)
                     .foregroundColor(.fog)
             }
+            Text(Self.foundUnderText(group.foundUnder))
+                .font(Constants.Typography.caption)
+                .foregroundColor(.fog)
             if let signs = signsLine(
                 photos: group.photoIDs.count,
                 voices: group.voiceRecordingIDs.count,
@@ -292,6 +310,14 @@ struct SeekSummarySection: View {
             }
         }
         .padding(.top, Constants.UI.Padding.xs)
+    }
+
+    static func foundUnderText(_ daypart: SeekSkyLight.Daypart) -> String {
+        switch daypart {
+        case .golden: return LS.seekSummaryFoundGolden
+        case .midday: return LS.seekSummaryFoundMidday
+        case .night: return LS.seekSummaryFoundNight
+        }
     }
 
     private func signsLine(photos: Int, voices: Int, marks: Int) -> String? {

--- a/Pilgrim/Scenes/WalkSummary/SeekSummarySection.swift
+++ b/Pilgrim/Scenes/WalkSummary/SeekSummarySection.swift
@@ -33,6 +33,11 @@ struct SeekSummaryData: Equatable {
     let alongTheWay: AlongTheWay
     /// Counts only reached clearings — never totals, never "X of Y" (R19).
     let unknownsFoundText: String
+    /// The gateway moment — the `.seekMode` event's timestamp, written at
+    /// recording start. Together with the walk's intention this is the
+    /// seed's whole provenance (SeekSeed), already persisted since 1.8.0.
+    let seededAt: Date?
+    let intentionWasVoiced: Bool
 }
 
 enum SeekSummaryModel {
@@ -75,7 +80,9 @@ enum SeekSummaryModel {
     static func summaryData(
         events: [WalkEvent.EventType],
         arrivals: [Arrival],
-        signs: [Sign]
+        signs: [Sign],
+        seededAt: Date? = nil,
+        intentionWasVoiced: Bool = false
     ) -> SeekSummaryData? {
         guard isSeekWalk(events: events), !arrivals.isEmpty else { return nil }
 
@@ -111,7 +118,9 @@ enum SeekSummaryModel {
                 voiceRecordingIDs: ids(of: .voiceRecording, in: strays),
                 waypointIDs: ids(of: .waypoint, in: strays)
             ),
-            unknownsFoundText: unknownsFoundText(arrivalCount: ordered.count)
+            unknownsFoundText: unknownsFoundText(arrivalCount: ordered.count),
+            seededAt: seededAt,
+            intentionWasVoiced: intentionWasVoiced
         )
     }
 
@@ -213,7 +222,13 @@ extension SeekSummaryModel {
                 )
             }
 
-        return summaryData(events: events, arrivals: arrivals, signs: signs)
+        return summaryData(
+            events: events,
+            arrivals: arrivals,
+            signs: signs,
+            seededAt: walk.workoutEvents.first { $0.eventType == .seekMode }?.timestamp,
+            intentionWasVoiced: !(walk.comment?.isEmpty ?? true)
+        )
     }
 
     private static func nearestRouteCoordinate(
@@ -249,6 +264,13 @@ struct SeekSummarySection: View {
             }
             if !data.alongTheWay.isEmpty {
                 alongTheWayRow
+            }
+            if let seededAt = data.seededAt {
+                Text(seededLine(at: seededAt))
+                    .font(Constants.Typography.caption)
+                    .italic()
+                    .foregroundColor(.fog)
+                    .padding(.top, Constants.UI.Padding.small)
             }
         }
         .padding(Constants.UI.Padding.normal)
@@ -310,6 +332,15 @@ struct SeekSummarySection: View {
             }
         }
         .padding(.top, Constants.UI.Padding.xs)
+    }
+
+    private func seededLine(at date: Date) -> String {
+        String(
+            format: data.intentionWasVoiced
+                ? LS.seekSummarySeededFormat
+                : LS.seekSummarySeededQuietFormat,
+            Self.arrivalTimeFormatter.string(from: date)
+        )
     }
 
     static func foundUnderText(_ daypart: SeekSkyLight.Daypart) -> String {

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
@@ -690,7 +690,22 @@ extension WalkSummaryView {
         }
 
         for waypoint in walk.waypoints {
-            pins.append(PilgrimAnnotation(coordinate: CLLocationCoordinate2D(latitude: waypoint.latitude, longitude: waypoint.longitude), kind: .waypoint(label: waypoint.label, icon: waypoint.icon)))
+            let coordinate = CLLocationCoordinate2D(latitude: waypoint.latitude, longitude: waypoint.longitude)
+            if SeekPersistence.isArrivalWaypoint(waypoint) {
+                let daypart = SeekSummaryModel.foundUnderDaypart(
+                    center: SeekPoint(latitude: waypoint.latitude, longitude: waypoint.longitude),
+                    arrivedAt: waypoint.timestamp
+                )
+                pins.append(PilgrimAnnotation(
+                    coordinate: coordinate,
+                    kind: .seekArrival(
+                        label: waypoint.label,
+                        lightHex: SeekSkyLight.hex(daypart: daypart, starlight: false)
+                    )
+                ))
+            } else {
+                pins.append(PilgrimAnnotation(coordinate: coordinate, kind: .waypoint(label: waypoint.label, icon: waypoint.icon)))
+            }
         }
 
         return pins

--- a/Pilgrim/Support Files/Base.lproj/Localizable.strings
+++ b/Pilgrim/Support Files/Base.lproj/Localizable.strings
@@ -196,6 +196,9 @@
 "seek.summary.found.two" = "Two unknowns found";
 "seek.summary.found.three" = "Three unknowns found";
 "seek.summary.found.many" = "%d unknowns found";
+"seek.summary.found_under.golden" = "Found in the golden hour";
+"seek.summary.found_under.midday" = "Found in broad daylight";
+"seek.summary.found_under.night" = "Found under the night sky";
 "seek.summary.along_the_way" = "Along the way";
 "seek.summary.sign.photo.one" = "a photo";
 "seek.summary.sign.photo.many" = "%d photos";

--- a/Pilgrim/Support Files/Base.lproj/Localizable.strings
+++ b/Pilgrim/Support Files/Base.lproj/Localizable.strings
@@ -199,6 +199,8 @@
 "seek.summary.found_under.golden" = "Found in the golden hour";
 "seek.summary.found_under.midday" = "Found in broad daylight";
 "seek.summary.found_under.night" = "Found under the night sky";
+"seek.summary.seeded" = "The way was shaped by your intention and the moment you set out — %@.";
+"seek.summary.seeded.quiet" = "The way was shaped by the moment you set out — %@.";
 "seek.summary.along_the_way" = "Along the way";
 "seek.summary.sign.photo.one" = "a photo";
 "seek.summary.sign.photo.many" = "%d photos";

--- a/Pilgrim/Views/PilgrimMapView.swift
+++ b/Pilgrim/Views/PilgrimMapView.swift
@@ -391,6 +391,13 @@ struct PilgrimMapView: UIViewRepresentable {
                 // CircleAnnotation in the middle — the thumbnail IS
                 // the marker.
                 continue
+            case .seekArrival(_, let lightHex):
+                // The bright core inside the found-place halo — the same
+                // two-part reading as the web viewer's Book.
+                circle.circleRadius = 4
+                circle.circleColor = StyleColor(UIColor(hex: lightHex))
+                circle.circleOpacity = 0.9
+                circle.circleStrokeWidth = 0
             case .waypoint, .whisper, .cairn:
                 continue
             }
@@ -414,6 +421,13 @@ struct PilgrimMapView: UIViewRepresentable {
             glow.circleRadius = isActive ? 28 : 22
             glow.circleColor = StyleColor(UIColor.stone)
             glow.circleOpacity = isActive ? 0.32 : 0.18
+            glow.circleStrokeWidth = 0
+            return glow
+        case .seekArrival(_, let lightHex):
+            var glow = CircleAnnotation(centerCoordinate: pin.coordinate)
+            glow.circleRadius = 26
+            glow.circleColor = StyleColor(UIColor(hex: lightHex))
+            glow.circleOpacity = 0.28
             glow.circleStrokeWidth = 0
             return glow
         default:

--- a/Pilgrim/Views/WalkModeFootprints.swift
+++ b/Pilgrim/Views/WalkModeFootprints.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+/// Static miniature of the path screen's mode language, for compact rows
+/// (the ink-scroll quick view). Wander: the grounded pair. Seek: one print
+/// beside a trail of dots dissolving upward into the unknown. No animation —
+/// these are glances, not scenes; the drifting versions live on the path
+/// screen only.
+struct WalkModeFootprints: View {
+    let isSeek: Bool
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 2) {
+            FootprintShape()
+                .fill(color)
+                .frame(width: 10, height: 16)
+                .scaleEffect(x: -1)
+                .rotationEffect(.degrees(-12))
+            if isSeek {
+                dissolvingDots
+                    .frame(width: 10, height: 18)
+                    .rotationEffect(.degrees(12))
+            } else {
+                FootprintShape()
+                    .fill(color.opacity(0.75))
+                    .frame(width: 10, height: 16)
+                    .rotationEffect(.degrees(12))
+            }
+        }
+        .accessibilityHidden(true)
+    }
+
+    private var dissolvingDots: some View {
+        Canvas { context, size in
+            let dots: [(x: CGFloat, y: CGFloat, r: CGFloat, a: Double)] = [
+                (0.5, 0.85, 1.6, 1.0),
+                (0.3, 0.65, 1.3, 0.85),
+                (0.7, 0.55, 1.3, 0.7),
+                (0.4, 0.38, 1.0, 0.5),
+                (0.6, 0.20, 1.0, 0.35),
+                (0.5, 0.05, 0.7, 0.22)
+            ]
+            for dot in dots {
+                let rect = CGRect(
+                    x: dot.x * size.width - dot.r,
+                    y: dot.y * size.height - dot.r,
+                    width: dot.r * 2,
+                    height: dot.r * 2
+                )
+                context.opacity = dot.a
+                context.fill(Ellipse().path(in: rect), with: .color(color))
+            }
+        }
+    }
+}

--- a/UnitTests/GoshuinMilestonesTests.swift
+++ b/UnitTests/GoshuinMilestonesTests.swift
@@ -56,4 +56,83 @@ final class GoshuinMilestonesTests: XCTestCase {
         XCTAssertEqual(GoshuinMilestones.label(for: .firstUnknown), "First Unknown")
         XCTAssertEqual(GoshuinMilestones.label(for: .unknownsFound(25)), "25 Unknowns")
     }
+
+    // MARK: - Primary milestone (stable caption)
+
+    func testPrimaryMilestone_isStableAndRanked() {
+        let crowded: Set<GoshuinMilestones.Milestone> = [
+            .longestWalk, .firstOfSeason("Summer"), .unknownsFound(10),
+            .unknownsFound(25), .nthWalk(10), .firstWalk
+        ]
+        XCTAssertEqual(GoshuinMilestones.primaryMilestone(of: crowded), .firstWalk)
+        XCTAssertEqual(
+            GoshuinMilestones.primaryMilestone(of: [.unknownsFound(10), .unknownsFound(25), .longestWalk]),
+            .unknownsFound(25),
+            "the largest crossing is the headline"
+        )
+        XCTAssertNil(GoshuinMilestones.primaryMilestone(of: []))
+    }
+
+    // MARK: - detect() aggregation (arrivalsBefore ordering, exclusion, ties)
+
+    private func seekWalk(uuid: UUID, daysAgo: Int, arrivals: Int) -> TempWalk {
+        let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+            .addingTimeInterval(-Double(daysAgo) * 86_400)
+        return WalkDataFactory.makeWalk(
+            uuid: uuid,
+            startDate: start,
+            waypoints: (0..<arrivals).map { index in
+                TempWaypoint(
+                    uuid: nil,
+                    latitude: Double(index),
+                    longitude: 0,
+                    label: SeekPersistence.arrivalWaypointLabel(clearingOrdinal: index + 1),
+                    icon: SeekPersistence.arrivalWaypointIcon,
+                    timestamp: start.addingTimeInterval(Double(index + 1) * 600)
+                )
+            }
+        )
+    }
+
+    private func seekMilestones(for walk: TempWalk, in all: [WalkInterface]) -> Set<GoshuinMilestones.Milestone> {
+        GoshuinMilestones.detect(
+            walkCount: all.count,
+            walkIndex: 4,
+            walk: walk,
+            allWalks: all,
+            arrivalCounts: GoshuinMilestones.arrivalCounts(for: all)
+        )
+    }
+
+    func testDetect_firstUnknown_goesToTheEarliestArrivalWalk() {
+        let earlier = seekWalk(uuid: UUID(), daysAgo: 2, arrivals: 1)
+        let later = seekWalk(uuid: UUID(), daysAgo: 0, arrivals: 1)
+        let all: [WalkInterface] = [earlier, later]
+
+        XCTAssertTrue(seekMilestones(for: earlier, in: all).contains(.firstUnknown))
+        XCTAssertFalse(
+            seekMilestones(for: later, in: all).contains(.firstUnknown),
+            "the earlier walk's arrivals must count as before the later walk"
+        )
+    }
+
+    func testDetect_ownArrivalsNeverCountAsBefore() {
+        let only = seekWalk(uuid: UUID(), daysAgo: 1, arrivals: 2)
+        XCTAssertTrue(
+            seekMilestones(for: only, in: [only]).contains(.firstUnknown),
+            "a walk's own arrivals must not inflate its arrivalsBefore"
+        )
+    }
+
+    func testDetect_identicalStartDates_awardFirstUnknownExactlyOnce() {
+        let first = seekWalk(uuid: UUID(uuidString: "00000000-0000-0000-0000-00000000000A")!, daysAgo: 1, arrivals: 1)
+        let second = seekWalk(uuid: UUID(uuidString: "00000000-0000-0000-0000-00000000000B")!, daysAgo: 1, arrivals: 1)
+        let all: [WalkInterface] = [first, second]
+
+        let awards = [
+            seekMilestones(for: first, in: all).contains(.firstUnknown),
+            seekMilestones(for: second, in: all).contains(.firstUnknown)
+        ]
+        XCTAssertEqual(awards.filter { $0 }.count, 1, "a startDate tie must resolve to exactly one first unknown")
+    }
 }

--- a/UnitTests/GoshuinMilestonesTests.swift
+++ b/UnitTests/GoshuinMilestonesTests.swift
@@ -25,4 +25,35 @@ final class GoshuinMilestonesTests: XCTestCase {
         let m = GoshuinMilestones.detect(walkCount: 2, walkIndex: 1, walk: nil, allWalks: [])
         XCTAssertFalse(m.contains(.firstWalk))
     }
+
+    // MARK: - Seeking thresholds
+
+    func testFirstUnknown_awardedToTheWalkWithTheFirstArrival() {
+        let m = GoshuinMilestones.seekingMilestones(arrivalsInWalk: 2, arrivalsBefore: 0)
+        XCTAssertTrue(m.contains(.firstUnknown))
+        XCTAssertFalse(m.contains(.unknownsFound(10)))
+    }
+
+    func testNoArrivals_earnsNothing() {
+        XCTAssertTrue(GoshuinMilestones.seekingMilestones(arrivalsInWalk: 0, arrivalsBefore: 5).isEmpty)
+    }
+
+    func testThresholdCrossing_awardedOnceToTheCrossingWalk() {
+        let crossing = GoshuinMilestones.seekingMilestones(arrivalsInWalk: 2, arrivalsBefore: 9)
+        XCTAssertTrue(crossing.contains(.unknownsFound(10)))
+        XCTAssertFalse(crossing.contains(.firstUnknown))
+
+        let after = GoshuinMilestones.seekingMilestones(arrivalsInWalk: 1, arrivalsBefore: 11)
+        XCTAssertFalse(after.contains(.unknownsFound(10)))
+    }
+
+    func testExactLanding_onThreshold_stillAwards() {
+        let m = GoshuinMilestones.seekingMilestones(arrivalsInWalk: 1, arrivalsBefore: 24)
+        XCTAssertTrue(m.contains(.unknownsFound(25)))
+    }
+
+    func testSeekingLabels() {
+        XCTAssertEqual(GoshuinMilestones.label(for: .firstUnknown), "First Unknown")
+        XCTAssertEqual(GoshuinMilestones.label(for: .unknownsFound(25)), "25 Unknowns")
+    }
 }

--- a/UnitTests/InkScrollLayoutTests.swift
+++ b/UnitTests/InkScrollLayoutTests.swift
@@ -27,7 +27,8 @@ final class InkScrollLayoutTests: XCTestCase {
             meditateDuration: 0,
             favicon: nil,
             isShared: false,
-            weatherCondition: nil
+            weatherCondition: nil,
+            isSeek: false
         )
     }
 

--- a/UnitTests/Seek/SeekChainGeneratorTests.swift
+++ b/UnitTests/Seek/SeekChainGeneratorTests.swift
@@ -1,25 +1,12 @@
 import XCTest
 @testable import Pilgrim
 
-/// SplitMix64 — deterministic RNG so generation is reproducible in tests.
-struct SeededRNG: RandomNumberGenerator {
-    private var state: UInt64
-    init(seed: UInt64) { state = seed }
-    mutating func next() -> UInt64 {
-        state &+= 0x9E3779B97F4A7C15
-        var z = state
-        z = (z ^ (z >> 30)) &* 0xBF58476D1CE4E5B9
-        z = (z ^ (z >> 27)) &* 0x94D049BB133111EB
-        return z ^ (z >> 31)
-    }
-}
-
 final class SeekChainGeneratorTests: XCTestCase {
 
     private let home = SeekPoint(latitude: 42.8782, longitude: -8.5448)
 
     private func chain(minutes: Int, seed: UInt64) -> SeekChain {
-        var rng = SeededRNG(seed: seed)
+        var rng = SeekSeededGenerator(seed: seed)
         return SeekChainGenerator.generate(durationMinutes: minutes, start: home, using: &rng)
     }
 
@@ -110,7 +97,7 @@ final class SeekChainGeneratorTests: XCTestCase {
             let start = SeekPoint(latitude: latitude, longitude: -8.5)
             for duration in [30, 60, 120, 180] {
                 for seed in 0..<80 {
-                    var rng = SeededRNG(seed: UInt64(seed))
+                    var rng = SeekSeededGenerator(seed: UInt64(seed))
                     let result = SeekChainGenerator.generate(
                         durationMinutes: duration, start: start, using: &rng
                     )
@@ -153,7 +140,7 @@ final class SeekChainGeneratorTests: XCTestCase {
     func testReroll_keepsPrefixAndReplacesActiveAndDownstream() {
         let original = chain(minutes: 180, seed: 11)
         let current = SeekPoint(latitude: home.latitude + 0.01, longitude: home.longitude)
-        var rng = SeededRNG(seed: 99)
+        var rng = SeekSeededGenerator(seed: 99)
         let rerolled = original.regeneratingRemainder(
             fromActiveIndex: 1,
             current: current,
@@ -170,7 +157,7 @@ final class SeekChainGeneratorTests: XCTestCase {
             let original = chain(minutes: 180, seed: UInt64(seed))
             let current = SeekPoint(latitude: home.latitude + 0.008, longitude: home.longitude - 0.004)
             let remaining = original.budgetMeters * 0.6
-            var rng = SeededRNG(seed: UInt64(seed) &+ 1000)
+            var rng = SeekSeededGenerator(seed: UInt64(seed) &+ 1000)
             let rerolled = original.regeneratingRemainder(
                 fromActiveIndex: 1,
                 current: current,
@@ -186,7 +173,7 @@ final class SeekChainGeneratorTests: XCTestCase {
         for seed in 0..<50 {
             let original = chain(minutes: 30, seed: UInt64(seed))
             let current = SeekPoint(latitude: home.latitude + 0.004, longitude: home.longitude + 0.002)
-            var rng = SeededRNG(seed: UInt64(seed) &+ 2000)
+            var rng = SeekSeededGenerator(seed: UInt64(seed) &+ 2000)
             let rerolled = original.regeneratingRemainder(
                 fromActiveIndex: 0,
                 current: current,
@@ -204,7 +191,7 @@ final class SeekChainGeneratorTests: XCTestCase {
 
     func testReroll_invalidIndex_returnsChainUnchanged() {
         let original = chain(minutes: 60, seed: 3)
-        var rng = SeededRNG(seed: 4)
+        var rng = SeekSeededGenerator(seed: 4)
         let result = original.regeneratingRemainder(
             fromActiveIndex: original.clearings.count,
             current: home,

--- a/UnitTests/Seek/SeekEngineTests.swift
+++ b/UnitTests/Seek/SeekEngineTests.swift
@@ -448,6 +448,22 @@ final class SeekEngineTests: XCTestCase {
         XCTAssertTrue(hasPulse, "the reroll's immediate pulse is the tap feedback")
         engine.stop()
     }
+
+    /// The production path always passes a SeekSeed; this pins the seeded
+    /// branch that seekAnewRequested actually exercises.
+    func testSeekAnew_withSeed_regeneratesDeterministically() {
+        let first = makeEngine(clearingCount: 2)
+        let second = makeEngine(clearingCount: 2)
+        let third = makeEngine(clearingCount: 2)
+
+        first.seekAnew(currentLocation: home, seed: 7)
+        second.seekAnew(currentLocation: home, seed: 7)
+        third.seekAnew(currentLocation: home, seed: 8)
+
+        XCTAssertEqual(first.chain, second.chain, "same seed, same reroll")
+        XCTAssertNotEqual(first.chain, third.chain, "a different seed is sent a different way")
+        [first, second, third].forEach { $0.stop() }
+    }
     // MARK: - Closeness curve (#6)
 
     func testCloseness_sharesTheCadenceCurve() {

--- a/UnitTests/Seek/SeekSeedTests.swift
+++ b/UnitTests/Seek/SeekSeedTests.swift
@@ -68,8 +68,11 @@ final class SeekSeedTests: XCTestCase {
         let start = SeekPoint(latitude: 42.8782, longitude: -8.5448)
         var first = SeekSeededGenerator(seed: 99)
         var second = SeekSeededGenerator(seed: 99)
+        var other = SeekSeededGenerator(seed: 100)
         let one = SeekChainGenerator.generate(durationMinutes: 60, start: start, using: &first)
         let two = SeekChainGenerator.generate(durationMinutes: 60, start: start, using: &second)
+        let three = SeekChainGenerator.generate(durationMinutes: 60, start: start, using: &other)
         XCTAssertEqual(one, two, "one seed is one seek")
+        XCTAssertNotEqual(one, three, "a different seed must be sent a different way")
     }
 }

--- a/UnitTests/Seek/SeekSeedTests.swift
+++ b/UnitTests/Seek/SeekSeedTests.swift
@@ -1,0 +1,75 @@
+import XCTest
+@testable import Pilgrim
+
+final class SeekSeedTests: XCTestCase {
+
+    private let moment = Date(timeIntervalSince1970: 1_790_000_000)
+
+    private func seed(
+        intention: String? = "let go",
+        moment: Date? = nil,
+        entropy: UInt64 = 7
+    ) -> UInt64 {
+        SeekSeed.make(
+            intention: intention,
+            moment: moment ?? self.moment,
+            fix: nil,
+            entropy: entropy
+        )
+    }
+
+    // MARK: - Determinism and mixing
+
+    func testSameQuestionSameMomentSameEntropy_sameSeed() {
+        XCTAssertEqual(seed(), seed())
+    }
+
+    func testTheIntentionIsAVoiceInTheSeed() {
+        XCTAssertNotEqual(
+            seed(intention: "let go"), seed(intention: "find courage"),
+            "a different question must be sent a different way"
+        )
+        XCTAssertNotEqual(
+            seed(intention: "let go"), seed(intention: "Let go"),
+            "the question exactly as asked - case and all"
+        )
+        XCTAssertNotEqual(seed(intention: "let go"), seed(intention: nil))
+    }
+
+    func testTheMomentIsAVoiceInTheSeed() {
+        XCTAssertNotEqual(
+            seed(), seed(moment: moment.addingTimeInterval(1)),
+            "the same question a second later never repeats the way"
+        )
+    }
+
+    func testEntropyIsAVoiceInTheSeed() {
+        XCTAssertNotEqual(seed(entropy: 7), seed(entropy: 8))
+    }
+
+    func testEmptyAndNilIntention_readAsUnasked() {
+        XCTAssertEqual(seed(intention: nil), seed(intention: ""))
+    }
+
+    // MARK: - Seeded generator
+
+    func testSeededGenerator_isDeterministicPerSeed() {
+        var first = SeekSeededGenerator(seed: 42)
+        var second = SeekSeededGenerator(seed: 42)
+        var other = SeekSeededGenerator(seed: 43)
+        let a = (0..<4).map { _ in first.next() }
+        let b = (0..<4).map { _ in second.next() }
+        let c = (0..<4).map { _ in other.next() }
+        XCTAssertEqual(a, b)
+        XCTAssertNotEqual(a, c)
+    }
+
+    func testSeededChainGeneration_isReproducible() {
+        let start = SeekPoint(latitude: 42.8782, longitude: -8.5448)
+        var first = SeekSeededGenerator(seed: 99)
+        var second = SeekSeededGenerator(seed: 99)
+        let one = SeekChainGenerator.generate(durationMinutes: 60, start: start, using: &first)
+        let two = SeekChainGenerator.generate(durationMinutes: 60, start: start, using: &second)
+        XCTAssertEqual(one, two, "one seed is one seek")
+    }
+}

--- a/UnitTests/Seek/SeekSummaryTests.swift
+++ b/UnitTests/Seek/SeekSummaryTests.swift
@@ -64,6 +64,30 @@ final class SeekSummaryTests: XCTestCase {
         XCTAssertEqual(data?.groups.first?.foundUnder, .midday)
     }
 
+    // MARK: - Seed keepsake
+
+    func testSummaryData_carriesTheGatewayMomentAndIntentionPresence() {
+        let seededAt = walkStart.addingTimeInterval(-30)
+        let data = SeekSummaryModel.summaryData(
+            events: [.seekMode, .seekArrival],
+            arrivals: [arrival(ordinal: 1, center: home, minutesIn: 10)],
+            signs: [],
+            seededAt: seededAt,
+            intentionWasVoiced: true
+        )
+        XCTAssertEqual(data?.seededAt, seededAt)
+        XCTAssertEqual(data?.intentionWasVoiced, true)
+    }
+
+    func testSummaryData_defaultsLeaveTheKeepsakeSilent() {
+        let data = SeekSummaryModel.summaryData(
+            events: [.seekMode],
+            arrivals: [arrival(ordinal: 1, center: home, minutesIn: 10)],
+            signs: []
+        )
+        XCTAssertNil(data?.seededAt, "no gateway moment, no keepsake line")
+    }
+
     // MARK: - Seek Detection
 
     func testIsSeekWalk_seekModeEventPresent() {

--- a/UnitTests/Seek/SeekSummaryTests.swift
+++ b/UnitTests/Seek/SeekSummaryTests.swift
@@ -64,6 +64,43 @@ final class SeekSummaryTests: XCTestCase {
         XCTAssertEqual(data?.groups.first?.foundUnder, .midday)
     }
 
+    // MARK: - Summary map annotations
+
+    func testComputeAnnotations_rendersArrivalsAsHourLitHalos() {
+        let noonAtEquator = DateFactory.makeDate(2024, 3, 20, 12, 0, 0)
+        let walk = WalkDataFactory.makeWalk(waypoints: [
+            TempWaypoint(
+                uuid: nil, latitude: 0, longitude: 0,
+                label: "First clearing", icon: SeekPersistence.arrivalWaypointIcon,
+                timestamp: noonAtEquator
+            ),
+            TempWaypoint(
+                uuid: nil, latitude: 0.001, longitude: 0,
+                label: "Grateful", icon: "heart", timestamp: noonAtEquator
+            )
+        ])
+
+        let pins = WalkSummaryView.computeAnnotations(for: walk)
+
+        guard let arrivalPin = pins.first(where: {
+            if case .seekArrival = $0.kind { return true } else { return false }
+        }), case let .seekArrival(label, lightHex) = arrivalPin.kind else {
+            return XCTFail("an arrival waypoint must render as a .seekArrival halo")
+        }
+        XCTAssertEqual(label, "First clearing")
+        XCTAssertEqual(
+            lightHex,
+            SeekSkyLight.hex(daypart: .midday, starlight: false),
+            "noon at the equator is broad daylight - and the record keeps the sky palette"
+        )
+        XCTAssertTrue(
+            pins.contains {
+                if case .waypoint(_, let icon) = $0.kind { return icon == "heart" } else { return false }
+            },
+            "ordinary waypoints keep their pin"
+        )
+    }
+
     // MARK: - Seed keepsake
 
     func testSummaryData_carriesTheGatewayMomentAndIntentionPresence() {

--- a/UnitTests/Seek/SeekSummaryTests.swift
+++ b/UnitTests/Seek/SeekSummaryTests.swift
@@ -40,6 +40,30 @@ final class SeekSummaryTests: XCTestCase {
         )
     }
 
+    // MARK: - Found under (the hour's light)
+
+    func testFoundUnderDaypart_readsTheSkyAtThePlaceAndMoment() {
+        let equator = SeekPoint(latitude: 0, longitude: 0)
+        let noonUTC = DateFactory.makeDate(2024, 3, 20, 12, 0, 0)
+        let midnightUTC = DateFactory.makeDate(2024, 3, 20, 0, 0, 0)
+        XCTAssertEqual(SeekSummaryModel.foundUnderDaypart(center: equator, arrivedAt: noonUTC), .midday)
+        XCTAssertEqual(SeekSummaryModel.foundUnderDaypart(center: equator, arrivedAt: midnightUTC), .night)
+    }
+
+    func testClearingGroups_carryTheirFoundUnderLight() {
+        let equator = SeekPoint(latitude: 0, longitude: 0)
+        let data = SeekSummaryModel.summaryData(
+            events: [.seekMode, .seekArrival],
+            arrivals: [SeekSummaryModel.Arrival(
+                label: "First clearing",
+                center: equator,
+                arrivedAt: DateFactory.makeDate(2024, 3, 20, 12, 0, 0)
+            )],
+            signs: []
+        )
+        XCTAssertEqual(data?.groups.first?.foundUnder, .midday)
+    }
+
     // MARK: - Seek Detection
 
     func testIsSeekWalk_seekModeEventPresent() {


### PR DESCRIPTION
The seek-accumulation package — five units that make the seeking compound between walks, per the product boundaries (strictly personal, no new screens, no global map).

## Units

1. **Mode glyphs in the journal quick view** — the ink-scroll expand card renders the path screen's mode language in miniature: wander = grounded pair of prints, seek = a print beside dots dissolving upward. `WalkSnapshot.isSeek` via one bulk `.seekMode`-event fetch.
2. **Seeded generation** — `SeekSeed` folds the intention (one-way hashed, exactly as typed), the gateway moment, the locking GPS fix, and OS entropy into a 64-bit seed; `SeekSeededGenerator` (SplitMix64) makes one seed one seek. Rerolls re-ask: same intention, new moment. All local, R5 intact.
3. **Summary hour-light halos + captions** — arrivals on the summary map become halos (glow + core) tinted by the sun's real elevation at the arrival: dawn-amber / pale gold / moonlight silver. Clearing groups gain "Found in the golden hour / in broad daylight / under the night sky" captions. New `.seekArrival` annotation kind; live walks keep their fog-layer halos.
4. **Seed keepsake line** — The Seeking closes with *"The way was shaped by your intention and the moment you set out — 7:42 PM."* Fully derived from already-persisted data (`.seekMode` event timestamp + `walk.comment`).
5. **Goshuin seeking seals** — First Unknown, then 10 / 25 / 50 / 100 lifetime unknowns, awarded once to the crossing walk. Shared pure `seekingMilestones` core feeds both detect overloads; `SealInput` gains `foundPlaceCount`.

## Verification

- 914 unit tests green (16 new across seed, summary, milestone suites); lint at baseline.
- U1 build was device-checked earlier; a final on-device pass of U2–U5 pending SE 3 reconnection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
