### PR TITLE
chore(release): warn when a bundled bootstrap has drifted

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -56,6 +56,40 @@ current_build_number() {
     grep -m1 'CURRENT_PROJECT_VERSION' "$PBXPROJ" | sed 's/.*= *\(.*\);/\1/' | tr -d '[:space:]'
 }
 
+# A bundled bootstrap only serves a fresh install that has not synced yet — the
+# offline first launch this app is actually used on. It goes stale the moment
+# someone publishes upstream without re-running the regen script, and nothing
+# reports it: the CDN is healthy, the app is healthy, and the copy in git is
+# simply older. The whisper bundle drifted a full version this way and sat
+# unnoticed for three months.
+#
+# Warn, never fail. A stale bundle ships a working app, and a release should not
+# depend on the CDN being reachable.
+check_bootstrap_freshness() {
+    local name="$1" file="$2" url="$3" refresh_cmd="$4"
+
+    if [ ! -f "$file" ]; then
+        warn "$name bootstrap not found at $file"
+        return
+    fi
+    if ! command -v jq &>/dev/null; then
+        warn "jq not installed, skipping $name bootstrap freshness check"
+        return
+    fi
+
+    local bundled live
+    bundled=$(jq -r '.version // empty' "$file" 2>/dev/null || true)
+    live=$(curl -fsS --max-time 10 "$url" 2>/dev/null | jq -r '.version // empty' 2>/dev/null || true)
+
+    if [ -z "$live" ]; then
+        warn "$name bootstrap: CDN unreachable, freshness unverified"
+    elif [ "$bundled" = "$live" ]; then
+        pass "$name bootstrap current (version $bundled)"
+    else
+        warn "$name bootstrap is stale — bundled $bundled, CDN $live. Run: scripts/release.sh $refresh_cmd"
+    fi
+}
+
 cmd_check() {
     step "Checking release readiness"
     local errors=0
@@ -90,6 +124,15 @@ cmd_check() {
         fail "Info.plist still references armv7"
     fi
     pass "Device capabilities OK (arm64)"
+
+    check_bootstrap_freshness "Whisper" \
+        "Pilgrim/Support Files/whispers-bootstrap.json" \
+        "https://cdn.pilgrimapp.org/audio/whisper/manifest.json" \
+        "bootstrap-whispers"
+    check_bootstrap_freshness "Route" \
+        "Pilgrim/Support Files/collective-routes-bootstrap.json" \
+        "https://cdn.pilgrimapp.org/collective/routes.json" \
+        "bootstrap-routes"
 
     step "Running SwiftLint"
     if command -v swiftlint &>/dev/null; then


### PR DESCRIPTION
`scripts/release.sh check` now compares each bundled bootstrap against what the CDN serves and warns when they differ.

## Why

A bundled bootstrap is read in exactly one situation: a fresh install that hasn't completed its first sync. After any successful sync the disk cache wins. So it matters for the offline first launch — install before a trip, walk without signal — which is a core use case for this app rather than an edge one.

It goes stale the moment someone publishes upstream without re-running the regen script, and nothing reports it. The CDN is fine, the app is fine, the copy in git is just older.

**Already happening:** the whisper bundle has been at version 4 for three months while the CDN serves version 5. The check found it on its first run.

The route dataset is more active — 36 commits to `routes/` in the last year, with three of the seven routes added in that window. A missing route changes the weight total, which moves the modulo, which changes which entry *every* date resolves to. An offline install would see a different daily route from everyone else, silently, with data that looks completely valid.

## Why warn and not fail

A stale bundle still ships a working app — the user gets correct data as soon as they sync. Failing a release over it would be disproportionate, and would make every release depend on the CDN being up. An unreachable host prints that it couldn't verify and the check continues.

Verified under `set -euo pipefail` that a failed fetch doesn't abort the script.

## Not wiring the regen into CI

The obvious alternative — have the workflows run `bootstrap-routes` before archiving — gives every release a hard dependency on the CDN and has CI committing a regenerated `pbxproj`. That trades a silent staleness problem for a loud fragility one. This surfaces the drift and leaves the decision to whoever is shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)