### PR TITLE
feat(share): Walk with Me — Interactive shares carry voice, photos, and pauses

### DIFF
--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -201,6 +201,7 @@
 		7ac8ee442a1ce6fcb926501a /* SharePayloadTourTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = cc51a46c5e27674f5165b409 /* SharePayloadTourTests.swift */; };
 		1A2B3C4D5E6F7A8B9C0D1E2F /* TourBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3C4D5E6F7A8B9C0D1E2F3A /* TourBuilderTests.swift */; };
 		7E8F9A0B1C2D3E4F5A6B7C8D /* RouteTrimmerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F9A0B1C2D3E4F5A6B7C8D9E /* RouteTrimmerTests.swift */; };
+		D69446C38B3D4915B5EE6940 /* TourPhotoExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82A6C2F48C9A4A83B2DF7DD4 /* TourPhotoExporterTests.swift */; };
 		50A16B63C6F23E2D1E6210BA /* Pods_Pilgrim.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */; };
 		510A5ED79C24B905DDD597A7 /* ScrollHapticEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F12E1FE28A875629DBD34C /* ScrollHapticEngineTests.swift */; };
 		52C6F28B0AAB6E494591E8EF /* VoiceGuideManifestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F883597323B0CE64E69DC9 /* VoiceGuideManifestService.swift */; };
@@ -255,6 +256,7 @@
 		7C39E4160B0DA105D78F4C83 /* SharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EA6F12A77BD40C46E34D47 /* SharePayload.swift */; };
 		3C4D5E6F7A8B9C0D1E2F3A4B /* TourBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5E6F7A8B9C0D1E2F3A4B5C /* TourBuilder.swift */; };
 		5C6D7E8F9A0B1C2D3E4F5A6B /* RouteTrimmer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D7E8F9A0B1C2D3E4F5A6B7C /* RouteTrimmer.swift */; };
+		F9B0C02BADD44059819D57D6 /* TourPhotoExporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D82C6861710E41CF801A9A4F /* TourPhotoExporter.swift */; };
 		7CC49F936D1CFDB1460010C5 /* ConstellationDecor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D6A3F7440EBCE25B7FA93C /* ConstellationDecor.swift */; };
 		8478CDC1C45890FF1F4E473A /* WalkPromptVoices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 862461B76A73D888F6A1A77D /* WalkPromptVoices.swift */; };
 		847990ED75B5CA66C0317D1C /* ArchivedWalkFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = F875DF77E21A42330B294FDB /* ArchivedWalkFixtures.swift */; };
@@ -807,6 +809,7 @@
 		cc51a46c5e27674f5165b409 /* SharePayloadTourTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SharePayloadTourTests.swift; sourceTree = "<group>"; };
 		2B3C4D5E6F7A8B9C0D1E2F3A /* TourBuilderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TourBuilderTests.swift; sourceTree = "<group>"; };
 		8F9A0B1C2D3E4F5A6B7C8D9E /* RouteTrimmerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RouteTrimmerTests.swift; sourceTree = "<group>"; };
+		82A6C2F48C9A4A83B2DF7DD4 /* TourPhotoExporterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TourPhotoExporterTests.swift; sourceTree = "<group>"; };
 		3E5EFD54CACA590B1BE78B75 /* BellPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BellPlayer.swift; sourceTree = "<group>"; };
 		3FE8447AB26F2388EA548BED /* SeekSoundPlayerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SeekSoundPlayerTests.swift; sourceTree = "<group>"; };
 		4181215714A52E71449BC390 /* WalkDataFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkDataFactory.swift; sourceTree = "<group>"; };
@@ -1075,6 +1078,7 @@
 		D0EA6F12A77BD40C46E34D47 /* SharePayload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SharePayload.swift; sourceTree = "<group>"; };
 		4D5E6F7A8B9C0D1E2F3A4B5C /* TourBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TourBuilder.swift; sourceTree = "<group>"; };
 		6D7E8F9A0B1C2D3E4F5A6B7C /* RouteTrimmer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RouteTrimmer.swift; sourceTree = "<group>"; };
+		D82C6861710E41CF801A9A4F /* TourPhotoExporter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TourPhotoExporter.swift; sourceTree = "<group>"; };
 		D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Pilgrim.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2FDF0BD38D9467B99B2C4D7 /* ActivityListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityListView.swift; sourceTree = "<group>"; };
 		D30651941E3AA93F6BB14A1D /* whisper-play-12.aac */ = {isa = PBXFileReference; includeInIndex = 1; path = "whisper-play-12.aac"; sourceTree = "<group>"; };
@@ -1839,6 +1843,7 @@
 				cc51a46c5e27674f5165b409 /* SharePayloadTourTests.swift */,
 				2B3C4D5E6F7A8B9C0D1E2F3A /* TourBuilderTests.swift */,
 				8F9A0B1C2D3E4F5A6B7C8D9E /* RouteTrimmerTests.swift */,
+				82A6C2F48C9A4A83B2DF7DD4 /* TourPhotoExporterTests.swift */,
 				AAAA000000000000000000D4 /* CustomPromptStyleStoreTests.swift */,
 				AAAA000000000000000000F4 /* IntentionHistoryStoreTests.swift */,
 				BBBB00000000000000000B /* WaypointCodableTests.swift */,
@@ -2116,6 +2121,7 @@
 				5D9D07CA4444A7B548B5CFA4 /* ShareService.swift */,
 				4D5E6F7A8B9C0D1E2F3A4B5C /* TourBuilder.swift */,
 				6D7E8F9A0B1C2D3E4F5A6B7C /* RouteTrimmer.swift */,
+				D82C6861710E41CF801A9A4F /* TourPhotoExporter.swift */,
 			);
 			path = Share;
 			sourceTree = "<group>";
@@ -2982,6 +2988,7 @@
 				6AE85BCC627AF8321E753C1F /* ShareService.swift in Sources */,
 				3C4D5E6F7A8B9C0D1E2F3A4B /* TourBuilder.swift in Sources */,
 				5C6D7E8F9A0B1C2D3E4F5A6B /* RouteTrimmer.swift in Sources */,
+				F9B0C02BADD44059819D57D6 /* TourPhotoExporter.swift in Sources */,
 				E9FD884A3895457CBF231700 /* SealHashComputer.swift in Sources */,
 				B3C4D5E6F7A8B9C0D1E2F3A4 /* SealColorPalette.swift in Sources */,
 				D7E8F9A0B1C2D3E4F5A6B7C8 /* SealGeometry.swift in Sources */,
@@ -3153,6 +3160,7 @@
 				7ac8ee442a1ce6fcb926501a /* SharePayloadTourTests.swift in Sources */,
 				1A2B3C4D5E6F7A8B9C0D1E2F /* TourBuilderTests.swift in Sources */,
 				7E8F9A0B1C2D3E4F5A6B7C8D /* RouteTrimmerTests.swift in Sources */,
+				D69446C38B3D4915B5EE6940 /* TourPhotoExporterTests.swift in Sources */,
 				AAAA000000000000000000D3 /* CustomPromptStyleStoreTests.swift in Sources */,
 				AAAA000000000000000000F3 /* IntentionHistoryStoreTests.swift in Sources */,
 				BBBB00000000000000000C /* WaypointCodableTests.swift in Sources */,

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -575,6 +575,8 @@
 		LR00000200000000LRWVLDT1 /* WebViewLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVLDT1 /* WebViewLoaderTests.swift */; };
 		LR00000200000000LRWVPV01 /* WalkSharePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVPV01 /* WalkSharePreviewView.swift */; };
 		F111E1130A361093119C4459 /* InteractiveShareSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF7056E6064D6423F5E736E /* InteractiveShareSection.swift */; };
+		1F6CBE35FAA44CF0A26DA0D6 /* WalkShareViewModel+ShareOrchestration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F520EBC1B6C4C57B0353112 /* WalkShareViewModel+ShareOrchestration.swift */; };
+		4C4159A687E6427094B9CA5A /* ShareStatusSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A615AC9A6DC4AFEBC7DBD97 /* ShareStatusSection.swift */; };
 		LR00000200000000LRWVRP01 /* WebViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVRP01 /* WebViewRepresentable.swift */; };
 		PERM000100000003 /* PermissionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = PERM000100000002 /* PermissionsViewModel.swift */; };
 		PERM000100000005 /* PermissionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PERM000100000004 /* PermissionsViewModelTests.swift */; };
@@ -1201,6 +1203,8 @@
 		LR00000100000000LRWVLDT1 /* WebViewLoaderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewLoaderTests.swift; sourceTree = "<group>"; };
 		LR00000100000000LRWVPV01 /* WalkSharePreviewView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkSharePreviewView.swift; sourceTree = "<group>"; };
 		6BF7056E6064D6423F5E736E /* InteractiveShareSection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InteractiveShareSection.swift; sourceTree = "<group>"; };
+		8F520EBC1B6C4C57B0353112 /* WalkShareViewModel+ShareOrchestration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "WalkShareViewModel+ShareOrchestration.swift"; sourceTree = "<group>"; };
+		9A615AC9A6DC4AFEBC7DBD97 /* ShareStatusSection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShareStatusSection.swift; sourceTree = "<group>"; };
 		LR00000100000000LRWVRP01 /* WebViewRepresentable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewRepresentable.swift; sourceTree = "<group>"; };
 		PERM000100000002 /* PermissionsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PermissionsViewModel.swift; sourceTree = "<group>"; };
 		PERM000100000004 /* PermissionsViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PermissionsViewModelTests.swift; sourceTree = "<group>"; };
@@ -2092,11 +2096,13 @@
 			children = (
 				16BE9557700152F043C359DC /* WalkShareView.swift */,
 				8E0BF1B23139F428720EB2CF /* WalkShareViewModel.swift */,
+				8F520EBC1B6C4C57B0353112 /* WalkShareViewModel+ShareOrchestration.swift */,
 				4B95E4FB1DF743CEF3AC77C2 /* RouteShapeView.swift */,
 				LR00000100000000LRWVLD01 /* WebViewLoader.swift */,
 				LR00000100000000LRWVRP01 /* WebViewRepresentable.swift */,
 				LR00000100000000LRWVPV01 /* WalkSharePreviewView.swift */,
 				6BF7056E6064D6423F5E736E /* InteractiveShareSection.swift */,
+				9A615AC9A6DC4AFEBC7DBD97 /* ShareStatusSection.swift */,
 			);
 			path = WalkShare;
 			sourceTree = "<group>";
@@ -3115,6 +3121,8 @@
 				LR00000200000000LRWVRP01 /* WebViewRepresentable.swift in Sources */,
 				LR00000200000000LRWVPV01 /* WalkSharePreviewView.swift in Sources */,
 				F111E1130A361093119C4459 /* InteractiveShareSection.swift in Sources */,
+				1F6CBE35FAA44CF0A26DA0D6 /* WalkShareViewModel+ShareOrchestration.swift in Sources */,
+				4C4159A687E6427094B9CA5A /* ShareStatusSection.swift in Sources */,
 				1ED04A655291254525CB5A42 /* JourneyEditorView.swift in Sources */,
 				BABACBE432D649DEE348D186 /* AppearanceView.swift in Sources */,
 				78C931B298CA7FEDAFD6CC4F /* ConstellationOverlay.swift in Sources */,

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -202,6 +202,7 @@
 		1A2B3C4D5E6F7A8B9C0D1E2F /* TourBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3C4D5E6F7A8B9C0D1E2F3A /* TourBuilderTests.swift */; };
 		7E8F9A0B1C2D3E4F5A6B7C8D /* RouteTrimmerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F9A0B1C2D3E4F5A6B7C8D9E /* RouteTrimmerTests.swift */; };
 		D69446C38B3D4915B5EE6940 /* TourPhotoExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82A6C2F48C9A4A83B2DF7DD4 /* TourPhotoExporterTests.swift */; };
+		FF09C76A879AAD0D3E6C1A54 /* ShareMediaUploadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598E81D4C0900F5E3DF2B1BC /* ShareMediaUploadTests.swift */; };
 		50A16B63C6F23E2D1E6210BA /* Pods_Pilgrim.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */; };
 		510A5ED79C24B905DDD597A7 /* ScrollHapticEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F12E1FE28A875629DBD34C /* ScrollHapticEngineTests.swift */; };
 		52C6F28B0AAB6E494591E8EF /* VoiceGuideManifestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F883597323B0CE64E69DC9 /* VoiceGuideManifestService.swift */; };
@@ -810,6 +811,7 @@
 		2B3C4D5E6F7A8B9C0D1E2F3A /* TourBuilderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TourBuilderTests.swift; sourceTree = "<group>"; };
 		8F9A0B1C2D3E4F5A6B7C8D9E /* RouteTrimmerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RouteTrimmerTests.swift; sourceTree = "<group>"; };
 		82A6C2F48C9A4A83B2DF7DD4 /* TourPhotoExporterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TourPhotoExporterTests.swift; sourceTree = "<group>"; };
+		598E81D4C0900F5E3DF2B1BC /* ShareMediaUploadTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShareMediaUploadTests.swift; sourceTree = "<group>"; };
 		3E5EFD54CACA590B1BE78B75 /* BellPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BellPlayer.swift; sourceTree = "<group>"; };
 		3FE8447AB26F2388EA548BED /* SeekSoundPlayerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SeekSoundPlayerTests.swift; sourceTree = "<group>"; };
 		4181215714A52E71449BC390 /* WalkDataFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkDataFactory.swift; sourceTree = "<group>"; };
@@ -1844,6 +1846,7 @@
 				2B3C4D5E6F7A8B9C0D1E2F3A /* TourBuilderTests.swift */,
 				8F9A0B1C2D3E4F5A6B7C8D9E /* RouteTrimmerTests.swift */,
 				82A6C2F48C9A4A83B2DF7DD4 /* TourPhotoExporterTests.swift */,
+				598E81D4C0900F5E3DF2B1BC /* ShareMediaUploadTests.swift */,
 				AAAA000000000000000000D4 /* CustomPromptStyleStoreTests.swift */,
 				AAAA000000000000000000F4 /* IntentionHistoryStoreTests.swift */,
 				BBBB00000000000000000B /* WaypointCodableTests.swift */,
@@ -3161,6 +3164,7 @@
 				1A2B3C4D5E6F7A8B9C0D1E2F /* TourBuilderTests.swift in Sources */,
 				7E8F9A0B1C2D3E4F5A6B7C8D /* RouteTrimmerTests.swift in Sources */,
 				D69446C38B3D4915B5EE6940 /* TourPhotoExporterTests.swift in Sources */,
+				FF09C76A879AAD0D3E6C1A54 /* ShareMediaUploadTests.swift in Sources */,
 				AAAA000000000000000000D3 /* CustomPromptStyleStoreTests.swift in Sources */,
 				AAAA000000000000000000F3 /* IntentionHistoryStoreTests.swift in Sources */,
 				BBBB00000000000000000C /* WaypointCodableTests.swift in Sources */,

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -198,6 +198,7 @@
 		4DC9042641824FA1900ABF64 /* SealInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA2E3CE11CDA4BC19D37CF82 /* SealInput.swift */; };
 		4E67344B8C0A415F1F08BD96 /* SeekFogModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB33487484B5D9579CE62A2 /* SeekFogModel.swift */; };
 		4E9F3E9C7E3A4840ACD9DA73 /* ActivityIntervalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B789284BE2A474BA89993F2 /* ActivityIntervalTests.swift */; };
+		7ac8ee442a1ce6fcb926501a /* SharePayloadTourTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = cc51a46c5e27674f5165b409 /* SharePayloadTourTests.swift */; };
 		50A16B63C6F23E2D1E6210BA /* Pods_Pilgrim.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */; };
 		510A5ED79C24B905DDD597A7 /* ScrollHapticEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F12E1FE28A875629DBD34C /* ScrollHapticEngineTests.swift */; };
 		52C6F28B0AAB6E494591E8EF /* VoiceGuideManifestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F883597323B0CE64E69DC9 /* VoiceGuideManifestService.swift */; };
@@ -799,6 +800,7 @@
 		390BFBA7B83028EA625B0CF9 /* AudioManifestService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioManifestService.swift; sourceTree = "<group>"; };
 		3A98AEE09143482AA1EFE5DC /* SolarHorizon.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SolarHorizon.swift; sourceTree = "<group>"; };
 		3B789284BE2A474BA89993F2 /* ActivityIntervalTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActivityIntervalTests.swift; sourceTree = "<group>"; };
+		cc51a46c5e27674f5165b409 /* SharePayloadTourTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SharePayloadTourTests.swift; sourceTree = "<group>"; };
 		3E5EFD54CACA590B1BE78B75 /* BellPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BellPlayer.swift; sourceTree = "<group>"; };
 		3FE8447AB26F2388EA548BED /* SeekSoundPlayerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SeekSoundPlayerTests.swift; sourceTree = "<group>"; };
 		4181215714A52E71449BC390 /* WalkDataFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkDataFactory.swift; sourceTree = "<group>"; };
@@ -1826,6 +1828,7 @@
 				E4102471AC572B099189FB03 /* WalkBuilderStatusTests.swift */,
 				B3E892B071C7BE6EBD74F3FC /* NewWalkComputationTests.swift */,
 				3B789284BE2A474BA89993F2 /* ActivityIntervalTests.swift */,
+				cc51a46c5e27674f5165b409 /* SharePayloadTourTests.swift */,
 				AAAA000000000000000000D4 /* CustomPromptStyleStoreTests.swift */,
 				AAAA000000000000000000F4 /* IntentionHistoryStoreTests.swift */,
 				BBBB00000000000000000B /* WaypointCodableTests.swift */,
@@ -3133,6 +3136,7 @@
 				CDB0F563A56A46B5981279A2 /* WalkBuilderStatusTests.swift in Sources */,
 				FE15922AE9DAD82F62BA4601 /* NewWalkComputationTests.swift in Sources */,
 				4E9F3E9C7E3A4840ACD9DA73 /* ActivityIntervalTests.swift in Sources */,
+				7ac8ee442a1ce6fcb926501a /* SharePayloadTourTests.swift in Sources */,
 				AAAA000000000000000000D3 /* CustomPromptStyleStoreTests.swift in Sources */,
 				AAAA000000000000000000F3 /* IntentionHistoryStoreTests.swift in Sources */,
 				BBBB00000000000000000C /* WaypointCodableTests.swift in Sources */,

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -199,6 +199,7 @@
 		4E67344B8C0A415F1F08BD96 /* SeekFogModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFB33487484B5D9579CE62A2 /* SeekFogModel.swift */; };
 		4E9F3E9C7E3A4840ACD9DA73 /* ActivityIntervalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B789284BE2A474BA89993F2 /* ActivityIntervalTests.swift */; };
 		7ac8ee442a1ce6fcb926501a /* SharePayloadTourTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = cc51a46c5e27674f5165b409 /* SharePayloadTourTests.swift */; };
+		1A2B3C4D5E6F7A8B9C0D1E2F /* TourBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3C4D5E6F7A8B9C0D1E2F3A /* TourBuilderTests.swift */; };
 		50A16B63C6F23E2D1E6210BA /* Pods_Pilgrim.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */; };
 		510A5ED79C24B905DDD597A7 /* ScrollHapticEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F12E1FE28A875629DBD34C /* ScrollHapticEngineTests.swift */; };
 		52C6F28B0AAB6E494591E8EF /* VoiceGuideManifestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F883597323B0CE64E69DC9 /* VoiceGuideManifestService.swift */; };
@@ -251,6 +252,7 @@
 		7A87A132315C9E46AFE8CF5C /* VolumeSliderRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = B886390B795403D3BB7B3372 /* VolumeSliderRow.swift */; };
 		7C015E0BE5E73ED93AC71E65 /* CollectiveArtifactFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4850AE45F47BD522EA066821 /* CollectiveArtifactFixtures.swift */; };
 		7C39E4160B0DA105D78F4C83 /* SharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EA6F12A77BD40C46E34D47 /* SharePayload.swift */; };
+		3C4D5E6F7A8B9C0D1E2F3A4B /* TourBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5E6F7A8B9C0D1E2F3A4B5C /* TourBuilder.swift */; };
 		7CC49F936D1CFDB1460010C5 /* ConstellationDecor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D6A3F7440EBCE25B7FA93C /* ConstellationDecor.swift */; };
 		8478CDC1C45890FF1F4E473A /* WalkPromptVoices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 862461B76A73D888F6A1A77D /* WalkPromptVoices.swift */; };
 		847990ED75B5CA66C0317D1C /* ArchivedWalkFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = F875DF77E21A42330B294FDB /* ArchivedWalkFixtures.swift */; };
@@ -801,6 +803,7 @@
 		3A98AEE09143482AA1EFE5DC /* SolarHorizon.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SolarHorizon.swift; sourceTree = "<group>"; };
 		3B789284BE2A474BA89993F2 /* ActivityIntervalTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActivityIntervalTests.swift; sourceTree = "<group>"; };
 		cc51a46c5e27674f5165b409 /* SharePayloadTourTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SharePayloadTourTests.swift; sourceTree = "<group>"; };
+		2B3C4D5E6F7A8B9C0D1E2F3A /* TourBuilderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TourBuilderTests.swift; sourceTree = "<group>"; };
 		3E5EFD54CACA590B1BE78B75 /* BellPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BellPlayer.swift; sourceTree = "<group>"; };
 		3FE8447AB26F2388EA548BED /* SeekSoundPlayerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SeekSoundPlayerTests.swift; sourceTree = "<group>"; };
 		4181215714A52E71449BC390 /* WalkDataFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkDataFactory.swift; sourceTree = "<group>"; };
@@ -1067,6 +1070,7 @@
 		D0A1823447A8FBD30A3D3EFA /* PilgrimPackageExporterArchivedTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PilgrimPackageExporterArchivedTests.swift; sourceTree = "<group>"; };
 		D0CF8169656208D52DB6F4D6 /* CollectiveRouteCatalogServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollectiveRouteCatalogServiceTests.swift; sourceTree = "<group>"; };
 		D0EA6F12A77BD40C46E34D47 /* SharePayload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SharePayload.swift; sourceTree = "<group>"; };
+		4D5E6F7A8B9C0D1E2F3A4B5C /* TourBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TourBuilder.swift; sourceTree = "<group>"; };
 		D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Pilgrim.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2FDF0BD38D9467B99B2C4D7 /* ActivityListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityListView.swift; sourceTree = "<group>"; };
 		D30651941E3AA93F6BB14A1D /* whisper-play-12.aac */ = {isa = PBXFileReference; includeInIndex = 1; path = "whisper-play-12.aac"; sourceTree = "<group>"; };
@@ -1829,6 +1833,7 @@
 				B3E892B071C7BE6EBD74F3FC /* NewWalkComputationTests.swift */,
 				3B789284BE2A474BA89993F2 /* ActivityIntervalTests.swift */,
 				cc51a46c5e27674f5165b409 /* SharePayloadTourTests.swift */,
+				2B3C4D5E6F7A8B9C0D1E2F3A /* TourBuilderTests.swift */,
 				AAAA000000000000000000D4 /* CustomPromptStyleStoreTests.swift */,
 				AAAA000000000000000000F4 /* IntentionHistoryStoreTests.swift */,
 				BBBB00000000000000000B /* WaypointCodableTests.swift */,
@@ -2104,6 +2109,7 @@
 				D0EA6F12A77BD40C46E34D47 /* SharePayload.swift */,
 				E6E1B5A537C865F5416F6EF2 /* RouteDownsampler.swift */,
 				5D9D07CA4444A7B548B5CFA4 /* ShareService.swift */,
+				4D5E6F7A8B9C0D1E2F3A4B5C /* TourBuilder.swift */,
 			);
 			path = Share;
 			sourceTree = "<group>";
@@ -2968,6 +2974,7 @@
 				7C39E4160B0DA105D78F4C83 /* SharePayload.swift in Sources */,
 				9A477336A61C4C38B9D4F13C /* RouteDownsampler.swift in Sources */,
 				6AE85BCC627AF8321E753C1F /* ShareService.swift in Sources */,
+				3C4D5E6F7A8B9C0D1E2F3A4B /* TourBuilder.swift in Sources */,
 				E9FD884A3895457CBF231700 /* SealHashComputer.swift in Sources */,
 				B3C4D5E6F7A8B9C0D1E2F3A4 /* SealColorPalette.swift in Sources */,
 				D7E8F9A0B1C2D3E4F5A6B7C8 /* SealGeometry.swift in Sources */,
@@ -3137,6 +3144,7 @@
 				FE15922AE9DAD82F62BA4601 /* NewWalkComputationTests.swift in Sources */,
 				4E9F3E9C7E3A4840ACD9DA73 /* ActivityIntervalTests.swift in Sources */,
 				7ac8ee442a1ce6fcb926501a /* SharePayloadTourTests.swift in Sources */,
+				1A2B3C4D5E6F7A8B9C0D1E2F /* TourBuilderTests.swift in Sources */,
 				AAAA000000000000000000D3 /* CustomPromptStyleStoreTests.swift in Sources */,
 				AAAA000000000000000000F3 /* IntentionHistoryStoreTests.swift in Sources */,
 				BBBB00000000000000000C /* WaypointCodableTests.swift in Sources */,

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -200,6 +200,7 @@
 		4E9F3E9C7E3A4840ACD9DA73 /* ActivityIntervalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B789284BE2A474BA89993F2 /* ActivityIntervalTests.swift */; };
 		7ac8ee442a1ce6fcb926501a /* SharePayloadTourTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = cc51a46c5e27674f5165b409 /* SharePayloadTourTests.swift */; };
 		1A2B3C4D5E6F7A8B9C0D1E2F /* TourBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B3C4D5E6F7A8B9C0D1E2F3A /* TourBuilderTests.swift */; };
+		7E8F9A0B1C2D3E4F5A6B7C8D /* RouteTrimmerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F9A0B1C2D3E4F5A6B7C8D9E /* RouteTrimmerTests.swift */; };
 		50A16B63C6F23E2D1E6210BA /* Pods_Pilgrim.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */; };
 		510A5ED79C24B905DDD597A7 /* ScrollHapticEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F12E1FE28A875629DBD34C /* ScrollHapticEngineTests.swift */; };
 		52C6F28B0AAB6E494591E8EF /* VoiceGuideManifestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F883597323B0CE64E69DC9 /* VoiceGuideManifestService.swift */; };
@@ -253,6 +254,7 @@
 		7C015E0BE5E73ED93AC71E65 /* CollectiveArtifactFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4850AE45F47BD522EA066821 /* CollectiveArtifactFixtures.swift */; };
 		7C39E4160B0DA105D78F4C83 /* SharePayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0EA6F12A77BD40C46E34D47 /* SharePayload.swift */; };
 		3C4D5E6F7A8B9C0D1E2F3A4B /* TourBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D5E6F7A8B9C0D1E2F3A4B5C /* TourBuilder.swift */; };
+		5C6D7E8F9A0B1C2D3E4F5A6B /* RouteTrimmer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D7E8F9A0B1C2D3E4F5A6B7C /* RouteTrimmer.swift */; };
 		7CC49F936D1CFDB1460010C5 /* ConstellationDecor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03D6A3F7440EBCE25B7FA93C /* ConstellationDecor.swift */; };
 		8478CDC1C45890FF1F4E473A /* WalkPromptVoices.swift in Sources */ = {isa = PBXBuildFile; fileRef = 862461B76A73D888F6A1A77D /* WalkPromptVoices.swift */; };
 		847990ED75B5CA66C0317D1C /* ArchivedWalkFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = F875DF77E21A42330B294FDB /* ArchivedWalkFixtures.swift */; };
@@ -804,6 +806,7 @@
 		3B789284BE2A474BA89993F2 /* ActivityIntervalTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ActivityIntervalTests.swift; sourceTree = "<group>"; };
 		cc51a46c5e27674f5165b409 /* SharePayloadTourTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SharePayloadTourTests.swift; sourceTree = "<group>"; };
 		2B3C4D5E6F7A8B9C0D1E2F3A /* TourBuilderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TourBuilderTests.swift; sourceTree = "<group>"; };
+		8F9A0B1C2D3E4F5A6B7C8D9E /* RouteTrimmerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RouteTrimmerTests.swift; sourceTree = "<group>"; };
 		3E5EFD54CACA590B1BE78B75 /* BellPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BellPlayer.swift; sourceTree = "<group>"; };
 		3FE8447AB26F2388EA548BED /* SeekSoundPlayerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SeekSoundPlayerTests.swift; sourceTree = "<group>"; };
 		4181215714A52E71449BC390 /* WalkDataFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkDataFactory.swift; sourceTree = "<group>"; };
@@ -1071,6 +1074,7 @@
 		D0CF8169656208D52DB6F4D6 /* CollectiveRouteCatalogServiceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollectiveRouteCatalogServiceTests.swift; sourceTree = "<group>"; };
 		D0EA6F12A77BD40C46E34D47 /* SharePayload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SharePayload.swift; sourceTree = "<group>"; };
 		4D5E6F7A8B9C0D1E2F3A4B5C /* TourBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TourBuilder.swift; sourceTree = "<group>"; };
+		6D7E8F9A0B1C2D3E4F5A6B7C /* RouteTrimmer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RouteTrimmer.swift; sourceTree = "<group>"; };
 		D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Pilgrim.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D2FDF0BD38D9467B99B2C4D7 /* ActivityListView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityListView.swift; sourceTree = "<group>"; };
 		D30651941E3AA93F6BB14A1D /* whisper-play-12.aac */ = {isa = PBXFileReference; includeInIndex = 1; path = "whisper-play-12.aac"; sourceTree = "<group>"; };
@@ -1834,6 +1838,7 @@
 				3B789284BE2A474BA89993F2 /* ActivityIntervalTests.swift */,
 				cc51a46c5e27674f5165b409 /* SharePayloadTourTests.swift */,
 				2B3C4D5E6F7A8B9C0D1E2F3A /* TourBuilderTests.swift */,
+				8F9A0B1C2D3E4F5A6B7C8D9E /* RouteTrimmerTests.swift */,
 				AAAA000000000000000000D4 /* CustomPromptStyleStoreTests.swift */,
 				AAAA000000000000000000F4 /* IntentionHistoryStoreTests.swift */,
 				BBBB00000000000000000B /* WaypointCodableTests.swift */,
@@ -2110,6 +2115,7 @@
 				E6E1B5A537C865F5416F6EF2 /* RouteDownsampler.swift */,
 				5D9D07CA4444A7B548B5CFA4 /* ShareService.swift */,
 				4D5E6F7A8B9C0D1E2F3A4B5C /* TourBuilder.swift */,
+				6D7E8F9A0B1C2D3E4F5A6B7C /* RouteTrimmer.swift */,
 			);
 			path = Share;
 			sourceTree = "<group>";
@@ -2975,6 +2981,7 @@
 				9A477336A61C4C38B9D4F13C /* RouteDownsampler.swift in Sources */,
 				6AE85BCC627AF8321E753C1F /* ShareService.swift in Sources */,
 				3C4D5E6F7A8B9C0D1E2F3A4B /* TourBuilder.swift in Sources */,
+				5C6D7E8F9A0B1C2D3E4F5A6B /* RouteTrimmer.swift in Sources */,
 				E9FD884A3895457CBF231700 /* SealHashComputer.swift in Sources */,
 				B3C4D5E6F7A8B9C0D1E2F3A4 /* SealColorPalette.swift in Sources */,
 				D7E8F9A0B1C2D3E4F5A6B7C8 /* SealGeometry.swift in Sources */,
@@ -3145,6 +3152,7 @@
 				4E9F3E9C7E3A4840ACD9DA73 /* ActivityIntervalTests.swift in Sources */,
 				7ac8ee442a1ce6fcb926501a /* SharePayloadTourTests.swift in Sources */,
 				1A2B3C4D5E6F7A8B9C0D1E2F /* TourBuilderTests.swift in Sources */,
+				7E8F9A0B1C2D3E4F5A6B7C8D /* RouteTrimmerTests.swift in Sources */,
 				AAAA000000000000000000D3 /* CustomPromptStyleStoreTests.swift in Sources */,
 				AAAA000000000000000000F3 /* IntentionHistoryStoreTests.swift in Sources */,
 				BBBB00000000000000000C /* WaypointCodableTests.swift in Sources */,

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -203,6 +203,7 @@
 		7E8F9A0B1C2D3E4F5A6B7C8D /* RouteTrimmerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8F9A0B1C2D3E4F5A6B7C8D9E /* RouteTrimmerTests.swift */; };
 		D69446C38B3D4915B5EE6940 /* TourPhotoExporterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 82A6C2F48C9A4A83B2DF7DD4 /* TourPhotoExporterTests.swift */; };
 		FF09C76A879AAD0D3E6C1A54 /* ShareMediaUploadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 598E81D4C0900F5E3DF2B1BC /* ShareMediaUploadTests.swift */; };
+		ADB1EFE3A67DBDD566E302AA /* WalkShareInteractiveTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C142E36B6C8770B5B7ACF2FB /* WalkShareInteractiveTests.swift */; };
 		50A16B63C6F23E2D1E6210BA /* Pods_Pilgrim.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */; };
 		510A5ED79C24B905DDD597A7 /* ScrollHapticEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F12E1FE28A875629DBD34C /* ScrollHapticEngineTests.swift */; };
 		52C6F28B0AAB6E494591E8EF /* VoiceGuideManifestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F883597323B0CE64E69DC9 /* VoiceGuideManifestService.swift */; };
@@ -812,6 +813,7 @@
 		8F9A0B1C2D3E4F5A6B7C8D9E /* RouteTrimmerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RouteTrimmerTests.swift; sourceTree = "<group>"; };
 		82A6C2F48C9A4A83B2DF7DD4 /* TourPhotoExporterTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TourPhotoExporterTests.swift; sourceTree = "<group>"; };
 		598E81D4C0900F5E3DF2B1BC /* ShareMediaUploadTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ShareMediaUploadTests.swift; sourceTree = "<group>"; };
+		C142E36B6C8770B5B7ACF2FB /* WalkShareInteractiveTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkShareInteractiveTests.swift; sourceTree = "<group>"; };
 		3E5EFD54CACA590B1BE78B75 /* BellPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BellPlayer.swift; sourceTree = "<group>"; };
 		3FE8447AB26F2388EA548BED /* SeekSoundPlayerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SeekSoundPlayerTests.swift; sourceTree = "<group>"; };
 		4181215714A52E71449BC390 /* WalkDataFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkDataFactory.swift; sourceTree = "<group>"; };
@@ -1847,6 +1849,7 @@
 				8F9A0B1C2D3E4F5A6B7C8D9E /* RouteTrimmerTests.swift */,
 				82A6C2F48C9A4A83B2DF7DD4 /* TourPhotoExporterTests.swift */,
 				598E81D4C0900F5E3DF2B1BC /* ShareMediaUploadTests.swift */,
+				C142E36B6C8770B5B7ACF2FB /* WalkShareInteractiveTests.swift */,
 				AAAA000000000000000000D4 /* CustomPromptStyleStoreTests.swift */,
 				AAAA000000000000000000F4 /* IntentionHistoryStoreTests.swift */,
 				BBBB00000000000000000B /* WaypointCodableTests.swift */,
@@ -3165,6 +3168,7 @@
 				7E8F9A0B1C2D3E4F5A6B7C8D /* RouteTrimmerTests.swift in Sources */,
 				D69446C38B3D4915B5EE6940 /* TourPhotoExporterTests.swift in Sources */,
 				FF09C76A879AAD0D3E6C1A54 /* ShareMediaUploadTests.swift in Sources */,
+				ADB1EFE3A67DBDD566E302AA /* WalkShareInteractiveTests.swift in Sources */,
 				AAAA000000000000000000D3 /* CustomPromptStyleStoreTests.swift in Sources */,
 				AAAA000000000000000000F3 /* IntentionHistoryStoreTests.swift in Sources */,
 				BBBB00000000000000000C /* WaypointCodableTests.swift in Sources */,

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -574,6 +574,7 @@
 		LR00000200000000LRWVLD01 /* WebViewLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVLD01 /* WebViewLoader.swift */; };
 		LR00000200000000LRWVLDT1 /* WebViewLoaderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVLDT1 /* WebViewLoaderTests.swift */; };
 		LR00000200000000LRWVPV01 /* WalkSharePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVPV01 /* WalkSharePreviewView.swift */; };
+		F111E1130A361093119C4459 /* InteractiveShareSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BF7056E6064D6423F5E736E /* InteractiveShareSection.swift */; };
 		LR00000200000000LRWVRP01 /* WebViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRWVRP01 /* WebViewRepresentable.swift */; };
 		PERM000100000003 /* PermissionsViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = PERM000100000002 /* PermissionsViewModel.swift */; };
 		PERM000100000005 /* PermissionsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = PERM000100000004 /* PermissionsViewModelTests.swift */; };
@@ -1199,6 +1200,7 @@
 		LR00000100000000LRWVLD01 /* WebViewLoader.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewLoader.swift; sourceTree = "<group>"; };
 		LR00000100000000LRWVLDT1 /* WebViewLoaderTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewLoaderTests.swift; sourceTree = "<group>"; };
 		LR00000100000000LRWVPV01 /* WalkSharePreviewView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkSharePreviewView.swift; sourceTree = "<group>"; };
+		6BF7056E6064D6423F5E736E /* InteractiveShareSection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InteractiveShareSection.swift; sourceTree = "<group>"; };
 		LR00000100000000LRWVRP01 /* WebViewRepresentable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WebViewRepresentable.swift; sourceTree = "<group>"; };
 		PERM000100000002 /* PermissionsViewModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PermissionsViewModel.swift; sourceTree = "<group>"; };
 		PERM000100000004 /* PermissionsViewModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PermissionsViewModelTests.swift; sourceTree = "<group>"; };
@@ -2094,6 +2096,7 @@
 				LR00000100000000LRWVLD01 /* WebViewLoader.swift */,
 				LR00000100000000LRWVRP01 /* WebViewRepresentable.swift */,
 				LR00000100000000LRWVPV01 /* WalkSharePreviewView.swift */,
+				6BF7056E6064D6423F5E736E /* InteractiveShareSection.swift */,
 			);
 			path = WalkShare;
 			sourceTree = "<group>";
@@ -3111,6 +3114,7 @@
 				LR00000200000000LRHEMS01 /* Hemisphere.swift in Sources */,
 				LR00000200000000LRWVRP01 /* WebViewRepresentable.swift in Sources */,
 				LR00000200000000LRWVPV01 /* WalkSharePreviewView.swift in Sources */,
+				F111E1130A361093119C4459 /* InteractiveShareSection.swift in Sources */,
 				1ED04A655291254525CB5A42 /* JourneyEditorView.swift in Sources */,
 				BABACBE432D649DEE348D186 /* AppearanceView.swift in Sources */,
 				78C931B298CA7FEDAFD6CC4F /* ConstellationOverlay.swift in Sources */,

--- a/Pilgrim/Models/ScreenshotDataSeeder.swift
+++ b/Pilgrim/Models/ScreenshotDataSeeder.swift
@@ -223,12 +223,14 @@ enum ScreenshotDataSeeder {
         if spec.talkMinutes > 0 {
             let talkStart = adjustedStart.addingTimeInterval(spec.durationMinutes * 60 * 0.25)
             let talkEnd = talkStart.addingTimeInterval(spec.talkMinutes * 60)
+            let relativePath = "demo/recording-\(index).m4a"
+            seedRecordingFileIfNeeded(relativePath: relativePath)
             voiceRecordings.append(TempVoiceRecording(
                 uuid: nil,
                 startDate: talkStart,
                 endDate: talkEnd,
                 duration: spec.talkMinutes * 60,
-                fileRelativePath: "demo/recording-\(index).m4a",
+                fileRelativePath: relativePath,
                 transcription: spec.transcription
             ))
         }
@@ -298,6 +300,28 @@ enum ScreenshotDataSeeder {
         )
         walk.favicon = spec.favicon
         return walk
+    }
+
+    /// Seeded recordings point `fileRelativePath` at `demo/recording-N.m4a`,
+    /// but nothing wrote those files — `TourBuilder.candidates(for:)` stats
+    /// the file on disk and marks a missing/zero-byte recording unavailable,
+    /// so the Interactive share section showed only "No recordings" rows.
+    /// Copies a short bundled sound into Documents the first time a given
+    /// path is needed; a no-op on every later seed.
+    private static func seedRecordingFileIfNeeded(relativePath: String) {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let destination = docs.appendingPathComponent(relativePath)
+        guard !FileManager.default.fileExists(atPath: destination.path) else { return }
+        guard let source = Bundle.main.url(forResource: "stone-tier-1", withExtension: "m4a") else { return }
+        do {
+            try FileManager.default.createDirectory(
+                at: destination.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try FileManager.default.copyItem(at: source, to: destination)
+        } catch {
+            print("[ScreenshotDataSeeder] Failed to seed recording file at \(relativePath): \(error)")
+        }
     }
 }
 #endif

--- a/Pilgrim/Models/Share/RouteTrimmer.swift
+++ b/Pilgrim/Models/Share/RouteTrimmer.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+enum RouteTrimmer {
+
+    /// Shaves `meters` of walked distance off each end of the route so a
+    /// shared page never reveals a doorstep. Walks shorter than 4x the trim
+    /// distance share untrimmed — mid-walk geometry is all they have.
+    static func trim(_ route: [SharePayload.RoutePoint], meters: Double) -> [SharePayload.RoutePoint] {
+        guard meters > 0, route.count > 3 else { return route }
+        var cumulative: [Double] = [0]
+        for i in 1..<route.count {
+            cumulative.append(cumulative[i - 1] + haversineMeters(route[i - 1], route[i]))
+        }
+        let total = cumulative[route.count - 1]
+        guard total >= meters * 4 else { return route }
+
+        var start = 0
+        while start < route.count - 1 && cumulative[start] < meters { start += 1 }
+        var end = route.count - 1
+        while end > 0 && total - cumulative[end] < meters { end -= 1 }
+        guard end > start else { return route }
+        return Array(route[start...end])
+    }
+
+    /// Whether a 150m trim can actually apply — the UI uses this to say
+    /// "too short to trim" instead of silently promising protection.
+    static func canTrim(_ route: [SharePayload.RoutePoint], meters: Double) -> Bool {
+        guard meters > 0, route.count > 3 else { return false }
+        var total = 0.0
+        for i in 1..<route.count { total += haversineMeters(route[i - 1], route[i]) }
+        return total >= meters * 4
+    }
+
+    private static func haversineMeters(_ a: SharePayload.RoutePoint, _ b: SharePayload.RoutePoint) -> Double {
+        let r = 6_371_000.0
+        let dLat = (b.lat - a.lat) * .pi / 180
+        let dLon = (b.lon - a.lon) * .pi / 180
+        let la = a.lat * .pi / 180
+        let lb = b.lat * .pi / 180
+        let h = sin(dLat / 2) * sin(dLat / 2) + cos(la) * cos(lb) * sin(dLon / 2) * sin(dLon / 2)
+        return 2 * r * asin(sqrt(h))
+    }
+}

--- a/Pilgrim/Models/Share/RouteTrimmer.swift
+++ b/Pilgrim/Models/Share/RouteTrimmer.swift
@@ -22,13 +22,10 @@ enum RouteTrimmer {
         return Array(route[start...end])
     }
 
-    /// Whether a 150m trim can actually apply — the UI uses this to say
+    /// Whether trim can actually apply to the route — the UI uses this to show
     /// "too short to trim" instead of silently promising protection.
     static func canTrim(_ route: [SharePayload.RoutePoint], meters: Double) -> Bool {
-        guard meters > 0, route.count > 3 else { return false }
-        var total = 0.0
-        for i in 1..<route.count { total += haversineMeters(route[i - 1], route[i]) }
-        return total >= meters * 4
+        trim(route, meters: meters).count < route.count
     }
 
     private static func haversineMeters(_ a: SharePayload.RoutePoint, _ b: SharePayload.RoutePoint) -> Double {

--- a/Pilgrim/Models/Share/SharePayload.swift
+++ b/Pilgrim/Models/Share/SharePayload.swift
@@ -73,11 +73,52 @@ struct SharePayload: Encodable {
         let lat: Double
         let lon: Double
         let ts: Int
-        let data: String
+        let data: String?
     }
 
+    struct Pause: Encodable {
+        let startTs: Int
+        let endTs: Int
+
+        enum CodingKeys: String, CodingKey {
+            case startTs = "start_ts"
+            case endTs = "end_ts"
+        }
+    }
+
+    struct Tour: Encodable {
+        let recordings: [TourRecording]
+        let trimM: Int
+
+        enum CodingKeys: String, CodingKey {
+            case recordings
+            case trimM = "trim_m"
+        }
+    }
+
+    struct TourRecording: Encodable {
+        let n: Int
+        let startTs: Int
+        let endTs: Int
+        let duration: Double
+        let kind: String
+        let transcription: String?
+        let wpm: Double?
+        let sizeBytes: Int
+
+        enum CodingKeys: String, CodingKey {
+            case n, duration, kind, transcription, wpm
+            case startTs = "start_ts"
+            case endTs = "end_ts"
+            case sizeBytes = "size_bytes"
+        }
+    }
+
+    var tour: Tour? = nil
+    var pauses: [Pause]? = nil
+
     enum CodingKeys: String, CodingKey {
-        case stats, route, journal, units, waypoints, mark, photos
+        case stats, route, journal, units, waypoints, mark, photos, tour, pauses
         case activityIntervals = "activity_intervals"
         case expiryDays = "expiry_days"
         case startDate = "start_date"

--- a/Pilgrim/Models/Share/ShareService.swift
+++ b/Pilgrim/Models/Share/ShareService.swift
@@ -168,6 +168,7 @@ extension ShareService {
         shareID: String,
         audioFiles: [URL],
         photos: [Data],
+        onItemSuccess: ((MediaKind, Int) -> Void)? = nil,
         progress: @escaping (MediaProgress) -> Void
     ) async -> [(kind: MediaKind, n: Int)] {
         return await withBackgroundAssertion(named: "pilgrim.share.media") {
@@ -186,12 +187,17 @@ extension ShareService {
                 // missing-files offer instead of a truncated upload.
                 if await backgroundTimeExhausted() {
                     for remaining in index..<photos.count { failures.append((.photos, remaining + 1)) }
-                    completed = total
+                    // Bounded to what THIS loop still owes, not the grand total — jumping straight to `total` would let `completed` overshoot if the app foregrounds before the audio loop below and that one finishes normally.
+                    completed += photos.count - index
                     report()
                     break
                 }
                 let ok = await putWithRetry(shareID: shareID, kind: .photos, n: index + 1) { data }
-                if !ok { failures.append((.photos, index + 1)) }
+                if ok {
+                    onItemSuccess?(.photos, index + 1)
+                } else {
+                    failures.append((.photos, index + 1))
+                }
                 completed += 1
                 report()
             }
@@ -199,14 +205,19 @@ extension ShareService {
             for (index, fileURL) in audioFiles.enumerated() {
                 if await backgroundTimeExhausted() {
                     for remaining in index..<audioFiles.count { failures.append((.audio, remaining + 1)) }
-                    completed = total
+                    // Same reasoning as the photos loop above.
+                    completed += audioFiles.count - index
                     report()
                     break
                 }
                 let ok = await putWithRetry(shareID: shareID, kind: .audio, n: index + 1) {
                     try Data(contentsOf: fileURL)
                 }
-                if !ok { failures.append((.audio, index + 1)) }
+                if ok {
+                    onItemSuccess?(.audio, index + 1)
+                } else {
+                    failures.append((.audio, index + 1))
+                }
                 completed += 1
                 report()
             }
@@ -222,6 +233,7 @@ extension ShareService {
     static func uploadSpecific(
         shareID: String,
         items: [(kind: MediaKind, n: Int, data: () throws -> Data)],
+        onItemSuccess: ((MediaKind, Int) -> Void)? = nil,
         progress: @escaping (MediaProgress) -> Void
     ) async -> [(kind: MediaKind, n: Int)] {
         return await withBackgroundAssertion(named: "pilgrim.share.media") {
@@ -234,23 +246,39 @@ extension ShareService {
                     break
                 }
                 let ok = await putWithRetry(shareID: shareID, kind: item.kind, n: item.n, body: item.data)
-                if !ok { failures.append((item.kind, item.n)) }
+                if ok {
+                    onItemSuccess?(item.kind, item.n)
+                } else {
+                    failures.append((item.kind, item.n))
+                }
                 progress(MediaProgress(completed: i + 1, total: items.count))
             }
             return failures
         }
     }
 
+    /// Injected rather than reading `UIApplication.shared` directly (mirrors
+    /// `WalkShareViewModel.isPhotosGranted`'s precedent): the OS background
+    /// state can't be driven from a unit test, so `backgroundTimeExhausted()`
+    /// needs a seam a test can force deterministically. Tests restore the
+    /// default in `tearDown`.
+    nonisolated(unsafe) static var backgroundStateProvider: @MainActor () -> (isBackground: Bool, remaining: TimeInterval) = {
+        (UIApplication.shared.applicationState == .background, UIApplication.shared.backgroundTimeRemaining)
+    }
+
     /// True once the OS is about to suspend the app mid-background-task: a
     /// PUT started now could be killed with the connection half-open, which
     /// the worker would just see as a dropped upload — better to never start
     /// it and let the repair record ("Carry the missing files") offer it
-    /// once Pilgrim is foreground again. 35s leaves headroom for the retry
-    /// window inside `putWithRetry` (one 800ms backoff) plus the request
-    /// itself to at least fail cleanly instead of being torn down mid-PUT.
+    /// once Pilgrim is foreground again. iOS grants ~30s of background time
+    /// total — a threshold at or above that grant is always-true the instant
+    /// the app backgrounds, abandoning the usable ~25s before it. 10s lets
+    /// small items still proceed and only stops near true exhaustion; the
+    /// real fix is a background URLSession (scheduled fast-follow).
     private static func backgroundTimeExhausted() async -> Bool {
         await MainActor.run {
-            UIApplication.shared.applicationState == .background && UIApplication.shared.backgroundTimeRemaining < 35
+            let state = backgroundStateProvider()
+            return state.isBackground && state.remaining < 10
         }
     }
 
@@ -365,6 +393,14 @@ extension ShareService {
                 lastError = error
             }
             if attempt == 0 {
+                // A single item's own attempt-plus-retry cycle can burn up to
+                // ~60s of request timeouts on its own — re-check here, not
+                // just once per item before this call, so a slow first
+                // attempt can't blow through the remaining background grant
+                // before the retry even starts.
+                if await backgroundTimeExhausted() {
+                    return false
+                }
                 try? await Task.sleep(nanoseconds: 800_000_000)
             }
         }

--- a/Pilgrim/Models/Share/ShareService.swift
+++ b/Pilgrim/Models/Share/ShareService.swift
@@ -262,8 +262,11 @@ extension ShareService {
     /// background time) and the normal completion path both race to end
     /// the same assertion, and the lock ensures only the first of them
     /// actually calls endBackgroundTask — calling it twice is documented
-    /// Apple misuse.
-    private static func withBackgroundAssertion<T: Sendable>(
+    /// Apple misuse. Not `private`: `WalkShareViewModel+ShareOrchestration.swift`
+    /// wraps `TourPhotoExporter.export` in the same assertion — Swift's
+    /// `private` is file-scoped, so staying cross-file-callable means at
+    /// most internal access (the default).
+    static func withBackgroundAssertion<T: Sendable>(
         named name: String,
         _ body: () async -> T
     ) async -> T {

--- a/Pilgrim/Models/Share/ShareService.swift
+++ b/Pilgrim/Models/Share/ShareService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import UIKit
 
 enum ShareService {
 
@@ -127,6 +128,143 @@ enum ShareService {
             dict["expiryOption"] = expiryOption
         }
         UserDefaults.standard.set(dict, forKey: "share:\(walkID.uuidString)")
+    }
+}
+
+// MARK: - Interactive media uploads
+
+extension ShareService {
+
+    struct MediaProgress: Equatable {
+        let completed: Int
+        let total: Int
+    }
+
+    enum MediaKind: String { case audio, photos }
+
+    static func mediaUploadRequest(shareID: String, kind: MediaKind, n: Int, contentLength: Int) -> URLRequest {
+        let url = URL(string: "\(baseURL)/api/share/\(shareID)/\(kind.rawValue)/\(n)")!
+        var request = URLRequest(url: url)
+        request.httpMethod = "PUT"
+        request.setValue(kind == .audio ? "audio/mp4" : "image/jpeg", forHTTPHeaderField: "Content-Type")
+        request.setValue("\(contentLength)", forHTTPHeaderField: "Content-Length")
+        request.setValue(deviceToken(), forHTTPHeaderField: "X-Device-Token")
+        request.timeoutInterval = 120
+        return request
+    }
+
+    /// Sequential by contract: photos MUST land in index order (enrich
+    /// HEADs only the last one), and one-at-a-time keeps memory flat for
+    /// 15MB audio files. PHOTOS UPLOAD FIRST — they gate the keepsake
+    /// render window; audio degrades gracefully to "voice unavailable".
+    /// Each item gets one retry. Runs inside a background-task assertion
+    /// so pocketing the phone doesn't kill the remaining PUTs. Returns
+    /// the indices (1-based, per kind) that ultimately failed.
+    static func uploadAllMedia(
+        shareID: String,
+        audioFiles: [URL],
+        photos: [Data],
+        progress: @escaping (MediaProgress) -> Void
+    ) async -> [(kind: MediaKind, n: Int)] {
+        var failures: [(kind: MediaKind, n: Int)] = []
+        let total = audioFiles.count + photos.count
+        var completed = 0
+
+        func report() { progress(MediaProgress(completed: completed, total: total)) }
+        report()
+
+        // Keep the PUT chain alive through pocketing/locking: request
+        // background execution for the whole sequence.
+        let bgTask = await MainActor.run {
+            UIApplication.shared.beginBackgroundTask(withName: "pilgrim.share.media")
+        }
+        defer {
+            if bgTask != .invalid {
+                Task { @MainActor in UIApplication.shared.endBackgroundTask(bgTask) }
+            }
+        }
+
+        // Photos first: enrich's keepsake render waits (bounded) on the
+        // LAST photo; audio has a graceful fallback on the page.
+        for (index, data) in photos.enumerated() {
+            let ok = await putWithRetry(shareID: shareID, kind: .photos, n: index + 1) { data }
+            if !ok { failures.append((.photos, index + 1)) }
+            completed += 1
+            report()
+        }
+
+        for (index, fileURL) in audioFiles.enumerated() {
+            let ok = await putWithRetry(shareID: shareID, kind: .audio, n: index + 1) {
+                try Data(contentsOf: fileURL)
+            }
+            if !ok { failures.append((.audio, index + 1)) }
+            completed += 1
+            report()
+        }
+        return failures
+    }
+
+    /// Targeted re-upload for a previous share's failed items ("Carry the
+    /// missing files"). Same ordering rules; audio resolved from URLs,
+    /// photos re-exported by the caller.
+    static func uploadSpecific(
+        shareID: String,
+        items: [(kind: MediaKind, n: Int, data: () throws -> Data)],
+        progress: @escaping (MediaProgress) -> Void
+    ) async -> [(kind: MediaKind, n: Int)] {
+        var failures: [(kind: MediaKind, n: Int)] = []
+        for (i, item) in items.enumerated() {
+            let ok = await putWithRetry(shareID: shareID, kind: item.kind, n: item.n, body: item.data)
+            if !ok { failures.append((item.kind, item.n)) }
+            progress(MediaProgress(completed: i + 1, total: items.count))
+        }
+        return failures
+    }
+
+    /// Failed-media bookkeeping alongside the cached share, so a re-entry
+    /// can offer repair for the share's whole life (the worker accepts
+    /// PUTs until expiry).
+    static func cacheFailedMedia(_ failures: [(kind: MediaKind, n: Int)], walkID: UUID) {
+        let key = "share-failed-media:\(walkID.uuidString)"
+        if failures.isEmpty {
+            UserDefaults.standard.removeObject(forKey: key)
+        } else {
+            UserDefaults.standard.set(failures.map { "\($0.kind.rawValue):\($0.n)" }, forKey: key)
+        }
+    }
+
+    static func failedMedia(for walkID: UUID) -> [(kind: MediaKind, n: Int)] {
+        let key = "share-failed-media:\(walkID.uuidString)"
+        guard let raw = UserDefaults.standard.stringArray(forKey: key) else { return [] }
+        return raw.compactMap { entry in
+            let parts = entry.split(separator: ":")
+            guard parts.count == 2, let kind = MediaKind(rawValue: String(parts[0])), let n = Int(parts[1]) else { return nil }
+            return (kind, n)
+        }
+    }
+
+    private static func putWithRetry(
+        shareID: String,
+        kind: MediaKind,
+        n: Int,
+        body: () throws -> Data
+    ) async -> Bool {
+        for attempt in 0..<2 {
+            do {
+                let data = try body()
+                let request = mediaUploadRequest(shareID: shareID, kind: kind, n: n, contentLength: data.count)
+                let (_, response) = try await URLSession.shared.upload(for: request, from: data)
+                if let http = response as? HTTPURLResponse, (200...299).contains(http.statusCode) {
+                    return true
+                }
+            } catch {
+                // fall through to retry
+            }
+            if attempt == 0 {
+                try? await Task.sleep(nanoseconds: 800_000_000)
+            }
+        }
+        return false
     }
 }
 

--- a/Pilgrim/Models/Share/ShareService.swift
+++ b/Pilgrim/Models/Share/ShareService.swift
@@ -218,26 +218,41 @@ extension ShareService {
         }
     }
 
+    /// A failed upload's slot (`kind`/`n`, the PUT index the worker is still
+    /// missing) plus the STABLE identity of the file it was meant to carry.
+    /// `n` alone isn't safe to retry against later: the local candidate list
+    /// an index was drawn from can shift (an export drop, an unpin) between
+    /// the original share and a retry, so the caller resolving this cache
+    /// must verify identity (recording `startTs`, or photo `localIdentifier`
+    /// + captured `ts`) before uploading anything under `n` again — see
+    /// `WalkShareViewModel.resolveRetryItems`. `kind` is a raw string, not
+    /// `MediaKind`, so this format doesn't depend on that enum's cases.
+    struct FailedMediaItem: Codable, Equatable {
+        let kind: String
+        let n: Int
+        let audioStartTs: Int?
+        let photoLocalID: String?
+        let photoTs: Int?
+    }
+
     /// Failed-media bookkeeping alongside the cached share, so a re-entry
     /// can offer repair for the share's whole life (the worker accepts
-    /// PUTs until expiry).
-    static func cacheFailedMedia(_ failures: [(kind: MediaKind, n: Int)], walkID: UUID) {
+    /// PUTs until expiry). Stored as JSON — no shipped data exists in this
+    /// format yet, so it's free to change without a migration.
+    static func cacheFailedMedia(_ failures: [FailedMediaItem], walkID: UUID) {
         let key = "share-failed-media:\(walkID.uuidString)"
         if failures.isEmpty {
             UserDefaults.standard.removeObject(forKey: key)
-        } else {
-            UserDefaults.standard.set(failures.map { "\($0.kind.rawValue):\($0.n)" }, forKey: key)
+        } else if let data = try? JSONEncoder().encode(failures) {
+            UserDefaults.standard.set(data, forKey: key)
         }
     }
 
-    static func failedMedia(for walkID: UUID) -> [(kind: MediaKind, n: Int)] {
+    static func failedMedia(for walkID: UUID) -> [FailedMediaItem] {
         let key = "share-failed-media:\(walkID.uuidString)"
-        guard let raw = UserDefaults.standard.stringArray(forKey: key) else { return [] }
-        return raw.compactMap { entry in
-            let parts = entry.split(separator: ":")
-            guard parts.count == 2, let kind = MediaKind(rawValue: String(parts[0])), let n = Int(parts[1]) else { return nil }
-            return (kind, n)
-        }
+        guard let data = UserDefaults.standard.data(forKey: key),
+              let items = try? JSONDecoder().decode([FailedMediaItem].self, from: data) else { return [] }
+        return items
     }
 
     /// Begins a background-task assertion, runs `body`, then ends it — so

--- a/Pilgrim/Models/Share/ShareService.swift
+++ b/Pilgrim/Models/Share/ShareService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import os
 
 enum ShareService {
 
@@ -166,59 +167,55 @@ extension ShareService {
         photos: [Data],
         progress: @escaping (MediaProgress) -> Void
     ) async -> [(kind: MediaKind, n: Int)] {
-        var failures: [(kind: MediaKind, n: Int)] = []
-        let total = audioFiles.count + photos.count
-        var completed = 0
+        return await withBackgroundAssertion(named: "pilgrim.share.media") {
+            var failures: [(kind: MediaKind, n: Int)] = []
+            let total = audioFiles.count + photos.count
+            var completed = 0
 
-        func report() { progress(MediaProgress(completed: completed, total: total)) }
-        report()
-
-        // Keep the PUT chain alive through pocketing/locking: request
-        // background execution for the whole sequence.
-        let bgTask = await MainActor.run {
-            UIApplication.shared.beginBackgroundTask(withName: "pilgrim.share.media")
-        }
-        defer {
-            if bgTask != .invalid {
-                Task { @MainActor in UIApplication.shared.endBackgroundTask(bgTask) }
-            }
-        }
-
-        // Photos first: enrich's keepsake render waits (bounded) on the
-        // LAST photo; audio has a graceful fallback on the page.
-        for (index, data) in photos.enumerated() {
-            let ok = await putWithRetry(shareID: shareID, kind: .photos, n: index + 1) { data }
-            if !ok { failures.append((.photos, index + 1)) }
-            completed += 1
+            func report() { progress(MediaProgress(completed: completed, total: total)) }
             report()
-        }
 
-        for (index, fileURL) in audioFiles.enumerated() {
-            let ok = await putWithRetry(shareID: shareID, kind: .audio, n: index + 1) {
-                try Data(contentsOf: fileURL)
+            // Photos first: enrich's keepsake render waits (bounded) on the
+            // LAST photo; audio has a graceful fallback on the page.
+            for (index, data) in photos.enumerated() {
+                let ok = await putWithRetry(shareID: shareID, kind: .photos, n: index + 1) { data }
+                if !ok { failures.append((.photos, index + 1)) }
+                completed += 1
+                report()
             }
-            if !ok { failures.append((.audio, index + 1)) }
-            completed += 1
-            report()
+
+            for (index, fileURL) in audioFiles.enumerated() {
+                let ok = await putWithRetry(shareID: shareID, kind: .audio, n: index + 1) {
+                    try Data(contentsOf: fileURL)
+                }
+                if !ok { failures.append((.audio, index + 1)) }
+                completed += 1
+                report()
+            }
+            return failures
         }
-        return failures
     }
 
     /// Targeted re-upload for a previous share's failed items ("Carry the
     /// missing files"). Same ordering rules; audio resolved from URLs,
-    /// photos re-exported by the caller.
+    /// photos re-exported by the caller. This is the recovery path with
+    /// the same per-file sizes as the original upload, so it shares the
+    /// same background-task protection as uploadAllMedia.
     static func uploadSpecific(
         shareID: String,
         items: [(kind: MediaKind, n: Int, data: () throws -> Data)],
         progress: @escaping (MediaProgress) -> Void
     ) async -> [(kind: MediaKind, n: Int)] {
-        var failures: [(kind: MediaKind, n: Int)] = []
-        for (i, item) in items.enumerated() {
-            let ok = await putWithRetry(shareID: shareID, kind: item.kind, n: item.n, body: item.data)
-            if !ok { failures.append((item.kind, item.n)) }
-            progress(MediaProgress(completed: i + 1, total: items.count))
+        return await withBackgroundAssertion(named: "pilgrim.share.media") {
+            var failures: [(kind: MediaKind, n: Int)] = []
+            progress(MediaProgress(completed: 0, total: items.count))
+            for (i, item) in items.enumerated() {
+                let ok = await putWithRetry(shareID: shareID, kind: item.kind, n: item.n, body: item.data)
+                if !ok { failures.append((item.kind, item.n)) }
+                progress(MediaProgress(completed: i + 1, total: items.count))
+            }
+            return failures
         }
-        return failures
     }
 
     /// Failed-media bookkeeping alongside the cached share, so a re-entry
@@ -243,12 +240,65 @@ extension ShareService {
         }
     }
 
+    /// Begins a background-task assertion, runs `body`, then ends it — so
+    /// backgrounding the app (pocketing, locking) doesn't suspend an
+    /// in-flight PUT chain. `BackgroundAssertionState` is the one-shot
+    /// guard: the expiration handler (fired by the OS if we overstay our
+    /// background time) and the normal completion path both race to end
+    /// the same assertion, and the lock ensures only the first of them
+    /// actually calls endBackgroundTask — calling it twice is documented
+    /// Apple misuse.
+    private static func withBackgroundAssertion<T: Sendable>(
+        named name: String,
+        _ body: () async -> T
+    ) async -> T {
+        let state = OSAllocatedUnfairLock(initialState: BackgroundAssertionState())
+
+        func endOnce() -> UIBackgroundTaskIdentifier? {
+            state.withLock { s in
+                guard !s.ended, s.identifier != .invalid else { return nil }
+                s.ended = true
+                return s.identifier
+            }
+        }
+
+        await MainActor.run {
+            let identifier = UIApplication.shared.beginBackgroundTask(withName: name) {
+                // Apple's documented contract: the expiration handler runs
+                // on the main thread already, so assert isolation instead
+                // of hopping through a Task — the app may already be
+                // suspending by the time this fires.
+                guard let idToEnd = endOnce() else { return }
+                MainActor.assumeIsolated {
+                    UIApplication.shared.endBackgroundTask(idToEnd)
+                }
+            }
+            state.withLock { $0.identifier = identifier }
+        }
+
+        let result = await body()
+
+        if let idToEnd = endOnce() {
+            await MainActor.run {
+                UIApplication.shared.endBackgroundTask(idToEnd)
+            }
+        }
+
+        return result
+    }
+
+    private struct BackgroundAssertionState {
+        var identifier: UIBackgroundTaskIdentifier = .invalid
+        var ended = false
+    }
+
     private static func putWithRetry(
         shareID: String,
         kind: MediaKind,
         n: Int,
         body: () throws -> Data
     ) async -> Bool {
+        var lastError: Error?
         for attempt in 0..<2 {
             do {
                 let data = try body()
@@ -258,12 +308,15 @@ extension ShareService {
                     return true
                 }
             } catch {
-                // fall through to retry
+                lastError = error
             }
             if attempt == 0 {
                 try? await Task.sleep(nanoseconds: 800_000_000)
             }
         }
+        #if DEBUG
+        print("[ShareService] media upload failed after retry: \(kind.rawValue)/\(n) — \(lastError?.localizedDescription ?? "non-2xx response")")
+        #endif
         return false
     }
 }

--- a/Pilgrim/Models/Share/ShareService.swift
+++ b/Pilgrim/Models/Share/ShareService.swift
@@ -150,7 +150,10 @@ extension ShareService {
         request.setValue(kind == .audio ? "audio/mp4" : "image/jpeg", forHTTPHeaderField: "Content-Type")
         request.setValue("\(contentLength)", forHTTPHeaderField: "Content-Length")
         request.setValue(deviceToken(), forHTTPHeaderField: "X-Device-Token")
-        request.timeoutInterval = 120
+        // Idle timeout — resets on bytes moving, so slow uploads survive;
+        // stalls fail fast so the repair path picks them up instead of
+        // burning background time on a connection that's already dead.
+        request.timeoutInterval = 30
         return request
     }
 
@@ -178,6 +181,15 @@ extension ShareService {
             // Photos first: enrich's keepsake render waits (bounded) on the
             // LAST photo; audio has a graceful fallback on the page.
             for (index, data) in photos.enumerated() {
+                // Don't start a PUT the OS is about to kill mid-flight — the
+                // repair record turns the untried tail into a Carry-the-
+                // missing-files offer instead of a truncated upload.
+                if await backgroundTimeExhausted() {
+                    for remaining in index..<photos.count { failures.append((.photos, remaining + 1)) }
+                    completed = total
+                    report()
+                    break
+                }
                 let ok = await putWithRetry(shareID: shareID, kind: .photos, n: index + 1) { data }
                 if !ok { failures.append((.photos, index + 1)) }
                 completed += 1
@@ -185,6 +197,12 @@ extension ShareService {
             }
 
             for (index, fileURL) in audioFiles.enumerated() {
+                if await backgroundTimeExhausted() {
+                    for remaining in index..<audioFiles.count { failures.append((.audio, remaining + 1)) }
+                    completed = total
+                    report()
+                    break
+                }
                 let ok = await putWithRetry(shareID: shareID, kind: .audio, n: index + 1) {
                     try Data(contentsOf: fileURL)
                 }
@@ -210,11 +228,29 @@ extension ShareService {
             var failures: [(kind: MediaKind, n: Int)] = []
             progress(MediaProgress(completed: 0, total: items.count))
             for (i, item) in items.enumerated() {
+                if await backgroundTimeExhausted() {
+                    for remaining in i..<items.count { failures.append((items[remaining].kind, items[remaining].n)) }
+                    progress(MediaProgress(completed: items.count, total: items.count))
+                    break
+                }
                 let ok = await putWithRetry(shareID: shareID, kind: item.kind, n: item.n, body: item.data)
                 if !ok { failures.append((item.kind, item.n)) }
                 progress(MediaProgress(completed: i + 1, total: items.count))
             }
             return failures
+        }
+    }
+
+    /// True once the OS is about to suspend the app mid-background-task: a
+    /// PUT started now could be killed with the connection half-open, which
+    /// the worker would just see as a dropped upload — better to never start
+    /// it and let the repair record ("Carry the missing files") offer it
+    /// once Pilgrim is foreground again. 35s leaves headroom for the retry
+    /// window inside `putWithRetry` (one 800ms backoff) plus the request
+    /// itself to at least fail cleanly instead of being torn down mid-PUT.
+    private static func backgroundTimeExhausted() async -> Bool {
+        await MainActor.run {
+            UIApplication.shared.applicationState == .background && UIApplication.shared.backgroundTimeRemaining < 35
         }
     }
 

--- a/Pilgrim/Models/Share/TourBuilder.swift
+++ b/Pilgrim/Models/Share/TourBuilder.swift
@@ -30,7 +30,7 @@ enum TourBuilder {
     /// that reads as non-speech (too few words, or implausibly slow) files
     /// the recording as ambience. The walker can override either way.
     static func classify(transcription: String?, wpm: Double?) -> TourRecordingKind {
-        guard let text = transcription?.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty else {
+        guard let text = transcription?.trimmingCharacters(in: .whitespacesAndNewlines) else {
             return .spoken
         }
         let wordCount = text.split(whereSeparator: \.isWhitespace).count

--- a/Pilgrim/Models/Share/TourBuilder.swift
+++ b/Pilgrim/Models/Share/TourBuilder.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+enum TourRecordingKind: String { case spoken, ambient }
+
+struct TourRecordingCandidate: Identifiable, Equatable {
+    let id: Int
+    let startTs: Int
+    let endTs: Int
+    let duration: Double
+    let sizeBytes: Int
+    let transcription: String?
+    let wpm: Double?
+    let autoKind: TourRecordingKind
+    var includeInShare: Bool
+    var kindOverride: TourRecordingKind?
+    var fileURL: URL?
+    let unavailableReason: String?
+
+    var effectiveKind: TourRecordingKind { kindOverride ?? autoKind }
+}
+
+enum TourBuilder {
+
+    static let maxRecordings = 12
+    static let maxFileBytes = 15 * 1024 * 1024
+    static let maxTotalBytes = 60 * 1024 * 1024
+    static let maxTotalSeconds: Double = 2700
+
+    /// A deliberate recording is presumed to be a voice: only a transcription
+    /// that reads as non-speech (too few words, or implausibly slow) files
+    /// the recording as ambience. The walker can override either way.
+    static func classify(transcription: String?, wpm: Double?) -> TourRecordingKind {
+        guard let text = transcription?.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty else {
+            return .spoken
+        }
+        let wordCount = text.split(whereSeparator: \.isWhitespace).count
+        if wordCount < 8 { return .ambient }
+        if let wpm, wpm < 30 { return .ambient }
+        return .spoken
+    }
+
+    static func candidates(for walk: WalkInterface) -> [TourRecordingCandidate] {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        let sorted = walk.voiceRecordings.sorted { $0.startDate < $1.startDate }
+        return sorted.enumerated().compactMap { index, rec in
+            guard !rec.fileRelativePath.isEmpty else { return nil }
+            let url = docs.appendingPathComponent(rec.fileRelativePath)
+            let startTs = Int(rec.startDate.timeIntervalSince1970)
+            let endTs = Int(rec.endDate.timeIntervalSince1970)
+            // The worker validates truncated integers and rejects the WHOLE
+            // POST on end_ts <= start_ts — a sub-second blip recording must
+            // be excluded here, not shipped.
+            guard endTs > startTs else { return nil }
+            let size = (try? FileManager.default.attributesOfItem(atPath: url.path)[.size]) as? Int
+            let unavailableReason: String?
+            if size == nil || size == 0 {
+                unavailableReason = "audio removed"
+            } else if let size, size > maxFileBytes {
+                unavailableReason = "too large to carry"
+            } else {
+                unavailableReason = nil
+            }
+            return TourRecordingCandidate(
+                id: index,
+                startTs: startTs,
+                endTs: endTs,
+                duration: rec.duration,
+                sizeBytes: size ?? 0,
+                transcription: rec.transcription,
+                wpm: rec.wordsPerMinute,
+                autoKind: classify(transcription: rec.transcription, wpm: rec.wordsPerMinute),
+                includeInShare: unavailableReason == nil,
+                kindOverride: nil,
+                fileURL: unavailableReason == nil ? url : nil,
+                unavailableReason: unavailableReason
+            )
+        }
+    }
+
+    static func totals(of candidates: [TourRecordingCandidate]) -> (count: Int, bytes: Int, seconds: Double) {
+        let included = candidates.filter { $0.includeInShare && $0.unavailableReason == nil }
+        return (included.count,
+                included.reduce(0) { $0 + $1.sizeBytes },
+                included.reduce(0) { $0 + $1.duration })
+    }
+
+    static func validationError(for candidates: [TourRecordingCandidate]) -> String? {
+        let (count, bytes, seconds) = totals(of: candidates)
+        if count > maxRecordings { return "A walk page carries at most \(maxRecordings) recordings — leave some out." }
+        if bytes > maxTotalBytes { return "Recordings total \(bytes / 1_048_576) MB — the page carries at most 60 MB." }
+        if seconds > maxTotalSeconds { return "Recordings total \(Int(seconds / 60)) minutes — the page carries at most 45." }
+        return nil
+    }
+
+    static func tourItems(candidates: [TourRecordingCandidate], trimM: Int) -> (tour: SharePayload.Tour, files: [URL]) {
+        let included = candidates.filter { $0.includeInShare && $0.unavailableReason == nil && $0.fileURL != nil }
+        let recordings = included.enumerated().map { index, c in
+            SharePayload.TourRecording(
+                n: index + 1,
+                startTs: c.startTs,
+                endTs: c.endTs,
+                duration: c.duration,
+                kind: c.effectiveKind.rawValue,
+                transcription: nil,
+                wpm: c.wpm,
+                sizeBytes: c.sizeBytes
+            )
+        }
+        let files = included.compactMap(\.fileURL)
+        return (SharePayload.Tour(recordings: recordings, trimM: trimM), files)
+    }
+}

--- a/Pilgrim/Models/Share/TourBuilder.swift
+++ b/Pilgrim/Models/Share/TourBuilder.swift
@@ -101,6 +101,9 @@ enum TourBuilder {
                 endTs: c.endTs,
                 duration: c.duration,
                 kind: c.effectiveKind.rawValue,
+                // Transcripts never leave the device: the page renders none, and
+                // a 45-minute walk's transcripts would blow the 2MB POST budget.
+                // Deliberate — do not wire c.transcription through.
                 transcription: nil,
                 wpm: c.wpm,
                 sizeBytes: c.sizeBytes

--- a/Pilgrim/Models/Share/TourPhotoExporter.swift
+++ b/Pilgrim/Models/Share/TourPhotoExporter.swift
@@ -12,6 +12,7 @@ enum TourPhotoExporter {
     static let maxBytes = 2 * 1024 * 1024
     static let targetPixels: CGFloat = 1600
     static let perPhotoTimeout: TimeInterval = 20
+    static let backstopGrace: TimeInterval = 2
 
     /// Interactive pages show photography full-bleed: export at 1600px
     /// (vs the classic page's 600px inline thumbnails), walking quality
@@ -25,6 +26,12 @@ enum TourPhotoExporter {
         return nil
     }
 
+    /// `progress` fires after every photo, off the main thread — `export` is a
+    /// nonisolated async function and reports from whatever executor happens to
+    /// be running when the current photo finishes, never the main actor. This
+    /// differs from the sibling `WalkPhotoMatcher.findCandidates`, whose
+    /// `completion` closure is always delivered on the main thread. Callers that
+    /// update UI from `progress` must hop to the MainActor themselves.
     static func export(_ candidates: [PhotoCandidate], progress: @escaping (Int, Int) -> Void) async -> [TourPhoto] {
         var out: [TourPhoto] = []
         for (i, candidate) in candidates.enumerated() {
@@ -34,12 +41,15 @@ enum TourPhotoExporter {
         return out
     }
 
-    // Guarantee: perPhotoTimeout cancels the underlying PHImageManager request
-    // itself (via cancelImageRequest), not just the value this function is
-    // waiting on. PhotoKit's documented contract is to invoke the result
-    // handler with a nil image once a request is cancelled, so a stalled
-    // iCloud fetch is interrupted at the source and cannot block the share
-    // beyond perPhotoTimeout — wall-clock time is genuinely bounded.
+    // Guarantee: wall-clock time is bounded by timeout + grace, not unbounded.
+    // perPhotoTimeout cancels the underlying PHImageManager request itself
+    // (PhotoKit's documented contract is to invoke the result handler with a
+    // nil image once a request is cancelled), and an independent backstop at
+    // perPhotoTimeout + backstopGrace force-resumes with nil even if that
+    // callback never fires at all — wedged iCloud requests are a credible
+    // failure mode, so the bound cannot depend entirely on PhotoKit calling
+    // back. Either path resumes through the same one-shot lock, and whichever
+    // fires first cancels the other's pending DispatchWorkItem.
     private static func loadOne(_ candidate: PhotoCandidate) async -> TourPhoto? {
         let fetch = PHAsset.fetchAssets(withLocalIdentifiers: [candidate.localIdentifier], options: nil)
         guard let asset = fetch.firstObject else { return nil }
@@ -51,7 +61,7 @@ enum TourPhotoExporter {
         options.resizeMode = .exact
 
         return await withCheckedContinuation { continuation in
-            let hasResumed = OSAllocatedUnfairLock(initialState: false)
+            let state = OSAllocatedUnfairLock(initialState: LoadState())
 
             let requestID = PHImageManager.default().requestImage(
                 for: asset,
@@ -59,9 +69,11 @@ enum TourPhotoExporter {
                 contentMode: .aspectFit,
                 options: options
             ) { image, _ in
-                let shouldResume = hasResumed.withLock { alreadyResumed -> Bool in
-                    guard !alreadyResumed else { return false }
-                    alreadyResumed = true
+                let shouldResume = state.withLock { box -> Bool in
+                    guard !box.resumed else { return false }
+                    box.resumed = true
+                    box.cancelItem?.cancel()
+                    box.backstopItem?.cancel()
                     return true
                 }
                 guard shouldResume else { return }
@@ -80,9 +92,37 @@ enum TourPhotoExporter {
                 ))
             }
 
-            DispatchQueue.global().asyncAfter(deadline: .now() + perPhotoTimeout) {
+            // Deadline 1: nudge PhotoKit to give up on the fetch itself.
+            let cancelItem = DispatchWorkItem {
                 PHImageManager.default().cancelImageRequest(requestID)
             }
+
+            // Deadline 2 (backstop): force the continuation to resume even if
+            // PhotoKit never calls the result handler at all — independent of
+            // whether cancelImageRequest actually interrupted anything.
+            let backstopItem = DispatchWorkItem {
+                let shouldResume = state.withLock { box -> Bool in
+                    guard !box.resumed else { return false }
+                    box.resumed = true
+                    return true
+                }
+                guard shouldResume else { return }
+                continuation.resume(returning: nil)
+            }
+
+            state.withLock {
+                $0.cancelItem = cancelItem
+                $0.backstopItem = backstopItem
+            }
+
+            DispatchQueue.global().asyncAfter(deadline: .now() + perPhotoTimeout, execute: cancelItem)
+            DispatchQueue.global().asyncAfter(deadline: .now() + perPhotoTimeout + backstopGrace, execute: backstopItem)
         }
+    }
+
+    private struct LoadState {
+        var resumed = false
+        var cancelItem: DispatchWorkItem?
+        var backstopItem: DispatchWorkItem?
     }
 }

--- a/Pilgrim/Models/Share/TourPhotoExporter.swift
+++ b/Pilgrim/Models/Share/TourPhotoExporter.swift
@@ -5,6 +5,12 @@ import os
 struct TourPhoto {
     let meta: SharePayload.Photo
     let jpegData: Data
+    /// The PHAsset identifier this export came from — stable identity for
+    /// matching a failed upload back to its source photo later, even if the
+    /// candidate list's ORDER or LENGTH has since changed (see
+    /// `WalkShareViewModel.resolveRetryItems`). Never sent to the server;
+    /// `meta`/`jpegData` are the payload.
+    let sourceLocalIdentifier: String
 }
 
 enum TourPhotoExporter {
@@ -88,7 +94,8 @@ enum TourPhotoExporter {
                         ts: Int(candidate.capturedAt.timeIntervalSince1970),
                         data: nil
                     ),
-                    jpegData: data
+                    jpegData: data,
+                    sourceLocalIdentifier: candidate.localIdentifier
                 ))
             }
 

--- a/Pilgrim/Models/Share/TourPhotoExporter.swift
+++ b/Pilgrim/Models/Share/TourPhotoExporter.swift
@@ -1,5 +1,6 @@
 import Photos
 import UIKit
+import os
 
 struct TourPhoto {
     let meta: SharePayload.Photo
@@ -27,60 +28,61 @@ enum TourPhotoExporter {
     static func export(_ candidates: [PhotoCandidate], progress: @escaping (Int, Int) -> Void) async -> [TourPhoto] {
         var out: [TourPhoto] = []
         for (i, candidate) in candidates.enumerated() {
-            let photo = await withTimeoutOrNil(seconds: perPhotoTimeout) {
-                await withCheckedContinuation { continuation in
-                    DispatchQueue.global(qos: .userInitiated).async {
-                        continuation.resume(returning: loadOne(candidate))
-                    }
-                }
-            }
-            if let photo { out.append(photo) }
+            if let photo = await loadOne(candidate) { out.append(photo) }
             progress(i + 1, candidates.count)
         }
         return out
     }
 
-    private static func withTimeoutOrNil<T: Sendable>(seconds: TimeInterval, _ work: @escaping () async -> T?) async -> T? {
-        await withTaskGroup(of: T?.self) { group in
-            group.addTask { await work() }
-            group.addTask {
-                try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-                return nil
-            }
-            guard let first = await group.next() else { return nil }
-            group.cancelAll()
-            return first
-        }
-    }
-
-    private static func loadOne(_ candidate: PhotoCandidate) -> TourPhoto? {
+    // Guarantee: perPhotoTimeout cancels the underlying PHImageManager request
+    // itself (via cancelImageRequest), not just the value this function is
+    // waiting on. PhotoKit's documented contract is to invoke the result
+    // handler with a nil image once a request is cancelled, so a stalled
+    // iCloud fetch is interrupted at the source and cannot block the share
+    // beyond perPhotoTimeout — wall-clock time is genuinely bounded.
+    private static func loadOne(_ candidate: PhotoCandidate) async -> TourPhoto? {
         let fetch = PHAsset.fetchAssets(withLocalIdentifiers: [candidate.localIdentifier], options: nil)
         guard let asset = fetch.firstObject else { return nil }
 
         let options = PHImageRequestOptions()
         options.deliveryMode = .highQualityFormat
         options.isNetworkAccessAllowed = true
-        options.isSynchronous = true
+        options.isSynchronous = false
         options.resizeMode = .exact
 
-        var result: TourPhoto?
-        PHImageManager.default().requestImage(
-            for: asset,
-            targetSize: CGSize(width: targetPixels, height: targetPixels),
-            contentMode: .aspectFit,
-            options: options
-        ) { image, _ in
-            guard let image, let data = jpegDataUnder(cap: maxBytes, image: image) else { return }
-            result = TourPhoto(
-                meta: SharePayload.Photo(
-                    lat: candidate.capturedLat,
-                    lon: candidate.capturedLng,
-                    ts: Int(candidate.capturedAt.timeIntervalSince1970),
-                    data: nil
-                ),
-                jpegData: data
-            )
+        return await withCheckedContinuation { continuation in
+            let hasResumed = OSAllocatedUnfairLock(initialState: false)
+
+            let requestID = PHImageManager.default().requestImage(
+                for: asset,
+                targetSize: CGSize(width: targetPixels, height: targetPixels),
+                contentMode: .aspectFit,
+                options: options
+            ) { image, _ in
+                let shouldResume = hasResumed.withLock { alreadyResumed -> Bool in
+                    guard !alreadyResumed else { return false }
+                    alreadyResumed = true
+                    return true
+                }
+                guard shouldResume else { return }
+                guard let image, let data = jpegDataUnder(cap: maxBytes, image: image) else {
+                    continuation.resume(returning: nil)
+                    return
+                }
+                continuation.resume(returning: TourPhoto(
+                    meta: SharePayload.Photo(
+                        lat: candidate.capturedLat,
+                        lon: candidate.capturedLng,
+                        ts: Int(candidate.capturedAt.timeIntervalSince1970),
+                        data: nil
+                    ),
+                    jpegData: data
+                ))
+            }
+
+            DispatchQueue.global().asyncAfter(deadline: .now() + perPhotoTimeout) {
+                PHImageManager.default().cancelImageRequest(requestID)
+            }
         }
-        return result
     }
 }

--- a/Pilgrim/Models/Share/TourPhotoExporter.swift
+++ b/Pilgrim/Models/Share/TourPhotoExporter.swift
@@ -1,0 +1,86 @@
+import Photos
+import UIKit
+
+struct TourPhoto {
+    let meta: SharePayload.Photo
+    let jpegData: Data
+}
+
+enum TourPhotoExporter {
+
+    static let maxBytes = 2 * 1024 * 1024
+    static let targetPixels: CGFloat = 1600
+    static let perPhotoTimeout: TimeInterval = 20
+
+    /// Interactive pages show photography full-bleed: export at 1600px
+    /// (vs the classic page's 600px inline thumbnails), walking quality
+    /// down until the file fits the worker's 2MB per-photo cap.
+    static func jpegDataUnder(cap: Int, image: UIImage) -> Data? {
+        for quality in [0.8, 0.65, 0.5, 0.35, 0.2] {
+            if let data = image.jpegData(compressionQuality: quality), data.count <= cap {
+                return data
+            }
+        }
+        return nil
+    }
+
+    static func export(_ candidates: [PhotoCandidate], progress: @escaping (Int, Int) -> Void) async -> [TourPhoto] {
+        var out: [TourPhoto] = []
+        for (i, candidate) in candidates.enumerated() {
+            let photo = await withTimeoutOrNil(seconds: perPhotoTimeout) {
+                await withCheckedContinuation { continuation in
+                    DispatchQueue.global(qos: .userInitiated).async {
+                        continuation.resume(returning: loadOne(candidate))
+                    }
+                }
+            }
+            if let photo { out.append(photo) }
+            progress(i + 1, candidates.count)
+        }
+        return out
+    }
+
+    private static func withTimeoutOrNil<T: Sendable>(seconds: TimeInterval, _ work: @escaping () async -> T?) async -> T? {
+        await withTaskGroup(of: T?.self) { group in
+            group.addTask { await work() }
+            group.addTask {
+                try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+                return nil
+            }
+            guard let first = await group.next() else { return nil }
+            group.cancelAll()
+            return first
+        }
+    }
+
+    private static func loadOne(_ candidate: PhotoCandidate) -> TourPhoto? {
+        let fetch = PHAsset.fetchAssets(withLocalIdentifiers: [candidate.localIdentifier], options: nil)
+        guard let asset = fetch.firstObject else { return nil }
+
+        let options = PHImageRequestOptions()
+        options.deliveryMode = .highQualityFormat
+        options.isNetworkAccessAllowed = true
+        options.isSynchronous = true
+        options.resizeMode = .exact
+
+        var result: TourPhoto?
+        PHImageManager.default().requestImage(
+            for: asset,
+            targetSize: CGSize(width: targetPixels, height: targetPixels),
+            contentMode: .aspectFit,
+            options: options
+        ) { image, _ in
+            guard let image, let data = jpegDataUnder(cap: maxBytes, image: image) else { return }
+            result = TourPhoto(
+                meta: SharePayload.Photo(
+                    lat: candidate.capturedLat,
+                    lon: candidate.capturedLng,
+                    ts: Int(candidate.capturedAt.timeIntervalSince1970),
+                    data: nil
+                ),
+                jpegData: data
+            )
+        }
+        return result
+    }
+}

--- a/Pilgrim/Models/Share/TourPhotoExporter.swift
+++ b/Pilgrim/Models/Share/TourPhotoExporter.swift
@@ -41,6 +41,11 @@ enum TourPhotoExporter {
     static func export(_ candidates: [PhotoCandidate], progress: @escaping (Int, Int) -> Void) async -> [TourPhoto] {
         var out: [TourPhoto] = []
         for (i, candidate) in candidates.enumerated() {
+            // A cancelled share() must stop within ~one photo, not run the
+            // whole remaining list — loadOne itself isn't cancellation-aware
+            // (its own timeout/backstop bound it independently), so this is
+            // the only place that can act on it.
+            if Task.isCancelled { break }
             if let photo = await loadOne(candidate) { out.append(photo) }
             progress(i + 1, candidates.count)
         }

--- a/Pilgrim/Scenes/WalkShare/InteractiveShareSection.swift
+++ b/Pilgrim/Scenes/WalkShare/InteractiveShareSection.swift
@@ -40,7 +40,9 @@ struct InteractiveShareSection: View {
                     if viewModel.tourCandidates.contains(where: { $0.includeInShare && $0.unavailableReason == nil }) {
                         Text("Voices will be audible to anyone with the link.")
                             .font(Constants.Typography.caption)
-                            .foregroundColor(.rust)
+                            .foregroundColor(.fog)
+                            .padding(.horizontal, Constants.UI.Padding.normal)
+                            .transition(.opacity)
                     }
                 } else {
                     Text("No recordings on this walk — the page will carry your route, photos, and moments.")
@@ -176,11 +178,12 @@ private struct TourRecordingRow: View {
                 .padding(.vertical, 4)
                 .background(Color.stone.opacity(0.12))
                 .cornerRadius(4)
-                .frame(minHeight: 44)
+                .frame(minWidth: 44, minHeight: 44)
                 .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .accessibilityLabel("Recording \(candidate.id + 1) kind, \(kindLabel)")
+        .accessibilityValue(candidate.effectiveKind == .spoken ? "voice" : "ambience")
         .accessibilityHint("Double tap to switch")
         .opacity(candidate.includeInShare ? 1 : 0.35)
     }

--- a/Pilgrim/Scenes/WalkShare/InteractiveShareSection.swift
+++ b/Pilgrim/Scenes/WalkShare/InteractiveShareSection.swift
@@ -9,10 +9,7 @@ struct InteractiveShareSection: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: Constants.UI.Padding.small) {
-            Text("Walk with me".uppercased())
-                .font(Constants.Typography.micro)
-                .foregroundColor(.fog)
-                .tracking(1.5)
+            ShareSectionLabel(text: "Walk with me")
 
             Toggle(isOn: $viewModel.interactiveEnabled.animation()) {
                 VStack(alignment: .leading, spacing: 4) {
@@ -88,6 +85,23 @@ struct InteractiveShareSection: View {
     }
 }
 
+// MARK: - Share Section Label
+
+/// The uppercased, tracked micro-label used above every WalkShare section
+/// ("Walk with me", "Share these details", "Reflection", "This walk lives
+/// for"). Single source for that exact chain — `WalkShareView.sectionLabel`
+/// forwards to this too, so the two files can't drift apart style-wise.
+struct ShareSectionLabel: View {
+    let text: String
+
+    var body: some View {
+        Text(text.uppercased())
+            .font(Constants.Typography.micro)
+            .foregroundColor(.fog)
+            .tracking(1.5)
+    }
+}
+
 // MARK: - Tour Recording Row
 
 private struct TourRecordingRow: View {
@@ -146,6 +160,7 @@ private struct TourRecordingRow: View {
                         .foregroundColor(.fog)
                 }
             }
+            .accessibilityElement(children: .combine)
 
             Spacer()
 

--- a/Pilgrim/Scenes/WalkShare/InteractiveShareSection.swift
+++ b/Pilgrim/Scenes/WalkShare/InteractiveShareSection.swift
@@ -1,0 +1,187 @@
+import SwiftUI
+
+/// The Interactive toggle and its disclosure: recordings with per-item
+/// include/kind controls, totals, trim. Lives in its own file to keep
+/// WalkShareView under the type-body-length ceiling.
+struct InteractiveShareSection: View {
+
+    @ObservedObject var viewModel: WalkShareViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Constants.UI.Padding.small) {
+            Text("Walk with me".uppercased())
+                .font(Constants.Typography.micro)
+                .foregroundColor(.fog)
+                .tracking(1.5)
+
+            Toggle(isOn: $viewModel.interactiveEnabled.animation()) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Interactive")
+                        .font(Constants.Typography.body)
+                        .foregroundColor(.ink)
+                    Text("Viewers walk your route on a living map — your recordings play where you made them, photos appear where you took them. Recordings and full-size photos upload over your connection.")
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.fog)
+                }
+            }
+            .tint(.moss)
+            .onChange(of: viewModel.interactiveEnabled) { _, on in
+                if on { viewModel.prepareInteractive() }
+            }
+
+            if viewModel.interactiveEnabled {
+                if viewModel.hasRecordings {
+                    recordingsList
+
+                    Text(viewModel.tourTotalsLabel)
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.fog)
+
+                    if viewModel.tourCandidates.contains(where: { $0.includeInShare && $0.unavailableReason == nil }) {
+                        Text("Voices will be audible to anyone with the link.")
+                            .font(Constants.Typography.caption)
+                            .foregroundColor(.rust)
+                    }
+                } else {
+                    Text("No recordings on this walk — the page will carry your route, photos, and moments.")
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.fog)
+                }
+
+                if let error = viewModel.tourValidationError {
+                    Text(error)
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.rust)
+                }
+
+                Toggle(isOn: $viewModel.trimEnabled) {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text("Trim start & end")
+                            .font(Constants.Typography.body)
+                            .foregroundColor(.ink)
+                        Text(viewModel.canTrimRoute
+                            ? "Keeps the first and last 150 m off the shared map — including photos and waymarkers there."
+                            : "This walk is too short to trim.")
+                            .font(Constants.Typography.caption)
+                            .foregroundColor(.fog)
+                    }
+                }
+                .tint(.moss)
+                .disabled(!viewModel.canTrimRoute)
+            }
+        }
+        .animation(.easeInOut(duration: 0.2), value: viewModel.interactiveEnabled)
+    }
+
+    private var recordingsList: some View {
+        VStack(alignment: .leading, spacing: Constants.UI.Padding.xs) {
+            ForEach(viewModel.tourCandidates) { candidate in
+                TourRecordingRow(
+                    candidate: candidate,
+                    onToggleInclude: { viewModel.toggleInclude(candidateID: candidate.id) },
+                    onFlipKind: { viewModel.flipKind(candidateID: candidate.id) }
+                )
+            }
+        }
+    }
+}
+
+// MARK: - Tour Recording Row
+
+private struct TourRecordingRow: View {
+
+    let candidate: TourRecordingCandidate
+    let onToggleInclude: () -> Void
+    let onFlipKind: () -> Void
+
+    private static let timeFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.timeStyle = .short
+        return f
+    }()
+
+    private var durationLabel: String {
+        let seconds = Int(candidate.duration)
+        return String(format: "%d:%02d", seconds / 60, seconds % 60)
+    }
+
+    private var startLabel: String {
+        Self.timeFormatter.string(from: Date(timeIntervalSince1970: TimeInterval(candidate.startTs)))
+    }
+
+    private var sizeLabel: String {
+        String(format: "%.1f MB", Double(candidate.sizeBytes) / 1_048_576)
+    }
+
+    private var kindLabel: String {
+        candidate.effectiveKind == .spoken ? "voice" : "ambience"
+    }
+
+    var body: some View {
+        HStack(spacing: Constants.UI.Padding.small) {
+            if candidate.unavailableReason == nil {
+                includeButton
+            }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Recording \(candidate.id + 1) · \(durationLabel) · \(startLabel)")
+                    .font(Constants.Typography.body)
+                    .foregroundColor(.ink)
+
+                if let reason = candidate.unavailableReason {
+                    Text(reason)
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.fog)
+                } else {
+                    if let preview = candidate.transcription?.trimmingCharacters(in: .whitespacesAndNewlines), !preview.isEmpty {
+                        Text(preview)
+                            .font(Constants.Typography.caption)
+                            .foregroundColor(.fog)
+                            .lineLimit(1)
+                    }
+                    Text(sizeLabel)
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.fog)
+                }
+            }
+
+            Spacer()
+
+            if candidate.unavailableReason == nil {
+                kindChip
+            }
+        }
+        .opacity(candidate.unavailableReason != nil ? 0.45 : (candidate.includeInShare ? 1 : 0.6))
+    }
+
+    private var includeButton: some View {
+        Button(action: onToggleInclude) {
+            Image(systemName: candidate.includeInShare ? "checkmark.circle.fill" : "circle")
+                .foregroundColor(candidate.includeInShare ? .moss : .fog)
+                .frame(minWidth: 44, minHeight: 44)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Include recording \(candidate.id + 1)")
+        .accessibilityValue(candidate.includeInShare ? "included" : "excluded")
+        .accessibilityHint("Double tap to toggle")
+    }
+
+    private var kindChip: some View {
+        Button(action: onFlipKind) {
+            Text(kindLabel)
+                .font(Constants.Typography.caption)
+                .foregroundColor(.stone)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 4)
+                .background(Color.stone.opacity(0.12))
+                .cornerRadius(4)
+                .frame(minHeight: 44)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Recording \(candidate.id + 1) kind, \(kindLabel)")
+        .accessibilityHint("Double tap to switch")
+        .opacity(candidate.includeInShare ? 1 : 0.35)
+    }
+}

--- a/Pilgrim/Scenes/WalkShare/ShareStatusSection.swift
+++ b/Pilgrim/Scenes/WalkShare/ShareStatusSection.swift
@@ -14,7 +14,7 @@ struct ShareStatusSection: View {
         switch viewModel.shareState {
         case .idle:
             primaryButton("Share Walk") {
-                Task { await viewModel.share() }
+                viewModel.beginShare()
             }
 
         case .uploading:
@@ -23,8 +23,14 @@ struct ShareStatusSection: View {
         case .preparingPhotos(let done, let total):
             progressRow("Preparing photos… \(done)/\(total)")
 
+        case .photosDropped(let prepared, let dropped):
+            droppedPhotosPrompt(prepared: prepared, dropped: dropped)
+
         case .uploadingMedia(let completed, let total):
-            progressRow("Carrying your walk… \(completed)/\(total)")
+            progressRow(
+                "Carrying your walk… \(completed)/\(total)",
+                subtitle: "keep Pilgrim open while your walk uploads"
+            )
 
         case .success(let url):
             sharedCard(url: url) { EmptyView() }
@@ -66,7 +72,7 @@ struct ShareStatusSection: View {
                     .multilineTextAlignment(.center)
 
                 primaryButton("Try Again") {
-                    Task { await viewModel.share() }
+                    viewModel.beginShare()
                 }
             }
         }
@@ -77,19 +83,57 @@ struct ShareStatusSection: View {
     }
 
     /// Shared by `.uploading`, `.preparingPhotos`, and `.uploadingMedia` —
-    /// same spinner-row chrome, different label.
-    private func progressRow(_ text: String, font: Font = Constants.Typography.caption) -> some View {
-        HStack(spacing: Constants.UI.Padding.small) {
-            SwiftUI.ProgressView()
-                .tint(.parchment)
-            Text(text)
-                .font(font)
-                .foregroundColor(.parchment)
+    /// same spinner-row chrome, different label. `subtitle` adds a second,
+    /// de-emphasized line below the spinner row (only `.uploadingMedia`
+    /// uses it today, for the "keep Pilgrim open" reminder).
+    private func progressRow(_ text: String, subtitle: String? = nil, font: Font = Constants.Typography.caption) -> some View {
+        VStack(spacing: 4) {
+            HStack(spacing: Constants.UI.Padding.small) {
+                SwiftUI.ProgressView()
+                    .tint(.parchment)
+                Text(text)
+                    .font(font)
+                    .foregroundColor(.parchment)
+            }
+            if let subtitle {
+                Text(subtitle)
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog)
+            }
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 14)
         .background(Color.stone.opacity(0.6))
         .cornerRadius(Constants.UI.CornerRadius.normal)
+    }
+
+    /// `.photosDropped`'s pre-POST consent pause: some requested photos
+    /// didn't export (iCloud-only assets that never downloaded, deletions
+    /// mid-export), so the walker chooses whether to proceed without them
+    /// or hold off — nothing has POSTed yet, so both choices are still free.
+    private func droppedPhotosPrompt(prepared: Int, dropped: Int) -> some View {
+        VStack(spacing: Constants.UI.Padding.small) {
+            Text("\(dropped) of \(prepared + dropped) photo\(dropped == 1 ? "" : "s") couldn't be prepared — they may still be waiting in iCloud.")
+                .font(Constants.Typography.caption)
+                .foregroundColor(.fog)
+                .multilineTextAlignment(.center)
+
+            primaryButton("Share without them") {
+                viewModel.continueShareWithoutDroppedPhotos()
+            }
+
+            Button {
+                viewModel.cancelDroppedPhotoShare()
+            } label: {
+                Text("Don't share yet")
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
     }
 
     /// The "page is live" card shared by `.success` and `.partial` — the

--- a/Pilgrim/Scenes/WalkShare/ShareStatusSection.swift
+++ b/Pilgrim/Scenes/WalkShare/ShareStatusSection.swift
@@ -73,10 +73,7 @@ struct ShareStatusSection: View {
     }
 
     private var routePreview: some View {
-        RouteShapeView(routeData: viewModel.walk.routeData)
-            .frame(height: 200)
-            .background(Color.parchmentSecondary)
-            .cornerRadius(Constants.UI.CornerRadius.normal)
+        ShareRouteThumbnail(routeData: viewModel.walk.routeData)
     }
 
     /// Shared by `.uploading`, `.preparingPhotos`, and `.uploadingMedia` —
@@ -162,5 +159,21 @@ struct ShareStatusSection: View {
                 .cornerRadius(Constants.UI.CornerRadius.normal)
         }
         .disabled(!viewModel.canShare)
+    }
+}
+
+// MARK: - Route Thumbnail
+
+/// The small route-shape preview shown both while sharing (`WalkShareView`)
+/// and once shared (`ShareStatusSection`'s card) — same `RouteShapeView`,
+/// frame, background, and corner radius either way, so one source exists.
+struct ShareRouteThumbnail: View {
+    let routeData: [RouteDataSampleInterface]
+
+    var body: some View {
+        RouteShapeView(routeData: routeData)
+            .frame(height: 200)
+            .background(Color.parchmentSecondary)
+            .cornerRadius(Constants.UI.CornerRadius.normal)
     }
 }

--- a/Pilgrim/Scenes/WalkShare/ShareStatusSection.swift
+++ b/Pilgrim/Scenes/WalkShare/ShareStatusSection.swift
@@ -50,7 +50,7 @@ struct ShareStatusSection: View {
                             .multilineTextAlignment(.center)
                     } else {
                         Button {
-                            Task { await viewModel.retryFailedMedia() }
+                            viewModel.beginRetry()
                         } label: {
                             Text("Carry the missing files")
                                 .font(Constants.Typography.button)

--- a/Pilgrim/Scenes/WalkShare/ShareStatusSection.swift
+++ b/Pilgrim/Scenes/WalkShare/ShareStatusSection.swift
@@ -1,0 +1,159 @@
+import SwiftUI
+
+/// The Share button through all its states — idle, in-flight progress
+/// (photo export, POST, media PUTs), the success/partial result card, and
+/// error retry. Lives in its own file to keep WalkShareView under the
+/// type-body-length ceiling (mirrors InteractiveShareSection).
+struct ShareStatusSection: View {
+
+    @ObservedObject var viewModel: WalkShareViewModel
+    let onOpenPreview: (String) -> Void
+
+    @ViewBuilder
+    var body: some View {
+        switch viewModel.shareState {
+        case .idle:
+            primaryButton("Share Walk") {
+                Task { await viewModel.share() }
+            }
+
+        case .uploading:
+            progressRow("Sharing...", font: Constants.Typography.button)
+
+        case .preparingPhotos(let done, let total):
+            progressRow("Preparing photos… \(done)/\(total)")
+
+        case .uploadingMedia(let completed, let total):
+            progressRow("Carrying your walk… \(completed)/\(total)")
+
+        case .success(let url):
+            sharedCard(url: url) { EmptyView() }
+
+        case .partial(let url, let failedCount):
+            sharedCard(url: url) {
+                VStack(spacing: Constants.UI.Padding.small) {
+                    Text("\(failedCount) file\(failedCount == 1 ? "" : "s") didn't make it — they'll show as unavailable on the page.")
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.rust)
+                        .multilineTextAlignment(.center)
+
+                    Button {
+                        Task { await viewModel.retryFailedMedia() }
+                    } label: {
+                        Text("Carry the missing files")
+                            .font(Constants.Typography.button)
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 12)
+                            .background(Color.stone)
+                            .foregroundColor(.parchment)
+                            .cornerRadius(Constants.UI.CornerRadius.small)
+                    }
+                }
+            }
+
+        case .error(let message):
+            VStack(spacing: Constants.UI.Padding.small) {
+                Text(message)
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.rust)
+                    .multilineTextAlignment(.center)
+
+                primaryButton("Try Again") {
+                    Task { await viewModel.share() }
+                }
+            }
+        }
+    }
+
+    private var routePreview: some View {
+        RouteShapeView(routeData: viewModel.walk.routeData)
+            .frame(height: 200)
+            .background(Color.parchmentSecondary)
+            .cornerRadius(Constants.UI.CornerRadius.normal)
+    }
+
+    /// Shared by `.uploading`, `.preparingPhotos`, and `.uploadingMedia` —
+    /// same spinner-row chrome, different label.
+    private func progressRow(_ text: String, font: Font = Constants.Typography.caption) -> some View {
+        HStack(spacing: Constants.UI.Padding.small) {
+            SwiftUI.ProgressView()
+                .tint(.parchment)
+            Text(text)
+                .font(font)
+                .foregroundColor(.parchment)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 14)
+        .background(Color.stone.opacity(0.6))
+        .cornerRadius(Constants.UI.CornerRadius.normal)
+    }
+
+    /// The "page is live" card shared by `.success` and `.partial` — the
+    /// route thumbnail, the Shared badge, and the expiry note are identical
+    /// either way; `extra` inserts `.partial`'s missing-files notice between
+    /// the expiry note and the "View scroll" link.
+    @ViewBuilder
+    private func sharedCard(url: String, @ViewBuilder extra: () -> some View) -> some View {
+        VStack(spacing: Constants.UI.Padding.normal) {
+            Button {
+                onOpenPreview(url)
+            } label: {
+                ZStack(alignment: .topTrailing) {
+                    routePreview
+                    Image(systemName: "chevron.right")
+                        .font(.caption)
+                        .foregroundColor(.fog.opacity(0.4))
+                        .padding(8)
+                        .accessibilityHidden(true)
+                }
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("View shared walk page")
+            .accessibilityHint("Opens the scroll of your shared walk")
+
+            HStack(spacing: 6) {
+                Text("Shared")
+                    .font(Constants.Typography.body)
+                    .foregroundColor(.stone)
+                Image(systemName: "checkmark")
+                    .font(.caption)
+                    .foregroundColor(.moss)
+            }
+
+            Text("Returns to the trail on \(viewModel.formattedExpiry)")
+                .font(Constants.Typography.caption)
+                .foregroundColor(.fog)
+                .italic()
+
+            extra()
+
+            Button {
+                onOpenPreview(url)
+            } label: {
+                Text("View scroll")
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog)
+                    .frame(maxWidth: .infinity)
+                    .padding(.vertical, 12)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+        }
+        .padding(Constants.UI.Padding.normal)
+        .background(Color.parchmentSecondary)
+        .cornerRadius(Constants.UI.CornerRadius.normal)
+    }
+
+    private func primaryButton(_ title: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Text(title)
+                .font(Constants.Typography.button)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 14)
+                .background(Color.stone)
+                .foregroundColor(.parchment)
+                .cornerRadius(Constants.UI.CornerRadius.normal)
+        }
+        .disabled(!viewModel.canShare)
+    }
+}

--- a/Pilgrim/Scenes/WalkShare/ShareStatusSection.swift
+++ b/Pilgrim/Scenes/WalkShare/ShareStatusSection.swift
@@ -37,16 +37,23 @@ struct ShareStatusSection: View {
                         .foregroundColor(.rust)
                         .multilineTextAlignment(.center)
 
-                    Button {
-                        Task { await viewModel.retryFailedMedia() }
-                    } label: {
-                        Text("Carry the missing files")
-                            .font(Constants.Typography.button)
-                            .frame(maxWidth: .infinity)
-                            .padding(.vertical, 12)
-                            .background(Color.stone)
-                            .foregroundColor(.parchment)
-                            .cornerRadius(Constants.UI.CornerRadius.small)
+                    if viewModel.repairUnavailable {
+                        Text("These files can no longer be carried — the walk's recordings have changed.")
+                            .font(Constants.Typography.caption)
+                            .foregroundColor(.fog)
+                            .multilineTextAlignment(.center)
+                    } else {
+                        Button {
+                            Task { await viewModel.retryFailedMedia() }
+                        } label: {
+                            Text("Carry the missing files")
+                                .font(Constants.Typography.button)
+                                .frame(maxWidth: .infinity)
+                                .padding(.vertical, 12)
+                                .background(Color.stone)
+                                .foregroundColor(.parchment)
+                                .cornerRadius(Constants.UI.CornerRadius.small)
+                        }
                     }
                 }
             }

--- a/Pilgrim/Scenes/WalkShare/WalkShareView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareView.swift
@@ -48,10 +48,20 @@ struct WalkShareView: View {
                         }
                     } else {
                         routePreview
-                        statToggles
-                        InteractiveShareSection(viewModel: viewModel)
-                        journalSection
-                        expiryPicker
+                        // A share is already in flight once the POST has landed a
+                        // live page and media PUTs are streaming — editing toggles,
+                        // the journal, or expiry now would desync the payload
+                        // already sent from what these controls show (wrong-slot
+                        // audio, a broken trim promise, undeclared PUTs). Disabling
+                        // at this container level freezes every input inside in one
+                        // place instead of chasing each control individually.
+                        Group {
+                            statToggles
+                            InteractiveShareSection(viewModel: viewModel)
+                            journalSection
+                            expiryPicker
+                        }
+                        .disabled(isShareInFlight)
                         ShareStatusSection(viewModel: viewModel, onOpenPreview: openPreview)
                     }
                 }

--- a/Pilgrim/Scenes/WalkShare/WalkShareView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareView.swift
@@ -21,9 +21,17 @@ struct WalkShareView: View {
         _viewModel = StateObject(wrappedValue: WalkShareViewModel(walk: walk, pinnedPhotos: pinnedPhotos))
     }
 
-    private var isShared: Bool {
-        if case .success = viewModel.shareState { return true }
-        return false
+    private var isShared: Bool { viewModel.isShared }
+
+    /// The POST already created a live page and, once media starts landing,
+    /// partial progress is recorded server-side — the sheet must not be
+    /// abandonable mid-flight. Gates both the toolbar Cancel and
+    /// `.interactiveDismissDisabled` below.
+    private var isShareInFlight: Bool {
+        switch viewModel.shareState {
+        case .preparingPhotos, .uploading, .uploadingMedia: return true
+        default: return false
+        }
     }
 
     var body: some View {
@@ -31,7 +39,7 @@ struct WalkShareView: View {
             ScrollView {
                 VStack(spacing: Constants.UI.Padding.big) {
                     if isShared {
-                        shareButton
+                        ShareStatusSection(viewModel: viewModel, onOpenPreview: openPreview)
                         if showPodcastCard,
                            PodcastSubmissionService.shared.isEligible(walk: walk),
                            case .success(let url) = viewModel.shareState {
@@ -44,7 +52,7 @@ struct WalkShareView: View {
                         InteractiveShareSection(viewModel: viewModel)
                         journalSection
                         expiryPicker
-                        shareButton
+                        ShareStatusSection(viewModel: viewModel, onOpenPreview: openPreview)
                     }
                 }
                 .padding(Constants.UI.Padding.normal)
@@ -64,13 +72,14 @@ struct WalkShareView: View {
                     }
                 }
                 ToolbarItem(placement: .navigationBarLeading) {
-                    if !isShared {
+                    if !isShared && !isShareInFlight {
                         Button("Cancel") { dismiss() }
                             .foregroundColor(.stone)
                     }
                 }
             }
         }
+        .interactiveDismissDisabled(isShareInFlight)
         // Reveal the podcast card after the ritual modal dismisses, not at
         // the moment of share success. The previous 800ms-after-success
         // trigger collided with the ritual's own reveal — the card animated
@@ -262,7 +271,7 @@ struct WalkShareView: View {
 
             HStack {
                 Spacer()
-                Text("Expires \(expiryDateFormatted)")
+                Text("Expires \(viewModel.formattedExpiry)")
                     .font(Constants.Typography.caption)
                     .foregroundColor(.fog)
                 Spacer()
@@ -294,113 +303,6 @@ struct WalkShareView: View {
         }
     }
 
-    private var expiryDateFormatted: String {
-        Self.expiryFormatter.string(from: viewModel.expiryDate)
-    }
-
-    private static let expiryFormatter: DateFormatter = {
-        let f = DateFormatter()
-        f.dateStyle = .long
-        return f
-    }()
-
-    // MARK: - Share Button
-
-    @ViewBuilder
-    private var shareButton: some View {
-        switch viewModel.shareState {
-        case .idle:
-            primaryButton("Share Walk") {
-                Task { await viewModel.share() }
-            }
-
-        case .uploading:
-            HStack(spacing: Constants.UI.Padding.small) {
-                SwiftUI.ProgressView()
-                    .tint(.parchment)
-                Text("Sharing...")
-                    .font(Constants.Typography.button)
-                    .foregroundColor(.parchment)
-            }
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 14)
-            .background(Color.stone.opacity(0.6))
-            .cornerRadius(Constants.UI.CornerRadius.normal)
-
-        case .success(let url):
-            VStack(spacing: Constants.UI.Padding.normal) {
-                Button {
-                    openPreview(url: url)
-                } label: {
-                    ZStack(alignment: .topTrailing) {
-                        routePreview
-                        Image(systemName: "chevron.right")
-                            .font(.caption)
-                            .foregroundColor(.fog.opacity(0.4))
-                            .padding(8)
-                            .accessibilityHidden(true)
-                    }
-                }
-                .buttonStyle(.plain)
-                .accessibilityLabel("View shared walk page")
-                .accessibilityHint("Opens the scroll of your shared walk")
-
-                HStack(spacing: 6) {
-                    Text("Shared")
-                        .font(Constants.Typography.body)
-                        .foregroundColor(.stone)
-                    Image(systemName: "checkmark")
-                        .font(.caption)
-                        .foregroundColor(.moss)
-                }
-
-                Text("Returns to the trail on \(expiryDateFormatted)")
-                    .font(Constants.Typography.caption)
-                    .foregroundColor(.fog)
-                    .italic()
-
-                Button {
-                    openPreview(url: url)
-                } label: {
-                    Text("View scroll")
-                        .font(Constants.Typography.caption)
-                        .foregroundColor(.fog)
-                        .frame(maxWidth: .infinity)
-                        .padding(.vertical, 12)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-            }
-            .padding(Constants.UI.Padding.normal)
-            .background(Color.parchmentSecondary)
-            .cornerRadius(Constants.UI.CornerRadius.normal)
-
-        case .error(let message):
-            VStack(spacing: Constants.UI.Padding.small) {
-                Text(message)
-                    .font(Constants.Typography.caption)
-                    .foregroundColor(.rust)
-                    .multilineTextAlignment(.center)
-
-                primaryButton("Try Again") {
-                    Task { await viewModel.share() }
-                }
-            }
-        }
-    }
-
-    private func primaryButton(_ title: String, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            Text(title)
-                .font(Constants.Typography.button)
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 14)
-                .background(Color.stone)
-                .foregroundColor(.parchment)
-                .cornerRadius(Constants.UI.CornerRadius.normal)
-        }
-    }
-
     // MARK: - Helpers
 
     private func sectionLabel(_ text: String) -> some View {
@@ -428,7 +330,11 @@ struct WalkShareView: View {
         old: WalkShareViewModel.ShareState,
         new: WalkShareViewModel.ShareState
     ) {
-        guard case .uploading = old, case .success(let url) = new else { return }
+        guard case .success(let url) = new else { return }
+        switch old {
+        case .uploading, .uploadingMedia: break
+        default: return
+        }
         guard let parsedURL = URL(string: url) else { return }
 
         webViewLoaderHolder.create(url: parsedURL)

--- a/Pilgrim/Scenes/WalkShare/WalkShareView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareView.swift
@@ -41,6 +41,7 @@ struct WalkShareView: View {
                     } else {
                         routePreview
                         statToggles
+                        InteractiveShareSection(viewModel: viewModel)
                         journalSection
                         expiryPicker
                         shareButton

--- a/Pilgrim/Scenes/WalkShare/WalkShareView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareView.swift
@@ -163,11 +163,7 @@ struct WalkShareView: View {
     // MARK: - Route Preview
 
     private var routePreview: some View {
-        let points = viewModel.walk.routeData
-        return RouteShapeView(routeData: points)
-            .frame(height: 200)
-            .background(Color.parchmentSecondary)
-            .cornerRadius(Constants.UI.CornerRadius.normal)
+        ShareRouteThumbnail(routeData: viewModel.walk.routeData)
     }
 
     // MARK: - Stat Toggles
@@ -316,10 +312,7 @@ struct WalkShareView: View {
     // MARK: - Helpers
 
     private func sectionLabel(_ text: String) -> some View {
-        Text(text.uppercased())
-            .font(Constants.Typography.micro)
-            .foregroundColor(.fog)
-            .tracking(1.5)
+        ShareSectionLabel(text: text)
     }
 
     private func openPreview(url: String) {

--- a/Pilgrim/Scenes/WalkShare/WalkShareView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareView.swift
@@ -167,16 +167,19 @@ struct WalkShareView: View {
             revealTask = nil
             podcastRevealTask?.cancel()
             podcastRevealTask = nil
-            // Swipe-to-dismiss during .preparingPhotos never runs the
-            // toolbar Cancel button's action — without this, a sheet closed
-            // that way would keep exporting photos and POSTing in the
-            // background with no UI left to show it.
-            viewModel.cancelShare()
             // Guard against iOS versions / scene configs where onDisappear
             // fires on the parent while the cover is still presented (e.g.,
-            // app backgrounded with modal open). Clearing the loader mid-
-            // presentation would leave the cover rendering an empty view.
+            // app backgrounded with modal open, or presenting the cover
+            // itself). Cancelling the share here would kill a live upload or
+            // a "Carry the missing files" repair running underneath the
+            // cover; clearing the loader mid-presentation would leave the
+            // cover rendering an empty view.
             if !showPreview {
+                // Swipe-to-dismiss during .preparingPhotos never runs the
+                // toolbar Cancel button's action — without this, a sheet
+                // closed that way would keep exporting photos and POSTing in
+                // the background with no UI left to show it.
+                viewModel.cancelShare()
                 webViewLoaderHolder.clear()
             }
         }

--- a/Pilgrim/Scenes/WalkShare/WalkShareView.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareView.swift
@@ -23,13 +23,27 @@ struct WalkShareView: View {
 
     private var isShared: Bool { viewModel.isShared }
 
-    /// The POST already created a live page and, once media starts landing,
-    /// partial progress is recorded server-side — the sheet must not be
-    /// abandonable mid-flight. Gates both the toolbar Cancel and
-    /// `.interactiveDismissDisabled` below.
+    /// Mid-edit desyncs (toggles, journal, expiry) must stay impossible for
+    /// the whole in-flight span — including the pre-POST photo-export phase
+    /// and the dropped-photo consent pause, neither of which has anything
+    /// server-side yet but both of which are mid-attempt. Gates the form
+    /// `Group.disabled` below. Narrower than this: `isDismissLocked`.
     private var isShareInFlight: Bool {
         switch viewModel.shareState {
-        case .preparingPhotos, .uploading, .uploadingMedia: return true
+        case .preparingPhotos, .photosDropped, .uploading, .uploadingMedia: return true
+        default: return false
+        }
+    }
+
+    /// Only `.uploading` (the POST has landed a live page) and
+    /// `.uploadingMedia` (PUTs are streaming) have put anything server-side
+    /// that abandoning the sheet would leave stranded — `.preparingPhotos`
+    /// is a local, cancellable export and `.photosDropped` is a pre-POST
+    /// consent pause, so neither locks the toolbar Cancel or interactive
+    /// dismiss the way `isShareInFlight` locks the form.
+    private var isDismissLocked: Bool {
+        switch viewModel.shareState {
+        case .uploading, .uploadingMedia: return true
         default: return false
         }
     }
@@ -82,14 +96,17 @@ struct WalkShareView: View {
                     }
                 }
                 ToolbarItem(placement: .navigationBarLeading) {
-                    if !isShared && !isShareInFlight {
-                        Button("Cancel") { dismiss() }
-                            .foregroundColor(.stone)
+                    if !isShared && !isDismissLocked {
+                        Button("Cancel") {
+                            viewModel.cancelShare()
+                            dismiss()
+                        }
+                        .foregroundColor(.stone)
                     }
                 }
             }
         }
-        .interactiveDismissDisabled(isShareInFlight)
+        .interactiveDismissDisabled(isDismissLocked)
         // Reveal the podcast card after the ritual modal dismisses, not at
         // the moment of share success. The previous 800ms-after-success
         // trigger collided with the ritual's own reveal — the card animated
@@ -150,6 +167,11 @@ struct WalkShareView: View {
             revealTask = nil
             podcastRevealTask?.cancel()
             podcastRevealTask = nil
+            // Swipe-to-dismiss during .preparingPhotos never runs the
+            // toolbar Cancel button's action — without this, a sheet closed
+            // that way would keep exporting photos and POSTing in the
+            // background with no UI left to show it.
+            viewModel.cancelShare()
             // Guard against iOS versions / scene configs where onDisappear
             // fires on the parent while the cover is still presented (e.g.,
             // app backgrounded with modal open). Clearing the loader mid-

--- a/Pilgrim/Scenes/WalkShare/WalkShareViewModel+ShareOrchestration.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareViewModel+ShareOrchestration.swift
@@ -20,8 +20,10 @@ extension WalkShareViewModel {
             // .preparingPhotos and applyPreparingPhotosProgress's guard would
             // reject every tick.
             shareState = .preparingPhotos(completed: 0, total: exportList.count)
-            tourPhotos = await TourPhotoExporter.export(exportList) { [weak self] done, total in
-                Task { @MainActor in self?.applyPreparingPhotosProgress(completed: done, total: total) }
+            tourPhotos = await ShareService.withBackgroundAssertion(named: "pilgrim.share.photo-export") {
+                await TourPhotoExporter.export(exportList) { [weak self] done, total in
+                    Task { @MainActor in self?.applyPreparingPhotosProgress(completed: done, total: total) }
+                }
             }
         } else {
             tourPhotos = []
@@ -38,15 +40,16 @@ extension WalkShareViewModel {
             let result = try await ShareService.share(payload: payload)
             if let uuid = walk.uuid {
                 ShareService.cacheShare(result, walkID: uuid, expiryDays: selectedExpiry.rawValue, expiryOption: selectedExpiry.cacheKey)
-                // A fresh share must never inherit a previous share's failed-media
-                // record — this walk may have had a `.partial` share before.
-                ShareService.cacheFailedMedia([], walkID: uuid)
             }
 
             if interactiveEnabled {
                 let tourItems = TourBuilder.tourItems(candidates: tourCandidates, trimM: 0)
                 let audioFiles = tourItems.files
                 let audioRecordings = tourItems.tour.recordings
+                if let uuid = walk.uuid {
+                    // Pre-populate so a kill mid-upload restores a repairable .partial instead of a lying .success; PUTs are idempotent, over-repair is harmless.
+                    ShareService.cacheFailedMedia(Self.expectedFailureRecords(recordings: audioRecordings, photos: tourPhotos), walkID: uuid)
+                }
                 // Prime the phase synchronously (no unstructured-Task hop to
                 // race) so the FIRST progress tick already finds shareState
                 // in .uploadingMedia — see applyMediaProgress.
@@ -68,6 +71,11 @@ extension WalkShareViewModel {
                     ? .success(url: result.url)
                     : .partial(url: result.url, failedCount: failures.count)
             } else {
+                if let uuid = walk.uuid {
+                    // A fresh share must never inherit a previous share's failed-media
+                    // record — this walk may have had a `.partial` share before.
+                    ShareService.cacheFailedMedia([], walkID: uuid)
+                }
                 shareState = .success(url: result.url)
             }
         } catch {
@@ -94,6 +102,28 @@ extension WalkShareViewModel {
             let photo = tourPhotos.indices.contains(failure.n - 1) ? tourPhotos[failure.n - 1] : nil
             return ShareService.FailedMediaItem(kind: failure.kind.rawValue, n: failure.n, audioStartTs: nil, photoLocalID: photo?.sourceLocalIdentifier, photoTs: photo?.meta.ts)
         }
+    }
+
+    /// The full "everything in this upload just failed" identity list, built
+    /// from the exact recordings/photos arrays about to be uploaded — the
+    /// same per-slot identity fields `failedMediaItem` computes for a real
+    /// failure, for every slot instead of just the failed ones. `share()`
+    /// writes this to the cache BEFORE `uploadAllMedia` runs (see the call
+    /// site) so a kill mid-upload leaves a repairable `.partial` record
+    /// instead of the stale all-clear that used to sit there. Not `private`:
+    /// unit-tested directly, same file-scoped-access reasoning as
+    /// `resolveRetryItems` below.
+    static func expectedFailureRecords(
+        recordings: [SharePayload.TourRecording],
+        photos: [TourPhoto]
+    ) -> [ShareService.FailedMediaItem] {
+        let audioItems = recordings.indices.map { index in
+            failedMediaItem(for: (kind: .audio, n: index + 1), audioRecordings: recordings, tourPhotos: photos)
+        }
+        let photoItems = photos.indices.map { index in
+            failedMediaItem(for: (kind: .photos, n: index + 1), audioRecordings: recordings, tourPhotos: photos)
+        }
+        return audioItems + photoItems
     }
 
     /// Rebuilds data sources for a previous share's failed items and
@@ -133,7 +163,9 @@ extension WalkShareViewModel {
         let photoCandidatesToReExport = pinnedPhotos.filter { failedPhotoIDs.contains($0.localIdentifier) }
         let currentPhotos: [TourPhoto] = photoCandidatesToReExport.isEmpty
             ? []
-            : await TourPhotoExporter.export(photoCandidatesToReExport) { _, _ in }
+            : await ShareService.withBackgroundAssertion(named: "pilgrim.share.photo-export") {
+                await TourPhotoExporter.export(photoCandidatesToReExport) { _, _ in }
+            }
 
         let (uploadable, remainingAfterResolve) = Self.resolveRetryItems(
             cached: failed,
@@ -172,13 +204,13 @@ extension WalkShareViewModel {
     /// directly unit-testable. Matches each cached failure to CURRENT data by
     /// stable identity, never by `n` alone: an index that's still "in bounds"
     /// after the underlying candidate set shifted (an export drop, an unpin)
-    /// can silently point at a DIFFERENT file than the one that failed.
-    /// Audio is index-checked THEN identity-verified at that same index
-    /// (recordings keep their relative order); photos are found by identity
-    /// search across the whole current set (their position isn't assumed to
-    /// be stable at all) and uploaded under the CACHED `n`, never their own
-    /// current position. Anything that doesn't verify is returned in
-    /// `remaining`, untouched, rather than uploaded to a guessed slot.
+    /// can silently point at a DIFFERENT file than the one that failed. Both
+    /// audio (by `startTs`) and photos (by `localIdentifier` + captured `ts`)
+    /// are found by identity search across the whole current set — neither
+    /// kind's position is assumed to be stable — and uploaded under the
+    /// CACHED `n`, never their own current position. Anything that doesn't
+    /// verify is returned in `remaining`, untouched, rather than uploaded to
+    /// a guessed slot.
     nonisolated static func resolveRetryItems(
         cached: [ShareService.FailedMediaItem],
         currentRecordings: [SharePayload.TourRecording],
@@ -195,10 +227,14 @@ extension WalkShareViewModel {
             }
             switch kind {
             case .audio:
-                let index = item.n - 1
-                guard currentRecordings.indices.contains(index),
-                      currentAudioFiles.indices.contains(index),
-                      currentRecordings[index].startTs == item.audioStartTs else {
+                // Identity search, not an index-locked lookup: startTs
+                // collisions are structurally impossible (recordings can't
+                // overlap within one truncated second), so a match on
+                // startTs alone is safe wherever it now sits — an excluded
+                // or reordered candidate can shift a recording OUT of its
+                // original slot without dropping it from the current set.
+                guard let index = currentRecordings.firstIndex(where: { $0.startTs == item.audioStartTs }),
+                      currentAudioFiles.indices.contains(index) else {
                     remaining.append(item)
                     continue
                 }

--- a/Pilgrim/Scenes/WalkShare/WalkShareViewModel+ShareOrchestration.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareViewModel+ShareOrchestration.swift
@@ -71,8 +71,14 @@ extension WalkShareViewModel {
     /// "Share without them": resumes past the dropped-photo pause with
     /// whatever exported successfully. Goes through `shareTask` — not a bare
     /// `Task { }` — for the same reason `beginShare()` does: so a Cancel tap
-    /// during the resumed upload has something to cancel.
+    /// during the resumed upload has something to cancel, and so a
+    /// same-runloop double-tap has nothing to hit. Claims `.uploading`
+    /// SYNCHRONOUSLY, before the `Task` is even spawned, so the prompt's
+    /// "Share without them" / "Don't share yet" buttons vanish immediately
+    /// instead of staying tappable through the geocode+POST that follows.
     func continueShareWithoutDroppedPhotos() {
+        guard shareTask == nil else { return }
+        shareState = .uploading
         shareTask = Task { [weak self] in
             guard let self else { return }
             await self.completeShare(tourPhotos: self.pendingTourPhotos)
@@ -81,10 +87,13 @@ extension WalkShareViewModel {
         }
     }
 
-    /// "Don't share yet": nothing exists server-side during `.photosDropped`,
-    /// so undoing it is just local state — no task to cancel, no cache to
-    /// unwind.
+    /// "Don't share yet": nothing exists server-side during `.photosDropped`
+    /// itself, but a "Share without them" resume may already be running (a
+    /// fast tap on that button followed by this one) — cancelling
+    /// `shareTask` is what makes "Don't share yet" actually mean no, rather
+    /// than letting an in-flight resume sail past this and share anyway.
     func cancelDroppedPhotoShare() {
+        shareTask?.cancel()
         pendingTourPhotos = []
         shareState = .idle
     }
@@ -94,6 +103,12 @@ extension WalkShareViewModel {
     /// onward, once the walker's photo set (full export, or "without them")
     /// is final.
     private func completeShare(tourPhotos: [TourPhoto]) async {
+        // Claim the locking state at the single choke point: from here through the POST a live page may exist — every caller gets the dismiss-lock, no caller can forget it.
+        shareState = .uploading
+        guard !Task.isCancelled else {
+            shareState = .idle
+            return
+        }
         let placeNames = await geocodeEndpoints()
         let payload = buildPayload(
             placeStart: placeNames.start,
@@ -122,7 +137,10 @@ extension WalkShareViewModel {
                 let failures = await ShareService.uploadAllMedia(
                     shareID: result.id,
                     audioFiles: audioFiles,
-                    photos: tourPhotos.map(\.jpegData)
+                    photos: tourPhotos.map(\.jpegData),
+                    onItemSuccess: { [weak self] kind, n in
+                        Task { @MainActor in self?.pruneFailedMedia(kind: kind, n: n) }
+                    }
                 ) { [weak self] progress in
                     Task { @MainActor in self?.applyMediaProgress(progress) }
                 }
@@ -191,6 +209,21 @@ extension WalkShareViewModel {
         return audioItems + photoItems
     }
 
+    /// Routes "Carry the missing files" through the same `shareTask` guard as
+    /// `beginShare()`. `retryFailedMedia()` flips `shareState` to
+    /// `.uploadingMedia` synchronously as its first real action (see below),
+    /// and that state change is what removes the retry button from
+    /// `.partial`'s view (`ShareStatusSection` only renders it there) — the
+    /// guard here is what covers the same-runloop double-tap before that
+    /// removal has rendered.
+    func beginRetry() {
+        guard shareTask == nil else { return }
+        shareTask = Task { [weak self] in
+            await self?.retryFailedMedia()
+            self?.shareTask = nil
+        }
+    }
+
     /// Rebuilds data sources for a previous share's failed items and
     /// re-attempts just those ("Carry the missing files"). Never trusts `n`
     /// alone to still point at the right file — `resolveRetryItems` verifies
@@ -249,7 +282,13 @@ extension WalkShareViewModel {
         }
 
         shareState = .uploadingMedia(completed: 0, total: uploadable.count)
-        let stillFailedRaw = await ShareService.uploadSpecific(shareID: cached.id, items: uploadable) { [weak self] progress in
+        let stillFailedRaw = await ShareService.uploadSpecific(
+            shareID: cached.id,
+            items: uploadable,
+            onItemSuccess: { [weak self] kind, n in
+                Task { @MainActor in self?.pruneFailedMedia(kind: kind, n: n) }
+            }
+        ) { [weak self] progress in
             Task { @MainActor in self?.applyMediaProgress(progress) }
         }
         // Recover each still-failed item's full identity from the cache we
@@ -318,6 +357,22 @@ extension WalkShareViewModel {
         }
 
         return (uploadable, remaining)
+    }
+
+    /// Prunes one just-uploaded item from the failed-media cache the moment
+    /// its PUT lands — wired as `onItemSuccess` from both `uploadAllMedia`
+    /// (in `completeShare`) and `uploadSpecific` (in `retryFailedMedia`), off
+    /// the MainActor, hence the `Task { @MainActor in ... }` hop at each call
+    /// site. A kill mid-upload (crash, force-quit, backgrounding past the OS
+    /// budget) now restores `.partial` counting only what's ACTUALLY still
+    /// missing, not everything the upload started with — the final
+    /// `cacheFailedMedia` write at the end of a normal run still supersedes
+    /// this, so it only matters for the interrupted case.
+    private func pruneFailedMedia(kind: ShareService.MediaKind, n: Int) {
+        guard let uuid = walk.uuid else { return }
+        var remaining = ShareService.failedMedia(for: uuid)
+        remaining.removeAll { $0.kind == kind.rawValue && $0.n == n }
+        ShareService.cacheFailedMedia(remaining, walkID: uuid)
     }
 
     /// Applies a media-upload progress tick only while `shareState` is still

--- a/Pilgrim/Scenes/WalkShare/WalkShareViewModel+ShareOrchestration.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareViewModel+ShareOrchestration.swift
@@ -6,14 +6,32 @@ import Foundation
 /// `ActiveWalkViewModel+Seek.swift`).
 extension WalkShareViewModel {
 
+    func beginShare() {
+        guard shareTask == nil else { return }
+        shareTask = Task { [weak self] in
+            await self?.share()
+            self?.shareTask = nil
+        }
+    }
+
+    /// Safe to call any time: a no-op once nothing is running, and a no-op
+    /// in EFFECT once the POST has landed — `share()` only honors
+    /// cancellation at the one checkpoint before anything exists
+    /// server-side.
+    func cancelShare() {
+        shareTask?.cancel()
+    }
+
     func share() async {
         guard canShare else { return }
         repairUnavailable = false
         shareState = .uploading
 
         let tourPhotos: [TourPhoto]
+        let exportCount: Int
         if interactiveEnabled, includePhotos, hasPinnedPhotos {
             let exportList = interactivePhotoExportList()
+            exportCount = exportList.count
             // Prime synchronously, same reason as .uploadingMedia below — the
             // first progress tick only fires after the first photo finishes
             // loading, so without this the phase would never actually become
@@ -27,8 +45,55 @@ extension WalkShareViewModel {
             }
         } else {
             tourPhotos = []
+            exportCount = 0
         }
 
+        // Nothing exists server-side yet — cancellation is clean up to the POST.
+        if Task.isCancelled {
+            shareState = .idle
+            return
+        }
+
+        // Fewer photos exported than requested (iCloud-only assets that
+        // never downloaded, deletions mid-export) — pause for the walker's
+        // consent before anything POSTs, rather than silently shipping a
+        // page short of photos it promised.
+        let dropped = exportCount - tourPhotos.count
+        if dropped > 0 {
+            pendingTourPhotos = tourPhotos
+            shareState = .photosDropped(prepared: tourPhotos.count, dropped: dropped)
+            return
+        }
+
+        await completeShare(tourPhotos: tourPhotos)
+    }
+
+    /// "Share without them": resumes past the dropped-photo pause with
+    /// whatever exported successfully. Goes through `shareTask` — not a bare
+    /// `Task { }` — for the same reason `beginShare()` does: so a Cancel tap
+    /// during the resumed upload has something to cancel.
+    func continueShareWithoutDroppedPhotos() {
+        shareTask = Task { [weak self] in
+            guard let self else { return }
+            await self.completeShare(tourPhotos: self.pendingTourPhotos)
+            self.pendingTourPhotos = []
+            self.shareTask = nil
+        }
+    }
+
+    /// "Don't share yet": nothing exists server-side during `.photosDropped`,
+    /// so undoing it is just local state — no task to cancel, no cache to
+    /// unwind.
+    func cancelDroppedPhotoShare() {
+        pendingTourPhotos = []
+        shareState = .idle
+    }
+
+    /// The POST → media-PUT path shared by `share()`'s happy path and
+    /// `continueShareWithoutDroppedPhotos()` — everything from geocoding
+    /// onward, once the walker's photo set (full export, or "without them")
+    /// is final.
+    private func completeShare(tourPhotos: [TourPhoto]) async {
         let placeNames = await geocodeEndpoints()
         let payload = buildPayload(
             placeStart: placeNames.start,

--- a/Pilgrim/Scenes/WalkShare/WalkShareViewModel+ShareOrchestration.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareViewModel+ShareOrchestration.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+/// The POST → media-PUT orchestration `share()` drives, plus the "Carry the
+/// missing files" retry path. Lives in its own file to keep
+/// `WalkShareViewModel` under the type-body-length ceiling (mirrors
+/// `ActiveWalkViewModel+Seek.swift`).
+extension WalkShareViewModel {
+
+    func share() async {
+        guard canShare else { return }
+        shareState = .uploading
+
+        let tourPhotos: [TourPhoto]
+        if interactiveEnabled, includePhotos, hasPinnedPhotos {
+            tourPhotos = await TourPhotoExporter.export(interactivePhotoExportList()) { [weak self] done, total in
+                Task { @MainActor in self?.shareState = .preparingPhotos(completed: done, total: total) }
+            }
+        } else {
+            tourPhotos = []
+        }
+
+        let placeNames = await geocodeEndpoints()
+        let payload = buildPayload(
+            placeStart: placeNames.start,
+            placeEnd: placeNames.end,
+            tourPhotoMeta: tourPhotos.map(\.meta)
+        )
+
+        do {
+            let result = try await ShareService.share(payload: payload)
+            if let uuid = walk.uuid {
+                ShareService.cacheShare(result, walkID: uuid, expiryDays: selectedExpiry.rawValue, expiryOption: selectedExpiry.cacheKey)
+            }
+
+            if interactiveEnabled {
+                let audioFiles = TourBuilder.tourItems(candidates: tourCandidates, trimM: 0).files
+                // Prime the phase synchronously (no unstructured-Task hop to
+                // race) so the FIRST progress tick already finds shareState
+                // in .uploadingMedia — see applyMediaProgress.
+                shareState = .uploadingMedia(completed: 0, total: audioFiles.count + tourPhotos.count)
+                let failures = await ShareService.uploadAllMedia(
+                    shareID: result.id,
+                    audioFiles: audioFiles,
+                    photos: tourPhotos.map(\.jpegData)
+                ) { [weak self] progress in
+                    Task { @MainActor in self?.applyMediaProgress(progress) }
+                }
+                if let uuid = walk.uuid { ShareService.cacheFailedMedia(failures, walkID: uuid) }
+                shareState = failures.isEmpty
+                    ? .success(url: result.url)
+                    : .partial(url: result.url, failedCount: failures.count)
+            } else {
+                shareState = .success(url: result.url)
+            }
+        } catch {
+            shareState = .error(message: error.localizedDescription)
+        }
+    }
+
+    /// Rebuilds data sources for a previous share's failed `(kind, n)` list
+    /// and re-attempts just those uploads ("Carry the missing files").
+    /// Assumes the walker's recording/photo selection hasn't changed since
+    /// the original share — true in the common case (retrying moments after
+    /// a failed PUT, same session). Across a re-entry `tourCandidates` may
+    /// be empty, so it's recomputed fresh from the walk; if a failed index
+    /// still doesn't resolve (selection genuinely changed), that item is
+    /// left out of the retry and stays counted as failed rather than
+    /// uploaded to the wrong slot.
+    func retryFailedMedia() async {
+        guard let uuid = walk.uuid, let cached = ShareService.cachedShare(for: uuid) else { return }
+        let failed = ShareService.failedMedia(for: uuid)
+        guard !failed.isEmpty else { return }
+
+        // Leave .partial synchronously, before the possibly-multi-second photo
+        // re-export below — otherwise "Carry the missing files" stays on
+        // screen and tappable during that gap, and a second tap would start
+        // an overlapping retry of the same items.
+        shareState = .uploadingMedia(completed: 0, total: failed.count)
+
+        let candidates = tourCandidates.isEmpty ? TourBuilder.candidates(for: walk) : tourCandidates
+        let audioFiles = TourBuilder.tourItems(candidates: candidates, trimM: 0).files
+
+        let photoData: [Data]
+        if failed.contains(where: { $0.kind == .photos }) {
+            let reExported = await TourPhotoExporter.export(interactivePhotoExportList()) { _, _ in }
+            photoData = reExported.map(\.jpegData)
+        } else {
+            photoData = []
+        }
+
+        var items: [(kind: ShareService.MediaKind, n: Int, data: () throws -> Data)] = []
+        var unresolved: [(kind: ShareService.MediaKind, n: Int)] = []
+        for failure in failed {
+            let index = failure.n - 1
+            switch failure.kind {
+            case .audio:
+                guard audioFiles.indices.contains(index) else { unresolved.append(failure); continue }
+                let fileURL = audioFiles[index]
+                items.append((kind: .audio, n: failure.n, data: { try Data(contentsOf: fileURL) }))
+            case .photos:
+                guard photoData.indices.contains(index) else { unresolved.append(failure); continue }
+                let data = photoData[index]
+                items.append((kind: .photos, n: failure.n, data: { data }))
+            }
+        }
+        guard !items.isEmpty else {
+            // Nothing could be rebuilt (e.g. the pinned set changed) — undo
+            // the state above rather than leave the UI stuck mid-progress.
+            shareState = .partial(url: cached.url, failedCount: failed.count)
+            return
+        }
+
+        shareState = .uploadingMedia(completed: 0, total: items.count)
+        let stillFailed = await ShareService.uploadSpecific(shareID: cached.id, items: items) { [weak self] progress in
+            Task { @MainActor in self?.applyMediaProgress(progress) }
+        }
+
+        let remaining = stillFailed + unresolved
+        ShareService.cacheFailedMedia(remaining, walkID: uuid)
+        shareState = remaining.isEmpty
+            ? .success(url: cached.url)
+            : .partial(url: cached.url, failedCount: remaining.count)
+    }
+
+    /// Applies a media-upload progress tick only while `shareState` is still
+    /// `.uploadingMedia`. Progress hops from `uploadAllMedia`/`uploadSpecific`
+    /// run as unstructured `Task`s off their (nonisolated) progress closure,
+    /// so a hop can still be queued on the MainActor after `share()` or
+    /// `retryFailedMedia()` has already set a terminal state and run after
+    /// it. Gating on the phase makes a late hop a no-op instead of
+    /// clobbering `.success`/`.partial`/`.error`.
+    private func applyMediaProgress(_ progress: ShareService.MediaProgress) {
+        guard case .uploadingMedia = shareState else { return }
+        shareState = .uploadingMedia(completed: progress.completed, total: progress.total)
+    }
+
+    /// The candidate list `share()` exports hi-res photos from — reused by
+    /// `retryFailedMedia()` so a retry re-derives the same trimmed window
+    /// and 20-photo cap the original share used (assuming `interactiveEnabled`
+    /// and `trimEnabled` haven't changed since; see `retryFailedMedia`).
+    private func interactivePhotoExportList() -> [PhotoCandidate] {
+        guard hasPinnedPhotos else { return [] }
+        let window = interactiveKeptWindow()
+        return Array(
+            pinnedPhotos
+                .filter { window?.contains(Int($0.capturedAt.timeIntervalSince1970)) ?? true }
+                .prefix(20)
+        )
+    }
+}

--- a/Pilgrim/Scenes/WalkShare/WalkShareViewModel+ShareOrchestration.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareViewModel+ShareOrchestration.swift
@@ -12,8 +12,15 @@ extension WalkShareViewModel {
 
         let tourPhotos: [TourPhoto]
         if interactiveEnabled, includePhotos, hasPinnedPhotos {
-            tourPhotos = await TourPhotoExporter.export(interactivePhotoExportList()) { [weak self] done, total in
-                Task { @MainActor in self?.shareState = .preparingPhotos(completed: done, total: total) }
+            let exportList = interactivePhotoExportList()
+            // Prime synchronously, same reason as .uploadingMedia below — the
+            // first progress tick only fires after the first photo finishes
+            // loading, so without this the phase would never actually become
+            // .preparingPhotos and applyPreparingPhotosProgress's guard would
+            // reject every tick.
+            shareState = .preparingPhotos(completed: 0, total: exportList.count)
+            tourPhotos = await TourPhotoExporter.export(exportList) { [weak self] done, total in
+                Task { @MainActor in self?.applyPreparingPhotosProgress(completed: done, total: total) }
             }
         } else {
             tourPhotos = []
@@ -33,7 +40,9 @@ extension WalkShareViewModel {
             }
 
             if interactiveEnabled {
-                let audioFiles = TourBuilder.tourItems(candidates: tourCandidates, trimM: 0).files
+                let tourItems = TourBuilder.tourItems(candidates: tourCandidates, trimM: 0)
+                let audioFiles = tourItems.files
+                let audioRecordings = tourItems.tour.recordings
                 // Prime the phase synchronously (no unstructured-Task hop to
                 // race) so the FIRST progress tick already finds shareState
                 // in .uploadingMedia — see applyMediaProgress.
@@ -45,7 +54,12 @@ extension WalkShareViewModel {
                 ) { [weak self] progress in
                     Task { @MainActor in self?.applyMediaProgress(progress) }
                 }
-                if let uuid = walk.uuid { ShareService.cacheFailedMedia(failures, walkID: uuid) }
+                if let uuid = walk.uuid {
+                    let failureItems = failures.map {
+                        Self.failedMediaItem(for: $0, audioRecordings: audioRecordings, tourPhotos: tourPhotos)
+                    }
+                    ShareService.cacheFailedMedia(failureItems, walkID: uuid)
+                }
                 shareState = failures.isEmpty
                     ? .success(url: result.url)
                     : .partial(url: result.url, failedCount: failures.count)
@@ -57,15 +71,34 @@ extension WalkShareViewModel {
         }
     }
 
-    /// Rebuilds data sources for a previous share's failed `(kind, n)` list
-    /// and re-attempts just those uploads ("Carry the missing files").
-    /// Assumes the walker's recording/photo selection hasn't changed since
-    /// the original share — true in the common case (retrying moments after
-    /// a failed PUT, same session). Across a re-entry `tourCandidates` may
-    /// be empty, so it's recomputed fresh from the walk; if a failed index
-    /// still doesn't resolve (selection genuinely changed), that item is
-    /// left out of the retry and stays counted as failed rather than
-    /// uploaded to the wrong slot.
+    /// Builds the stable-identity cache record for one failed upload slot,
+    /// reading from the SAME arrays `share()` just uploaded from — `failure.n`
+    /// indexes directly into them, since that's the order `uploadAllMedia`
+    /// PUT things in. This identity (not `n` alone) is what lets a later
+    /// retry verify it's about to send the right bytes — see
+    /// `resolveRetryItems`.
+    private static func failedMediaItem(
+        for failure: (kind: ShareService.MediaKind, n: Int),
+        audioRecordings: [SharePayload.TourRecording],
+        tourPhotos: [TourPhoto]
+    ) -> ShareService.FailedMediaItem {
+        switch failure.kind {
+        case .audio:
+            let startTs = audioRecordings.indices.contains(failure.n - 1) ? audioRecordings[failure.n - 1].startTs : nil
+            return ShareService.FailedMediaItem(kind: failure.kind.rawValue, n: failure.n, audioStartTs: startTs, photoLocalID: nil, photoTs: nil)
+        case .photos:
+            let photo = tourPhotos.indices.contains(failure.n - 1) ? tourPhotos[failure.n - 1] : nil
+            return ShareService.FailedMediaItem(kind: failure.kind.rawValue, n: failure.n, audioStartTs: nil, photoLocalID: photo?.sourceLocalIdentifier, photoTs: photo?.meta.ts)
+        }
+    }
+
+    /// Rebuilds data sources for a previous share's failed items and
+    /// re-attempts just those ("Carry the missing files"). Never trusts `n`
+    /// alone to still point at the right file — `resolveRetryItems` verifies
+    /// stable identity (recording `startTs`; photo `localIdentifier` + `ts`)
+    /// against the CURRENT candidate set before anything is queued for
+    /// upload, so a shifted or missing candidate is skipped (stays counted
+    /// as failed) rather than risking the wrong bytes landing on a live page.
     func retryFailedMedia() async {
         guard let uuid = walk.uuid, let cached = ShareService.cachedShare(for: uuid) else { return }
         let failed = ShareService.failedMedia(for: uuid)
@@ -77,49 +110,105 @@ extension WalkShareViewModel {
         // an overlapping retry of the same items.
         shareState = .uploadingMedia(completed: 0, total: failed.count)
 
-        let candidates = tourCandidates.isEmpty ? TourBuilder.candidates(for: walk) : tourCandidates
-        let audioFiles = TourBuilder.tourItems(candidates: candidates, trimM: 0).files
-
-        let photoData: [Data]
-        if failed.contains(where: { $0.kind == .photos }) {
-            let reExported = await TourPhotoExporter.export(interactivePhotoExportList()) { _, _ in }
-            photoData = reExported.map(\.jpegData)
+        let currentRecordings: [SharePayload.TourRecording]
+        let currentAudioFiles: [URL]
+        if failed.contains(where: { $0.kind == ShareService.MediaKind.audio.rawValue }) {
+            let candidates = tourCandidates.isEmpty ? TourBuilder.candidates(for: walk) : tourCandidates
+            let tourItems = TourBuilder.tourItems(candidates: candidates, trimM: 0)
+            currentRecordings = tourItems.tour.recordings
+            currentAudioFiles = tourItems.files
         } else {
-            photoData = []
+            currentRecordings = []
+            currentAudioFiles = []
         }
 
-        var items: [(kind: ShareService.MediaKind, n: Int, data: () throws -> Data)] = []
-        var unresolved: [(kind: ShareService.MediaKind, n: Int)] = []
-        for failure in failed {
-            let index = failure.n - 1
-            switch failure.kind {
-            case .audio:
-                guard audioFiles.indices.contains(index) else { unresolved.append(failure); continue }
-                let fileURL = audioFiles[index]
-                items.append((kind: .audio, n: failure.n, data: { try Data(contentsOf: fileURL) }))
-            case .photos:
-                guard photoData.indices.contains(index) else { unresolved.append(failure); continue }
-                let data = photoData[index]
-                items.append((kind: .photos, n: failure.n, data: { data }))
-            }
-        }
-        guard !items.isEmpty else {
-            // Nothing could be rebuilt (e.g. the pinned set changed) — undo
-            // the state above rather than leave the UI stuck mid-progress.
-            shareState = .partial(url: cached.url, failedCount: failed.count)
+        // Re-export only the specific photos that failed, by identity — not
+        // the whole (up to 20-photo) export list again.
+        let failedPhotoIDs = Set(failed.compactMap { $0.kind == ShareService.MediaKind.photos.rawValue ? $0.photoLocalID : nil })
+        let photoCandidatesToReExport = pinnedPhotos.filter { failedPhotoIDs.contains($0.localIdentifier) }
+        let currentPhotos: [TourPhoto] = photoCandidatesToReExport.isEmpty
+            ? []
+            : await TourPhotoExporter.export(photoCandidatesToReExport) { _, _ in }
+
+        let (uploadable, remainingAfterResolve) = Self.resolveRetryItems(
+            cached: failed,
+            currentRecordings: currentRecordings,
+            currentAudioFiles: currentAudioFiles,
+            currentPhotos: currentPhotos
+        )
+
+        guard !uploadable.isEmpty else {
+            ShareService.cacheFailedMedia(remainingAfterResolve, walkID: uuid)
+            shareState = .partial(url: cached.url, failedCount: remainingAfterResolve.count)
             return
         }
 
-        shareState = .uploadingMedia(completed: 0, total: items.count)
-        let stillFailed = await ShareService.uploadSpecific(shareID: cached.id, items: items) { [weak self] progress in
+        shareState = .uploadingMedia(completed: 0, total: uploadable.count)
+        let stillFailedRaw = await ShareService.uploadSpecific(shareID: cached.id, items: uploadable) { [weak self] progress in
             Task { @MainActor in self?.applyMediaProgress(progress) }
         }
+        // Recover each still-failed item's full identity from the cache we
+        // resolved it from, so a THIRD attempt can still verify it too.
+        let stillFailed = stillFailedRaw.compactMap { raw in
+            failed.first { $0.kind == raw.kind.rawValue && $0.n == raw.n }
+        }
 
-        let remaining = stillFailed + unresolved
+        let remaining = stillFailed + remainingAfterResolve
         ShareService.cacheFailedMedia(remaining, walkID: uuid)
         shareState = remaining.isEmpty
             ? .success(url: cached.url)
             : .partial(url: cached.url, failedCount: remaining.count)
+    }
+
+    /// Pure identity resolution — no MainActor/instance state — so it's
+    /// directly unit-testable. Matches each cached failure to CURRENT data by
+    /// stable identity, never by `n` alone: an index that's still "in bounds"
+    /// after the underlying candidate set shifted (an export drop, an unpin)
+    /// can silently point at a DIFFERENT file than the one that failed.
+    /// Audio is index-checked THEN identity-verified at that same index
+    /// (recordings keep their relative order); photos are found by identity
+    /// search across the whole current set (their position isn't assumed to
+    /// be stable at all) and uploaded under the CACHED `n`, never their own
+    /// current position. Anything that doesn't verify is returned in
+    /// `remaining`, untouched, rather than uploaded to a guessed slot.
+    nonisolated static func resolveRetryItems(
+        cached: [ShareService.FailedMediaItem],
+        currentRecordings: [SharePayload.TourRecording],
+        currentAudioFiles: [URL],
+        currentPhotos: [TourPhoto]
+    ) -> (uploadable: [(kind: ShareService.MediaKind, n: Int, data: () throws -> Data)], remaining: [ShareService.FailedMediaItem]) {
+        var uploadable: [(kind: ShareService.MediaKind, n: Int, data: () throws -> Data)] = []
+        var remaining: [ShareService.FailedMediaItem] = []
+
+        for item in cached {
+            guard let kind = ShareService.MediaKind(rawValue: item.kind) else {
+                remaining.append(item)
+                continue
+            }
+            switch kind {
+            case .audio:
+                let index = item.n - 1
+                guard currentRecordings.indices.contains(index),
+                      currentAudioFiles.indices.contains(index),
+                      currentRecordings[index].startTs == item.audioStartTs else {
+                    remaining.append(item)
+                    continue
+                }
+                let fileURL = currentAudioFiles[index]
+                uploadable.append((kind: .audio, n: item.n, data: { try Data(contentsOf: fileURL) }))
+            case .photos:
+                guard let match = currentPhotos.first(where: {
+                    $0.sourceLocalIdentifier == item.photoLocalID && $0.meta.ts == item.photoTs
+                }) else {
+                    remaining.append(item)
+                    continue
+                }
+                let data = match.jpegData
+                uploadable.append((kind: .photos, n: item.n, data: { data }))
+            }
+        }
+
+        return (uploadable, remaining)
     }
 
     /// Applies a media-upload progress tick only while `shareState` is still
@@ -132,6 +221,15 @@ extension WalkShareViewModel {
     private func applyMediaProgress(_ progress: ShareService.MediaProgress) {
         guard case .uploadingMedia = shareState else { return }
         shareState = .uploadingMedia(completed: progress.completed, total: progress.total)
+    }
+
+    /// Same late-arrival guard as `applyMediaProgress`, for the photo-export
+    /// phase: a stale tick landing after a terminal state must not clobber
+    /// `.success`/`.partial`/`.error`, and must not re-lock dismissal by
+    /// flipping `shareState` back into an `isShareInFlight` case.
+    private func applyPreparingPhotosProgress(completed: Int, total: Int) {
+        guard case .preparingPhotos = shareState else { return }
+        shareState = .preparingPhotos(completed: completed, total: total)
     }
 
     /// The candidate list `share()` exports hi-res photos from — reused by

--- a/Pilgrim/Scenes/WalkShare/WalkShareViewModel+ShareOrchestration.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareViewModel+ShareOrchestration.swift
@@ -8,6 +8,7 @@ extension WalkShareViewModel {
 
     func share() async {
         guard canShare else { return }
+        repairUnavailable = false
         shareState = .uploading
 
         let tourPhotos: [TourPhoto]
@@ -37,6 +38,9 @@ extension WalkShareViewModel {
             let result = try await ShareService.share(payload: payload)
             if let uuid = walk.uuid {
                 ShareService.cacheShare(result, walkID: uuid, expiryDays: selectedExpiry.rawValue, expiryOption: selectedExpiry.cacheKey)
+                // A fresh share must never inherit a previous share's failed-media
+                // record — this walk may have had a `.partial` share before.
+                ShareService.cacheFailedMedia([], walkID: uuid)
             }
 
             if interactiveEnabled {
@@ -100,6 +104,7 @@ extension WalkShareViewModel {
     /// upload, so a shifted or missing candidate is skipped (stays counted
     /// as failed) rather than risking the wrong bytes landing on a live page.
     func retryFailedMedia() async {
+        repairUnavailable = false
         guard let uuid = walk.uuid, let cached = ShareService.cachedShare(for: uuid) else { return }
         let failed = ShareService.failedMedia(for: uuid)
         guard !failed.isEmpty else { return }
@@ -139,6 +144,9 @@ extension WalkShareViewModel {
 
         guard !uploadable.isEmpty else {
             ShareService.cacheFailedMedia(remainingAfterResolve, walkID: uuid)
+            // None of the cached failures still match anything carryable —
+            // don't silently loop back to the same retry button forever.
+            repairUnavailable = true
             shareState = .partial(url: cached.url, failedCount: remainingAfterResolve.count)
             return
         }
@@ -235,8 +243,11 @@ extension WalkShareViewModel {
     /// The candidate list `share()` exports hi-res photos from — reused by
     /// `retryFailedMedia()` so a retry re-derives the same trimmed window
     /// and 20-photo cap the original share used (assuming `interactiveEnabled`
-    /// and `trimEnabled` haven't changed since; see `retryFailedMedia`).
-    private func interactivePhotoExportList() -> [PhotoCandidate] {
+    /// and `trimEnabled` haven't changed since; see `retryFailedMedia`), and by
+    /// `tourTotalsLabel` so the pre-share totals count the same kept-window
+    /// photos the export will actually send. Internal (not `private`) so it's
+    /// callable from `WalkShareViewModel.swift` across the file boundary.
+    func interactivePhotoExportList() -> [PhotoCandidate] {
         guard hasPinnedPhotos else { return [] }
         let window = interactiveKeptWindow()
         return Array(

--- a/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
@@ -241,7 +241,7 @@ final class WalkShareViewModel: ObservableObject {
     }
 
     /// Task 8's `share()` must filter `pinnedPhotos` to this same window before exporting hi-res
-    /// bytes — otherwise the export, the declared photo metadata, and the trimmed route would each tell a different story.
+    /// bytes — otherwise the export, the declared photo metadata, and the trimmed route would each tell a different story about which photos belong to the shared page.
     func interactiveKeptWindow() -> ClosedRange<Int>? {
         computeInteractiveRoute().keptWindow
     }
@@ -361,7 +361,8 @@ final class WalkShareViewModel: ObservableObject {
             elevationDescent: toggleElevation ? walk.descend : nil,
             steps: toggleSteps ? walk.steps : nil,
             meditateDuration: walk.meditateDuration,
-            talkDuration: interactive ? includedTalkCandidates.reduce(0) { $0 + $1.duration } : walk.talkDuration,
+            // Recordings outrun active time by design (a talk can run through a pause); NewWalk clamps talkDuration to activeDuration for the same reason, and the worker 400s on meditate+talk > active — clamp the included-candidate sum the same way.
+            talkDuration: interactive ? min(includedTalkCandidates.reduce(0) { $0 + $1.duration }, walk.talkDuration) : walk.talkDuration,
             weatherCondition: walk.weatherCondition,
             weatherTemperature: walk.weatherTemperature
         )

--- a/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
@@ -19,12 +19,56 @@ final class WalkShareViewModel: ObservableObject {
     var waypointCount: Int { walk.waypoints.count }
     var hasWaypoints: Bool { waypointCount > 0 }
 
+    /// Injected rather than read straight off `PermissionManager.standard`
+    /// (defaults to the real check): the OS permission prompt can't be driven
+    /// from a unit test, so `prepareInteractive()`'s auto-enable-once branch
+    /// needs a seam a test can force true or false deterministically.
+    private let isPhotosGranted: () -> Bool
+
     var pinnedPhotoCount: Int { pinnedPhotos.count }
     var hasPinnedPhotos: Bool {
         pinnedPhotoCount > 0
             && UserPreferences.walkReliquaryEnabled.value
-            && PermissionManager.standard.isPhotosGranted
+            && isPhotosGranted()
     }
+
+    @Published var interactiveEnabled = false
+    @Published var tourCandidates: [TourRecordingCandidate] = []
+    @Published var trimEnabled = true
+
+    static let trimMeters = 150
+
+    var hasRecordings: Bool { !tourCandidates.isEmpty }
+
+    var tourValidationError: String? {
+        interactiveEnabled ? TourBuilder.validationError(for: tourCandidates) : nil
+    }
+
+    var tourTotalsLabel: String {
+        let (count, bytes, seconds) = TourBuilder.totals(of: tourCandidates)
+        let photoCount = includePhotos ? min(pinnedPhotos.count, 20) : 0
+        var parts: [String] = []
+        if count > 0 {
+            let mb = Double(bytes) / 1_048_576
+            parts.append("\(count) recording\(count == 1 ? "" : "s") · \(String(format: "%.1f", mb)) MB · \(Int(seconds / 60)) min")
+        }
+        if photoCount > 0 {
+            parts.append("\(photoCount) hi-res photo\(photoCount == 1 ? "" : "s")")
+        }
+        return parts.isEmpty ? "no recordings included" : parts.joined(separator: " · ")
+    }
+
+    /// `RouteTrimmer.canTrim` only needs to know whether trimming would
+    /// shorten the route, not the trimmed result — so this works off the raw
+    /// route rather than sharing `computeInteractiveRoute()`'s downsampled one.
+    var canTrimRoute: Bool {
+        let points = walk.routeData.map {
+            SharePayload.RoutePoint(lat: $0.latitude, lon: $0.longitude, alt: $0.altitude, ts: Int($0.timestamp.timeIntervalSince1970))
+        }
+        return RouteTrimmer.canTrim(points, meters: Double(Self.trimMeters))
+    }
+
+    private var didAutoEnablePhotos = false
 
     @Published var journal = ""
     @Published var selectedExpiry: ExpiryOption = .season
@@ -112,7 +156,7 @@ final class WalkShareViewModel: ObservableObject {
     var formattedActivityBreakdown: String? {
         let parts = [
             walk.meditateDuration > 0 ? "\(Int(walk.meditateDuration / 60))m meditation" : nil,
-            walk.talkDuration > 0 ? "\(Int(walk.talkDuration / 60))m reflection" : nil,
+            walk.talkDuration > 0 ? "\(Int(walk.talkDuration / 60))m reflection" : nil
         ].compactMap { $0 }
         return parts.isEmpty ? nil : parts.joined(separator: ", ")
     }
@@ -122,9 +166,14 @@ final class WalkShareViewModel: ObservableObject {
         return "\(steps.formatted())"
     }
 
-    init(walk: WalkInterface, pinnedPhotos: [PhotoCandidate] = []) {
+    init(
+        walk: WalkInterface,
+        pinnedPhotos: [PhotoCandidate] = [],
+        isPhotosGranted: @escaping () -> Bool = { PermissionManager.standard.isPhotosGranted }
+    ) {
         self.walk = walk
         self.pinnedPhotos = pinnedPhotos
+        self.isPhotosGranted = isPhotosGranted
         if let uuid = walk.uuid, let cached = ShareService.cachedShare(for: uuid), !cached.isExpired {
             shareState = .success(url: cached.url)
             cachedExpiryDate = cached.expiry
@@ -146,6 +195,40 @@ final class WalkShareViewModel: ObservableObject {
         } catch {
             shareState = .error(message: error.localizedDescription)
         }
+    }
+
+    func prepareInteractive() {
+        if tourCandidates.isEmpty {
+            tourCandidates = TourBuilder.candidates(for: walk)
+        }
+        // Interactive means "carry the media": the first enable brings photos
+        // along automatically (the spec's auto-enable); the walker can still
+        // switch them off afterwards and we never re-flip.
+        if hasPinnedPhotos && !didAutoEnablePhotos {
+            didAutoEnablePhotos = true
+            includePhotos = true
+        }
+    }
+
+    func toggleInclude(candidateID: Int) {
+        guard let i = tourCandidates.firstIndex(where: { $0.id == candidateID }),
+              tourCandidates[i].unavailableReason == nil else { return }
+        tourCandidates[i].includeInShare.toggle()
+    }
+
+    func flipKind(candidateID: Int) {
+        guard let i = tourCandidates.firstIndex(where: { $0.id == candidateID }) else { return }
+        let current = tourCandidates[i].effectiveKind
+        let flipped: TourRecordingKind = current == .spoken ? .ambient : .spoken
+        tourCandidates[i].kindOverride = flipped == tourCandidates[i].autoKind ? nil : flipped
+    }
+
+    /// Task 8's `share()` must filter `pinnedPhotos` to this same window before
+    /// exporting hi-res bytes — otherwise the export, the declared photo
+    /// metadata, and the trimmed route would each tell a different story about
+    /// which photos belong to the shared page.
+    func interactiveKeptWindow() -> ClosedRange<Int>? {
+        computeInteractiveRoute().keptWindow
     }
 
     private func geocodeEndpoints() async -> (start: String?, end: String?) {
@@ -218,19 +301,10 @@ final class WalkShareViewModel: ObservableObject {
         }
     }
 
-    private func buildPayload(placeStart: String?, placeEnd: String?) -> SharePayload {
+    func buildPayload(placeStart: String?, placeEnd: String?, tourPhotoMeta: [SharePayload.Photo] = []) -> SharePayload {
         let isMetric = UserPreferences.distanceMeasurementType.safeValue == .kilometers
-
-        let routePoints = walk.routeData.map { sample in
-            SharePayload.RoutePoint(
-                lat: sample.latitude,
-                lon: sample.longitude,
-                alt: sample.altitude,
-                ts: Int(sample.timestamp.timeIntervalSince1970)
-            )
-        }
-
-        let downsampled = RouteDownsampler.downsample(routePoints)
+        let interactive = interactiveEnabled
+        let (finalRoute, trimM, keptWindow) = computeInteractiveRoute()
 
         var intervals: [SharePayload.ActivityIntervalPayload] = []
 
@@ -280,34 +354,9 @@ final class WalkShareViewModel: ObservableObject {
 
         let formatter = ISO8601DateFormatter()
 
-        let waypointPayload: [SharePayload.Waypoint]? = {
-            guard includeWaypoints, hasWaypoints else { return nil }
-            return walk.waypoints.map { wp in
-                SharePayload.Waypoint(
-                    lat: wp.latitude,
-                    lon: wp.longitude,
-                    label: wp.label,
-                    icon: wp.icon,
-                    ts: Int(wp.timestamp.timeIntervalSince1970)
-                )
-            }
-        }()
-
-        let photoPayload: [SharePayload.Photo]? = {
-            guard includePhotos, hasPinnedPhotos else { return nil }
-            return pinnedPhotos.compactMap { photo in
-                Self.loadSharePhoto(
-                    localIdentifier: photo.localIdentifier,
-                    lat: photo.capturedLat,
-                    lon: photo.capturedLng,
-                    capturedAt: photo.capturedAt
-                )
-            }
-        }()
-
         var payload = SharePayload(
             stats: stats,
-            route: downsampled,
+            route: finalRoute,
             activityIntervals: intervals,
             journal: journal.isEmpty ? nil : journal,
             expiryDays: selectedExpiry.rawValue,
@@ -318,11 +367,92 @@ final class WalkShareViewModel: ObservableObject {
             placeStart: placeStart,
             placeEnd: placeEnd,
             mark: markValue,
-            waypoints: waypointPayload,
-            photos: photoPayload
+            waypoints: waypointPayload(keptWindow: keptWindow),
+            photos: photoPayload(interactive: interactive, tourPhotoMeta: tourPhotoMeta)
         )
+        if interactive {
+            applyInteractiveTourAndPauses(to: &payload, trimM: trimM)
+        }
         payload.turningDay = turningDayCode()
         return payload
+    }
+
+    /// Test-only passthrough so specs can build a payload without geocoding.
+    func testBuildPayload(tourPhotoMeta: [SharePayload.Photo] = []) -> SharePayload {
+        buildPayload(placeStart: nil, placeEnd: nil, tourPhotoMeta: tourPhotoMeta)
+    }
+
+    private func waypointPayload(keptWindow: ClosedRange<Int>?) -> [SharePayload.Waypoint]? {
+        guard includeWaypoints, hasWaypoints else { return nil }
+        return walk.waypoints
+            .filter { wp in keptWindow.map { $0.contains(Int(wp.timestamp.timeIntervalSince1970)) } ?? true }
+            .map { wp in
+                SharePayload.Waypoint(
+                    lat: wp.latitude,
+                    lon: wp.longitude,
+                    label: wp.label,
+                    icon: wp.icon,
+                    ts: Int(wp.timestamp.timeIntervalSince1970)
+                )
+            }
+    }
+
+    private func photoPayload(interactive: Bool, tourPhotoMeta: [SharePayload.Photo]) -> [SharePayload.Photo]? {
+        guard includePhotos, hasPinnedPhotos else { return nil }
+        if interactive {
+            // Metadata comes ONLY from the export (same array, same order), so
+            // declared photo n always matches the uploaded file n. Never map
+            // pinnedPhotos here — a failed export would orphan map markers.
+            return tourPhotoMeta.isEmpty ? nil : tourPhotoMeta
+        }
+        return pinnedPhotos.compactMap { photo in
+            Self.loadSharePhoto(
+                localIdentifier: photo.localIdentifier,
+                lat: photo.capturedLat,
+                lon: photo.capturedLng,
+                capturedAt: photo.capturedAt
+            )
+        }
+    }
+
+    private func applyInteractiveTourAndPauses(to payload: inout SharePayload, trimM: Int) {
+        payload.tour = TourBuilder.tourItems(candidates: tourCandidates, trimM: trimM).tour
+        // The worker validates TRUNCATED integers: filter after truncation or a
+        // sub-second pause 400s the whole share.
+        payload.pauses = Array(
+            walk.pauses
+                .map { (start: Int($0.startDate.timeIntervalSince1970), end: Int($0.endDate.timeIntervalSince1970)) }
+                .filter { $0.end > $0.start }
+                .prefix(200)
+        ).map { SharePayload.Pause(startTs: $0.start, endTs: $0.end) }
+    }
+
+    /// Single source of truth for the trimmed route: `buildPayload` and
+    /// `interactiveKeptWindow()` must never compute this independently, or the
+    /// payload's route and the window used to filter waypoints/photos against
+    /// it could drift apart.
+    private func computeInteractiveRoute() -> (route: [SharePayload.RoutePoint], trimM: Int, keptWindow: ClosedRange<Int>?) {
+        let routePoints = walk.routeData.map { sample in
+            SharePayload.RoutePoint(
+                lat: sample.latitude,
+                lon: sample.longitude,
+                alt: sample.altitude,
+                ts: Int(sample.timestamp.timeIntervalSince1970)
+            )
+        }
+        let downsampled = RouteDownsampler.downsample(routePoints)
+
+        let trimM = interactiveEnabled && trimEnabled ? Self.trimMeters : 0
+        let finalRoute = interactiveEnabled && trimM > 0
+            ? RouteTrimmer.trim(downsampled, meters: Double(trimM))
+            : downsampled
+        // Trim's promise covers everything with a coordinate: waypoints and photo
+        // metadata whose timestamps fall outside the kept route window are excluded
+        // too — a doorstep photo must not pin the doorstep trim just hid.
+        let keptWindow: ClosedRange<Int>? = (interactiveEnabled && trimM > 0 && finalRoute.count >= 2)
+            ? finalRoute.first!.ts...finalRoute.last!.ts
+            : nil
+        return (finalRoute, trimM, keptWindow)
     }
 
     private func turningDayCode() -> String? {

--- a/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
@@ -44,6 +44,9 @@ final class WalkShareViewModel: ObservableObject {
         interactiveEnabled ? TourBuilder.validationError(for: tourCandidates) : nil
     }
 
+    /// Gates the Share button: an over-cap tour must be trimmed before POSTing, never silently clipped.
+    var canShare: Bool { tourValidationError == nil }
+
     var tourTotalsLabel: String {
         let (count, bytes, seconds) = TourBuilder.totals(of: tourCandidates)
         let photoCount = includePhotos ? min(pinnedPhotos.count, 20) : 0
@@ -106,9 +109,22 @@ final class WalkShareViewModel: ObservableObject {
 
     enum ShareState: Equatable {
         case idle
-        case uploading
+        case preparingPhotos(completed: Int, total: Int) // hi-res export (pre-POST)
+        case uploading                                   // POST phase
+        case uploadingMedia(completed: Int, total: Int)  // PUT phase
         case success(url: String)
+        case partial(url: String, failedCount: Int)      // page live, some media missing
         case error(message: String)
+    }
+
+    /// VM-level source of truth for "this walk has a live page" — `.partial`
+    /// counts the same as `.success`. Exists so the distinction is testable
+    /// without SwiftUI (the view mirrors this locally).
+    var isShared: Bool {
+        switch shareState {
+        case .success, .partial: return true
+        default: return false
+        }
     }
 
     var expiryDate: Date {
@@ -118,6 +134,18 @@ final class WalkShareViewModel: ObservableObject {
             to: Date()
         ) ?? Date()
     }
+
+    /// Shared by both the pre-share expiry picker and the post-share card
+    /// so "Expires..." and "Returns to the trail on..." always agree.
+    var formattedExpiry: String {
+        Self.expiryFormatter.string(from: expiryDate)
+    }
+
+    private static let expiryFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateStyle = .long
+        return f
+    }()
 
     var hasExistingShare: Bool {
         guard let uuid = walk.uuid else { return false }
@@ -173,27 +201,19 @@ final class WalkShareViewModel: ObservableObject {
         self.pinnedPhotos = pinnedPhotos
         self.isPhotosGranted = isPhotosGranted
         if let uuid = walk.uuid, let cached = ShareService.cachedShare(for: uuid), !cached.isExpired {
-            shareState = .success(url: cached.url)
             cachedExpiryDate = cached.expiry
+            // A share with un-landed media PUTs still has a live page —
+            // restore .partial so "Carry the missing files" survives
+            // leaving and returning here, not a quiet .success.
+            let failedCount = ShareService.failedMedia(for: uuid).count
+            shareState = failedCount > 0
+                ? .partial(url: cached.url, failedCount: failedCount)
+                : .success(url: cached.url)
         }
     }
 
-    func share() async {
-        shareState = .uploading
-
-        let placeNames = await geocodeEndpoints()
-        let payload = buildPayload(placeStart: placeNames.start, placeEnd: placeNames.end)
-
-        do {
-            let result = try await ShareService.share(payload: payload)
-            if let uuid = walk.uuid {
-                ShareService.cacheShare(result, walkID: uuid, expiryDays: selectedExpiry.rawValue, expiryOption: selectedExpiry.cacheKey)
-            }
-            shareState = .success(url: result.url)
-        } catch {
-            shareState = .error(message: error.localizedDescription)
-        }
-    }
+    // share(), retryFailedMedia(), and their private helpers live in
+    // WalkShareViewModel+ShareOrchestration.swift.
 
     func prepareInteractive() {
         if tourCandidates.isEmpty {
@@ -229,7 +249,8 @@ final class WalkShareViewModel: ObservableObject {
         computeInteractiveRoute().keptWindow
     }
 
-    private func geocodeEndpoints() async -> (start: String?, end: String?) {
+    // Called from WalkShareViewModel+ShareOrchestration.swift's `share()`.
+    func geocodeEndpoints() async -> (start: String?, end: String?) {
         let routeData = walk.routeData
         guard let first = routeData.first, let last = routeData.last else {
             return (nil, nil)

--- a/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
@@ -241,23 +241,18 @@ final class WalkShareViewModel: ObservableObject {
         tourCandidates[i].kindOverride = flipped == tourCandidates[i].autoKind ? nil : flipped
     }
 
-    /// Task 8's `share()` must filter `pinnedPhotos` to this same window before
-    /// exporting hi-res bytes — otherwise the export, the declared photo
-    /// metadata, and the trimmed route would each tell a different story about
-    /// which photos belong to the shared page.
+    /// Task 8's `share()` must filter `pinnedPhotos` to this same window before exporting hi-res
+    /// bytes — otherwise the export, the declared photo metadata, and the trimmed route would each tell a different story.
     func interactiveKeptWindow() -> ClosedRange<Int>? {
         computeInteractiveRoute().keptWindow
     }
 
     // Called from WalkShareViewModel+ShareOrchestration.swift's `share()`.
     func geocodeEndpoints() async -> (start: String?, end: String?) {
-        let routeData = walk.routeData
-        guard let first = routeData.first, let last = routeData.last else {
-            return (nil, nil)
-        }
+        guard let anchors = geocodeAnchorPoints() else { return (nil, nil) }
 
-        let startLoc = CLLocation(latitude: first.latitude, longitude: first.longitude)
-        let endLoc = CLLocation(latitude: last.latitude, longitude: last.longitude)
+        let startLoc = CLLocation(latitude: anchors.start.lat, longitude: anchors.start.lon)
+        let endLoc = CLLocation(latitude: anchors.end.lat, longitude: anchors.end.lon)
 
         async let startName = geocodeSingle(geocoder: CLGeocoder(), location: startLoc)
         async let endName = geocodeSingle(geocoder: CLGeocoder(), location: endLoc)
@@ -265,6 +260,17 @@ final class WalkShareViewModel: ObservableObject {
         let (s, e) = await (startName, endName)
         if s != nil && e != nil && s == e { return (s, nil) }
         return (s, e)
+    }
+
+    /// The coordinates `geocodeEndpoints()` reverse-geocodes: the shipped, post-trim route when interactive, the walk's raw route ends otherwise.
+    func geocodeAnchorPoints() -> (start: SharePayload.RoutePoint, end: SharePayload.RoutePoint)? {
+        if interactiveEnabled {
+            let route = computeInteractiveRoute().route
+            guard let first = route.first, let last = route.last else { return nil }
+            return (first, last)
+        }
+        guard let first = walk.routeData.first, let last = walk.routeData.last else { return nil }
+        return (routePoint(first), routePoint(last))
     }
 
     /// Loads a pinned photo as a low-res base64 JPEG for the share
@@ -451,35 +457,29 @@ final class WalkShareViewModel: ObservableObject {
     /// two different arrays — the same divergence class Task 3 closed for
     /// `RouteTrimmer.canTrim`/`.trim` themselves.
     private func downsampledRoutePoints() -> [SharePayload.RoutePoint] {
-        let routePoints = walk.routeData.map { sample in
-            SharePayload.RoutePoint(
-                lat: sample.latitude,
-                lon: sample.longitude,
-                alt: sample.altitude,
-                ts: Int(sample.timestamp.timeIntervalSince1970)
-            )
-        }
-        return RouteDownsampler.downsample(routePoints)
+        RouteDownsampler.downsample(walk.routeData.map(routePoint))
     }
 
-    /// Single source of truth for the trimmed route: `buildPayload` and
-    /// `interactiveKeptWindow()` must never compute this independently, or the
-    /// payload's route and the window used to filter waypoints/photos against
-    /// it could drift apart.
+    /// The `RouteDataSampleInterface` → `SharePayload.RoutePoint` field mapping shared by `downsampledRoutePoints()` and `geocodeAnchorPoints()`'s classic branch.
+    private func routePoint(_ sample: RouteDataSampleInterface) -> SharePayload.RoutePoint {
+        SharePayload.RoutePoint(lat: sample.latitude, lon: sample.longitude, alt: sample.altitude, ts: Int(sample.timestamp.timeIntervalSince1970))
+    }
+
+    /// Single source of truth for the trimmed route: `buildPayload` and `interactiveKeptWindow()`
+    /// must never compute this independently, or the payload's route and the filter window could drift apart.
     private func computeInteractiveRoute() -> (route: [SharePayload.RoutePoint], trimM: Int, keptWindow: ClosedRange<Int>?) {
         let downsampled = downsampledRoutePoints()
+        guard interactiveEnabled && trimEnabled else { return (downsampled, 0, nil) }
 
-        let trimM = interactiveEnabled && trimEnabled ? Self.trimMeters : 0
-        let finalRoute = interactiveEnabled && trimM > 0
-            ? RouteTrimmer.trim(downsampled, meters: Double(trimM))
-            : downsampled
-        // Trim's promise covers everything with a coordinate: waypoints and photo
-        // metadata whose timestamps fall outside the kept route window are excluded
-        // too — a doorstep photo must not pin the doorstep trim just hid.
-        let keptWindow: ClosedRange<Int>? = (interactiveEnabled && trimM > 0 && finalRoute.count >= 2)
-            ? finalRoute.first!.ts...finalRoute.last!.ts
+        // Report the trim by OUTCOME, not intent: RouteTrimmer silently no-ops on a route too short to trim, so trimM/keptWindow must reflect what actually happened — never claim a 150m trim while shipping the full, untrimmed route.
+        let trimmed = RouteTrimmer.trim(downsampled, meters: Double(Self.trimMeters))
+        let didTrim = trimmed.count < downsampled.count
+        let trimM = didTrim ? Self.trimMeters : 0
+        // Trim's promise covers everything with a coordinate: waypoints and photo metadata outside the kept route window are excluded too — a doorstep photo must not pin the doorstep trim just hid.
+        let keptWindow: ClosedRange<Int>? = (didTrim && trimmed.count >= 2)
+            ? trimmed.first!.ts...trimmed.last!.ts
             : nil
-        return (finalRoute, trimM, keptWindow)
+        return (trimmed, trimM, keptWindow)
     }
 
     private func turningDayCode() -> String? {

--- a/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
@@ -19,10 +19,7 @@ final class WalkShareViewModel: ObservableObject {
     var waypointCount: Int { walk.waypoints.count }
     var hasWaypoints: Bool { waypointCount > 0 }
 
-    /// Injected rather than read straight off `PermissionManager.standard`
-    /// (defaults to the real check): the OS permission prompt can't be driven
-    /// from a unit test, so `prepareInteractive()`'s auto-enable-once branch
-    /// needs a seam a test can force true or false deterministically.
+    /// Injected rather than read straight off `PermissionManager.standard` (defaults to the real check): the OS permission prompt can't be driven from a unit test, so `prepareInteractive()`'s auto-enable-once branch needs a seam a test can force true or false deterministically.
     private let isPhotosGranted: () -> Bool
 
     var pinnedPhotoCount: Int { pinnedPhotos.count }
@@ -61,10 +58,7 @@ final class WalkShareViewModel: ObservableObject {
         return parts.isEmpty ? "no recordings included" : parts.joined(separator: " · ")
     }
 
-    /// Judges trim against the same points `computeInteractiveRoute()` would
-    /// actually hand `RouteTrimmer.trim` — both read `downsampledRoutePoints()`
-    /// so a route long enough to trim can never disagree with a route the UI
-    /// was told could be trimmed.
+    /// Judges trim against the same points `computeInteractiveRoute()` would actually hand `RouteTrimmer.trim` — both read `downsampledRoutePoints()` so a route long enough to trim can never disagree with a route the UI was told could be trimmed.
     var canTrimRoute: Bool {
         RouteTrimmer.canTrim(downsampledRoutePoints(), meters: Double(Self.trimMeters))
     }
@@ -77,6 +71,10 @@ final class WalkShareViewModel: ObservableObject {
     @Published var shareState: ShareState = .idle
     /// Set when `retryFailedMedia()` can't re-identify any cached failure against current data — `.partial` still holds, but `ShareStatusSection` swaps the retry button for an explanation. Reset at the top of both `share()` and `retryFailedMedia()`. Not `private(set)`: both live in the orchestration extension file, and Swift's private access is file-scoped, not type-scoped — same reason `shareState` above is unrestricted.
     @Published var repairUnavailable = false
+    /// Owns the in-flight `share()`/`completeShare()` attempt — nil whenever nothing is running, so `beginShare()` can guard a double-tap and `cancelShare()` has something to cancel. Not `@Published` (nothing renders off it directly) and not `private`, same file-scoped-access reasoning as `shareState` above.
+    var shareTask: Task<Void, Never>?
+    /// Photos already exported when `.photosDropped` paused the share for consent — "Share without them" resumes with these, "Don't share yet" discards them. Same access reasoning as `shareTask`.
+    var pendingTourPhotos: [TourPhoto] = []
     private var cachedExpiryDate: Date?
 
     enum ExpiryOption: Int, CaseIterable {
@@ -112,6 +110,7 @@ final class WalkShareViewModel: ObservableObject {
     enum ShareState: Equatable {
         case idle
         case preparingPhotos(completed: Int, total: Int) // hi-res export (pre-POST)
+        case photosDropped(prepared: Int, dropped: Int)  // export done short; pre-POST consent pause
         case uploading                                   // POST phase
         case uploadingMedia(completed: Int, total: Int)  // PUT phase
         case success(url: String)

--- a/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
@@ -49,7 +49,7 @@ final class WalkShareViewModel: ObservableObject {
 
     var tourTotalsLabel: String {
         let (count, bytes, seconds) = TourBuilder.totals(of: tourCandidates)
-        let photoCount = includePhotos ? min(pinnedPhotos.count, 20) : 0
+        let photoCount = includePhotos ? interactivePhotoExportList().count : 0
         var parts: [String] = []
         if count > 0 {
             let mb = Double(bytes) / 1_048_576
@@ -75,6 +75,8 @@ final class WalkShareViewModel: ObservableObject {
     @Published var selectedExpiry: ExpiryOption = .season
 
     @Published var shareState: ShareState = .idle
+    /// Set when `retryFailedMedia()` can't re-identify any cached failure against current data — `.partial` still holds, but `ShareStatusSection` swaps the retry button for an explanation. Reset at the top of both `share()` and `retryFailedMedia()`. Not `private(set)`: both live in the orchestration extension file, and Swift's private access is file-scoped, not type-scoped — same reason `shareState` above is unrestricted.
+    @Published var repairUnavailable = false
     private var cachedExpiryDate: Date?
 
     enum ExpiryOption: Int, CaseIterable {
@@ -135,8 +137,7 @@ final class WalkShareViewModel: ObservableObject {
         ) ?? Date()
     }
 
-    /// Shared by both the pre-share expiry picker and the post-share card
-    /// so "Expires..." and "Returns to the trail on..." always agree.
+    /// Shared by both the pre-share expiry picker and the post-share card so "Expires..." and "Returns to the trail on..." always agree.
     var formattedExpiry: String {
         Self.expiryFormatter.string(from: expiryDate)
     }
@@ -212,8 +213,7 @@ final class WalkShareViewModel: ObservableObject {
         }
     }
 
-    // share(), retryFailedMedia(), and their private helpers live in
-    // WalkShareViewModel+ShareOrchestration.swift.
+    // share(), retryFailedMedia(), and their private helpers live in WalkShareViewModel+ShareOrchestration.swift.
 
     func prepareInteractive() {
         if tourCandidates.isEmpty {

--- a/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
@@ -341,13 +341,12 @@ final class WalkShareViewModel: ObservableObject {
             ))
         }
 
-        for recording in walk.voiceRecordings {
-            intervals.append(SharePayload.ActivityIntervalPayload(
-                type: "talk",
-                startTs: Int(recording.startDate.timeIntervalSince1970),
-                endTs: Int(recording.endDate.timeIntervalSince1970)
-            ))
-        }
+        // Consent follows the checkbox: an excluded recording leaves no trace — no talk interval, no rust on the route, no minutes in the total.
+        let includedTalkCandidates = tourCandidates.filter { $0.includeInShare && $0.unavailableReason == nil }
+        let talkIntervals: [SharePayload.ActivityIntervalPayload] = interactive
+            ? includedTalkCandidates.map { SharePayload.ActivityIntervalPayload(type: "talk", startTs: $0.startTs, endTs: $0.endTs) }
+            : walk.voiceRecordings.map { SharePayload.ActivityIntervalPayload(type: "talk", startTs: Int($0.startDate.timeIntervalSince1970), endTs: Int($0.endDate.timeIntervalSince1970)) }
+        intervals.append(contentsOf: talkIntervals)
 
         var toggledStats: [String] = []
         if toggleDistance { toggledStats.append("distance") }
@@ -363,7 +362,7 @@ final class WalkShareViewModel: ObservableObject {
             elevationDescent: toggleElevation ? walk.descend : nil,
             steps: toggleSteps ? walk.steps : nil,
             meditateDuration: walk.meditateDuration,
-            talkDuration: walk.talkDuration,
+            talkDuration: interactive ? includedTalkCandidates.reduce(0) { $0 + $1.duration } : walk.talkDuration,
             weatherCondition: walk.weatherCondition,
             weatherTemperature: walk.weatherTemperature
         )

--- a/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
@@ -58,14 +58,12 @@ final class WalkShareViewModel: ObservableObject {
         return parts.isEmpty ? "no recordings included" : parts.joined(separator: " · ")
     }
 
-    /// `RouteTrimmer.canTrim` only needs to know whether trimming would
-    /// shorten the route, not the trimmed result — so this works off the raw
-    /// route rather than sharing `computeInteractiveRoute()`'s downsampled one.
+    /// Judges trim against the same points `computeInteractiveRoute()` would
+    /// actually hand `RouteTrimmer.trim` — both read `downsampledRoutePoints()`
+    /// so a route long enough to trim can never disagree with a route the UI
+    /// was told could be trimmed.
     var canTrimRoute: Bool {
-        let points = walk.routeData.map {
-            SharePayload.RoutePoint(lat: $0.latitude, lon: $0.longitude, alt: $0.altitude, ts: Int($0.timestamp.timeIntervalSince1970))
-        }
-        return RouteTrimmer.canTrim(points, meters: Double(Self.trimMeters))
+        RouteTrimmer.canTrim(downsampledRoutePoints(), meters: Double(Self.trimMeters))
     }
 
     private var didAutoEnablePhotos = false
@@ -427,11 +425,11 @@ final class WalkShareViewModel: ObservableObject {
         ).map { SharePayload.Pause(startTs: $0.start, endTs: $0.end) }
     }
 
-    /// Single source of truth for the trimmed route: `buildPayload` and
-    /// `interactiveKeptWindow()` must never compute this independently, or the
-    /// payload's route and the window used to filter waypoints/photos against
-    /// it could drift apart.
-    private func computeInteractiveRoute() -> (route: [SharePayload.RoutePoint], trimM: Int, keptWindow: ClosedRange<Int>?) {
+    /// Shared by `canTrimRoute` and `computeInteractiveRoute()` so the route
+    /// judged for trimmability and the route actually trimmed can never be
+    /// two different arrays — the same divergence class Task 3 closed for
+    /// `RouteTrimmer.canTrim`/`.trim` themselves.
+    private func downsampledRoutePoints() -> [SharePayload.RoutePoint] {
         let routePoints = walk.routeData.map { sample in
             SharePayload.RoutePoint(
                 lat: sample.latitude,
@@ -440,7 +438,15 @@ final class WalkShareViewModel: ObservableObject {
                 ts: Int(sample.timestamp.timeIntervalSince1970)
             )
         }
-        let downsampled = RouteDownsampler.downsample(routePoints)
+        return RouteDownsampler.downsample(routePoints)
+    }
+
+    /// Single source of truth for the trimmed route: `buildPayload` and
+    /// `interactiveKeptWindow()` must never compute this independently, or the
+    /// payload's route and the window used to filter waypoints/photos against
+    /// it could drift apart.
+    private func computeInteractiveRoute() -> (route: [SharePayload.RoutePoint], trimM: Int, keptWindow: ClosedRange<Int>?) {
+        let downsampled = downsampledRoutePoints()
 
         let trimM = interactiveEnabled && trimEnabled ? Self.trimMeters : 0
         let finalRoute = interactiveEnabled && trimM > 0

--- a/UnitTests/Helpers/WalkDataFactory.swift
+++ b/UnitTests/Helpers/WalkDataFactory.swift
@@ -109,3 +109,22 @@ enum WalkDataFactory {
         TempWalkEvent(uuid: uuid, eventType: eventType, timestamp: timestamp)
     }
 }
+
+extension PhotoCandidate {
+
+    static func fixture(
+        localIdentifier: String = "test-photo-1",
+        capturedAt: Date = DateFactory.makeDate(2024, 6, 15, 9, 5, 0),
+        capturedLat: Double = 48.8566,
+        capturedLng: Double = 2.3522,
+        isPinned: Bool = true
+    ) -> PhotoCandidate {
+        PhotoCandidate(
+            localIdentifier: localIdentifier,
+            capturedAt: capturedAt,
+            capturedLat: capturedLat,
+            capturedLng: capturedLng,
+            isPinned: isPinned
+        )
+    }
+}

--- a/UnitTests/RouteTrimmerTests.swift
+++ b/UnitTests/RouteTrimmerTests.swift
@@ -33,4 +33,72 @@ final class RouteTrimmerTests: XCTestCase {
         XCTAssertFalse(RouteTrimmer.canTrim(straightRoute(points: 4), meters: 150))
         XCTAssertTrue(RouteTrimmer.canTrim(straightRoute(points: 20), meters: 150))
     }
+
+    func testClusteredEndpointCollisionIsHonest() {
+        // Route with ~1000m + ~1000m + ~1m segments: total ~2km, but endpoints cluster
+        // together at the end, causing trim's start/end pointers to collide.
+        // canTrim must return false AND trim must return route unchanged.
+        let route = [
+            SharePayload.RoutePoint(lat: 35.0, lon: -105.0, alt: 2000, ts: 1000),
+            SharePayload.RoutePoint(lat: 35.009, lon: -105.0, alt: 2000, ts: 1030),      // ~1000m from point 0
+            SharePayload.RoutePoint(lat: 35.018, lon: -105.0, alt: 2000, ts: 1060),      // ~1000m from point 1
+            SharePayload.RoutePoint(lat: 35.018009, lon: -105.0, alt: 2000, ts: 1090),   // ~1m from point 2
+        ]
+        XCTAssertFalse(RouteTrimmer.canTrim(route, meters: 150))
+        XCTAssertEqual(RouteTrimmer.trim(route, meters: 150).count, 4)
+    }
+
+    func testCanTrimAlwaysAgreesWithTrim() {
+        let geometries: [(name: String, route: [SharePayload.RoutePoint])] = [
+            ("uniform 20-point", straightRoute(points: 20)),
+            ("clustered endpoints", [
+                SharePayload.RoutePoint(lat: 35.0, lon: -105.0, alt: 2000, ts: 1000),
+                SharePayload.RoutePoint(lat: 35.009, lon: -105.0, alt: 2000, ts: 1030),
+                SharePayload.RoutePoint(lat: 35.018, lon: -105.0, alt: 2000, ts: 1060),
+                SharePayload.RoutePoint(lat: 35.018009, lon: -105.0, alt: 2000, ts: 1090),
+            ]),
+            ("short 4-point walk", straightRoute(points: 4)),
+            ("10-point with huge end segment", Array((0..<9).map { i in
+                SharePayload.RoutePoint(lat: 35.0 + Double(i) * 0.001, lon: -105.0, alt: 2000, ts: 1000 + i * 30)
+            }) + [
+                SharePayload.RoutePoint(lat: 35.009, lon: -105.0 + 0.045, alt: 2000, ts: 1270)  // ~5km from previous
+            ]),
+        ]
+
+        for geometry in geometries {
+            let canTrimResult = RouteTrimmer.canTrim(geometry.route, meters: 150)
+            let trimResult = RouteTrimmer.trim(geometry.route, meters: 150)
+            let trimChanged = trimResult.count < geometry.route.count
+            XCTAssertEqual(canTrimResult, trimChanged, "Mismatch for \(geometry.name): canTrim=\(canTrimResult), trim changed=\(trimChanged)")
+        }
+    }
+
+    func testDegenerateRouteCounts() {
+        // Empty route
+        let empty: [SharePayload.RoutePoint] = []
+        XCTAssertEqual(RouteTrimmer.trim(empty, meters: 150).count, 0)
+        XCTAssertFalse(RouteTrimmer.canTrim(empty, meters: 150))
+
+        // 1-point route
+        let onePoint = [SharePayload.RoutePoint(lat: 35.0, lon: -105.0, alt: 2000, ts: 1000)]
+        XCTAssertEqual(RouteTrimmer.trim(onePoint, meters: 150).count, 1)
+        XCTAssertFalse(RouteTrimmer.canTrim(onePoint, meters: 150))
+
+        // 2-point route
+        let twoPoints = [
+            SharePayload.RoutePoint(lat: 35.0, lon: -105.0, alt: 2000, ts: 1000),
+            SharePayload.RoutePoint(lat: 35.001, lon: -105.0, alt: 2000, ts: 1030),
+        ]
+        XCTAssertEqual(RouteTrimmer.trim(twoPoints, meters: 150).count, 2)
+        XCTAssertFalse(RouteTrimmer.canTrim(twoPoints, meters: 150))
+
+        // 3-point route
+        let threePoints = [
+            SharePayload.RoutePoint(lat: 35.0, lon: -105.0, alt: 2000, ts: 1000),
+            SharePayload.RoutePoint(lat: 35.001, lon: -105.0, alt: 2000, ts: 1030),
+            SharePayload.RoutePoint(lat: 35.002, lon: -105.0, alt: 2000, ts: 1060),
+        ]
+        XCTAssertEqual(RouteTrimmer.trim(threePoints, meters: 150).count, 3)
+        XCTAssertFalse(RouteTrimmer.canTrim(threePoints, meters: 150))
+    }
 }

--- a/UnitTests/RouteTrimmerTests.swift
+++ b/UnitTests/RouteTrimmerTests.swift
@@ -1,0 +1,36 @@
+import XCTest
+@testable import Pilgrim
+
+final class RouteTrimmerTests: XCTestCase {
+
+    /// ~111m per 0.001 degrees latitude.
+    private func straightRoute(points: Int, stepDegrees: Double = 0.001) -> [SharePayload.RoutePoint] {
+        (0..<points).map { i in
+            SharePayload.RoutePoint(lat: 35.0 + Double(i) * stepDegrees, lon: -105.0, alt: 2000, ts: 1000 + i * 30)
+        }
+    }
+
+    func testTrimZeroReturnsRouteUnchanged() {
+        let route = straightRoute(points: 10)
+        XCTAssertEqual(RouteTrimmer.trim(route, meters: 0).count, 10)
+    }
+
+    func testTrimRemovesBothEnds() {
+        let route = straightRoute(points: 20)   // ~2.1km total, 111m steps
+        let trimmed = RouteTrimmer.trim(route, meters: 150)
+        XCTAssertLessThan(trimmed.count, 20)
+        XCTAssertGreaterThan(trimmed.first!.lat, route.first!.lat)
+        XCTAssertLessThan(trimmed.last!.lat, route.last!.lat)
+        XCTAssertGreaterThanOrEqual(trimmed.count, 2)
+    }
+
+    func testShortWalkSharesUntrimmed() {
+        let route = straightRoute(points: 4)    // ~333m total < 4 * 150
+        XCTAssertEqual(RouteTrimmer.trim(route, meters: 150).count, 4)
+    }
+
+    func testCanTrimReflectsThreshold() {
+        XCTAssertFalse(RouteTrimmer.canTrim(straightRoute(points: 4), meters: 150))
+        XCTAssertTrue(RouteTrimmer.canTrim(straightRoute(points: 20), meters: 150))
+    }
+}

--- a/UnitTests/ShareMediaUploadTests.swift
+++ b/UnitTests/ShareMediaUploadTests.swift
@@ -20,11 +20,14 @@ final class ShareMediaUploadTests: XCTestCase {
 
     func testCacheFailedMedia_roundTripsThenEmptyClears() {
         let walkID = UUID()
-        let failures: [(kind: ShareService.MediaKind, n: Int)] = [(.photos, 2), (.audio, 1)]
+        let failures: [ShareService.FailedMediaItem] = [
+            ShareService.FailedMediaItem(kind: "photos", n: 2, audioStartTs: nil, photoLocalID: "photo-abc", photoTs: 1_000),
+            ShareService.FailedMediaItem(kind: "audio", n: 1, audioStartTs: 500, photoLocalID: nil, photoTs: nil)
+        ]
 
         ShareService.cacheFailedMedia(failures, walkID: walkID)
         let reloaded = ShareService.failedMedia(for: walkID)
-        XCTAssertEqual(reloaded.map { "\($0.kind.rawValue):\($0.n)" }, ["photos:2", "audio:1"])
+        XCTAssertEqual(reloaded, failures, "round-trip through JSON must preserve identity fields, not just kind/n")
 
         ShareService.cacheFailedMedia([], walkID: walkID)
         XCTAssertTrue(ShareService.failedMedia(for: walkID).isEmpty)

--- a/UnitTests/ShareMediaUploadTests.swift
+++ b/UnitTests/ShareMediaUploadTests.swift
@@ -1,0 +1,32 @@
+import XCTest
+@testable import Pilgrim
+
+final class ShareMediaUploadTests: XCTestCase {
+
+    func testRequestShapeMatchesWorkerContract() {
+        let req = ShareService.mediaUploadRequest(shareID: "abc123defg", kind: .audio, n: 3, contentLength: 12345)
+        XCTAssertEqual(req.url?.absoluteString, "https://walk.pilgrimapp.org/api/share/abc123defg/audio/3")
+        XCTAssertEqual(req.httpMethod, "PUT")
+        XCTAssertEqual(req.value(forHTTPHeaderField: "Content-Type"), "audio/mp4")
+        XCTAssertEqual(req.value(forHTTPHeaderField: "Content-Length"), "12345")
+        XCTAssertNotNil(req.value(forHTTPHeaderField: "X-Device-Token"))
+    }
+
+    func testPhotoRequestUsesJpegContentType() {
+        let req = ShareService.mediaUploadRequest(shareID: "abc123defg", kind: .photos, n: 1, contentLength: 500)
+        XCTAssertEqual(req.url?.absoluteString, "https://walk.pilgrimapp.org/api/share/abc123defg/photos/1")
+        XCTAssertEqual(req.value(forHTTPHeaderField: "Content-Type"), "image/jpeg")
+    }
+
+    func testCacheFailedMedia_roundTripsThenEmptyClears() {
+        let walkID = UUID()
+        let failures: [(kind: ShareService.MediaKind, n: Int)] = [(.photos, 2), (.audio, 1)]
+
+        ShareService.cacheFailedMedia(failures, walkID: walkID)
+        let reloaded = ShareService.failedMedia(for: walkID)
+        XCTAssertEqual(reloaded.map { "\($0.kind.rawValue):\($0.n)" }, ["photos:2", "audio:1"])
+
+        ShareService.cacheFailedMedia([], walkID: walkID)
+        XCTAssertTrue(ShareService.failedMedia(for: walkID).isEmpty)
+    }
+}

--- a/UnitTests/ShareMediaUploadTests.swift
+++ b/UnitTests/ShareMediaUploadTests.swift
@@ -10,6 +10,7 @@ final class ShareMediaUploadTests: XCTestCase {
         XCTAssertEqual(req.value(forHTTPHeaderField: "Content-Type"), "audio/mp4")
         XCTAssertEqual(req.value(forHTTPHeaderField: "Content-Length"), "12345")
         XCTAssertNotNil(req.value(forHTTPHeaderField: "X-Device-Token"))
+        XCTAssertEqual(req.timeoutInterval, 30, "an idle timeout, not a whole-upload one — it resets on bytes moving")
     }
 
     func testPhotoRequestUsesJpegContentType() {

--- a/UnitTests/ShareMediaUploadTests.swift
+++ b/UnitTests/ShareMediaUploadTests.swift
@@ -30,7 +30,42 @@ final class ShareMediaUploadTests: XCTestCase {
         let reloaded = ShareService.failedMedia(for: walkID)
         XCTAssertEqual(reloaded, failures, "round-trip through JSON must preserve identity fields, not just kind/n")
 
+        // Simulates the per-item prune `completeShare`/`retryFailedMedia` perform via
+        // `uploadAllMedia`/`uploadSpecific`'s `onItemSuccess`: a completed (kind, n) removed
+        // from the cached record with the same read-modify-write `cacheFailedMedia` round trip.
+        let afterOnePruned = ShareService.failedMedia(for: walkID).filter { !($0.kind == "audio" && $0.n == 1) }
+        ShareService.cacheFailedMedia(afterOnePruned, walkID: walkID)
+        XCTAssertEqual(ShareService.failedMedia(for: walkID), [failures[0]], "pruning the completed item must remove exactly it, leaving the other cached failure untouched")
+
         ShareService.cacheFailedMedia([], walkID: walkID)
         XCTAssertTrue(ShareService.failedMedia(for: walkID).isEmpty)
+    }
+
+    // MARK: - Round 2 review: honest background budget
+
+    override func tearDown() {
+        ShareService.backgroundStateProvider = { (UIApplication.shared.applicationState == .background, UIApplication.shared.backgroundTimeRemaining) }
+        super.tearDown()
+    }
+
+    @MainActor
+    func testBackgroundStateProviderDefaultReflectsRealApplicationState() {
+        let state = ShareService.backgroundStateProvider()
+        XCTAssertFalse(state.isBackground, "the test host runs foreground — the default provider must read UIApplication directly, not report background")
+    }
+
+    func testUploadAllMediaSkipsNetworkWhenBackgroundExhausted() async {
+        ShareService.backgroundStateProvider = { (true, 2) } // background, well under the 10s threshold
+
+        let audioFiles = [URL(fileURLWithPath: "/tmp/pilgrim-share-media-upload-tests-nonexistent.m4a")]
+        let photos = [Data([0xAA]), Data([0xBB])]
+        var lastProgress: ShareService.MediaProgress?
+
+        let failures = await ShareService.uploadAllMedia(shareID: "test-share-id", audioFiles: audioFiles, photos: photos) { progress in
+            lastProgress = progress
+        }
+
+        XCTAssertEqual(failures.count, audioFiles.count + photos.count, "background-exhausted from the very first item of each loop must fail everything without attempting a PUT — the nonexistent audio fileURL never gets read")
+        XCTAssertEqual(lastProgress, ShareService.MediaProgress(completed: audioFiles.count + photos.count, total: audioFiles.count + photos.count), "the per-loop skip accounting must still land exactly on (total, total)")
     }
 }

--- a/UnitTests/SharePayloadTourTests.swift
+++ b/UnitTests/SharePayloadTourTests.swift
@@ -1,0 +1,72 @@
+import XCTest
+@testable import Pilgrim
+
+final class SharePayloadTourTests: XCTestCase {
+
+    private func encodeToJSON(_ payload: SharePayload) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(payload)
+        return try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+    }
+
+    private func minimalPayload(tour: SharePayload.Tour?, pauses: [SharePayload.Pause]? = nil, photos: [SharePayload.Photo]? = nil) -> SharePayload {
+        var payload = SharePayload(
+            stats: .init(distance: 1000, activeDuration: 600, elevationAscent: nil, elevationDescent: nil, steps: nil, meditateDuration: 0, talkDuration: 0, weatherCondition: nil, weatherTemperature: nil),
+            route: [.init(lat: 35.68, lon: -105.94, alt: 2100, ts: 1000), .init(lat: 35.69, lon: -105.93, alt: 2110, ts: 1600)],
+            activityIntervals: [],
+            journal: nil,
+            expiryDays: 90,
+            units: "metric",
+            startDate: "2026-08-11T08:00:00Z",
+            tzIdentifier: "America/Denver",
+            toggledStats: ["distance"],
+            placeStart: nil, placeEnd: nil, mark: nil,
+            waypoints: nil,
+            photos: photos
+        )
+        payload.tour = tour
+        payload.pauses = pauses
+        return payload
+    }
+
+    func testTourEncodesSnakeCaseWithOrderedRecordings() throws {
+        let tour = SharePayload.Tour(
+            recordings: [
+                .init(n: 1, startTs: 1100, endTs: 1400, duration: 300, kind: "spoken", transcription: nil, wpm: 120, sizeBytes: 2_400_000),
+                .init(n: 2, startTs: 1450, endTs: 1500, duration: 50, kind: "ambient", transcription: nil, wpm: nil, sizeBytes: 800_000),
+            ],
+            trimM: 150
+        )
+        let json = try encodeToJSON(minimalPayload(tour: tour))
+        let tourJSON = try XCTUnwrap(json["tour"] as? [String: Any])
+        XCTAssertEqual(tourJSON["trim_m"] as? Int, 150)
+        let recs = try XCTUnwrap(tourJSON["recordings"] as? [[String: Any]])
+        XCTAssertEqual(recs.count, 2)
+        XCTAssertEqual(recs[0]["n"] as? Int, 1)
+        XCTAssertEqual(recs[0]["start_ts"] as? Int, 1100)
+        XCTAssertEqual(recs[0]["end_ts"] as? Int, 1400)
+        XCTAssertEqual(recs[0]["kind"] as? String, "spoken")
+        XCTAssertEqual(recs[0]["size_bytes"] as? Int, 2_400_000)
+        XCTAssertEqual(recs[1]["wpm"] as? Double, nil)
+    }
+
+    func testPausesEncodeSnakeCase() throws {
+        let json = try encodeToJSON(minimalPayload(tour: nil, pauses: [.init(startTs: 1150, endTs: 1450)]))
+        let pauses = try XCTUnwrap(json["pauses"] as? [[String: Any]])
+        XCTAssertEqual(pauses[0]["start_ts"] as? Int, 1150)
+        XCTAssertEqual(pauses[0]["end_ts"] as? Int, 1450)
+    }
+
+    func testAbsentTourAndPausesOmittedFromJSON() throws {
+        let json = try encodeToJSON(minimalPayload(tour: nil))
+        XCTAssertNil(json["tour"])
+        XCTAssertNil(json["pauses"])
+    }
+
+    func testPhotoWithoutDataOmitsDataKey() throws {
+        let photo = SharePayload.Photo(lat: 35.69, lon: -105.94, ts: 1200, data: nil)
+        let json = try encodeToJSON(minimalPayload(tour: nil, photos: [photo]))
+        let photos = try XCTUnwrap(json["photos"] as? [[String: Any]])
+        XCTAssertNil(photos[0]["data"])
+        XCTAssertEqual(photos[0]["ts"] as? Int, 1200)
+    }
+}

--- a/UnitTests/TourBuilderTests.swift
+++ b/UnitTests/TourBuilderTests.swift
@@ -93,4 +93,70 @@ final class TourBuilderTests: XCTestCase {
         XCTAssertEqual(tour.recordings.count, 1)
         XCTAssertEqual(files.count, 1)
     }
+
+    // MARK: - candidates(for:)
+
+    func testCandidates_availableFileIncluded() throws {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        // Flat filename, deliberately outside Documents/recordings — the app
+        // host's OrphanRecordingSweep owns that directory and would race this file.
+        let relativePath = "tourbuilder-available-\(UUID().uuidString).m4a"
+        let fileURL = docs.appendingPathComponent(relativePath)
+        try TestAudioFile.writeSilentAudioFile(to: fileURL, duration: 0.2)
+        addTeardownBlock { try? FileManager.default.removeItem(at: fileURL) }
+
+        let recording = WalkDataFactory.makeVoiceRecording(fileRelativePath: relativePath)
+        let walk = WalkDataFactory.makeWalk(voiceRecordings: [recording])
+
+        let candidates = TourBuilder.candidates(for: walk)
+
+        let found = try XCTUnwrap(candidates.first)
+        XCTAssertEqual(candidates.count, 1)
+        XCTAssertNil(found.unavailableReason)
+        XCTAssertTrue(found.includeInShare)
+        let expectedSize = try XCTUnwrap(FileManager.default.attributesOfItem(atPath: fileURL.path)[.size] as? Int)
+        XCTAssertEqual(found.sizeBytes, expectedSize)
+        XCTAssertEqual(found.fileURL, fileURL)
+    }
+
+    func testCandidates_missingFileMarkedAudioRemoved() {
+        let recording = WalkDataFactory.makeVoiceRecording(fileRelativePath: "tourbuilder-missing-\(UUID().uuidString).m4a")
+        let walk = WalkDataFactory.makeWalk(voiceRecordings: [recording])
+
+        let candidates = TourBuilder.candidates(for: walk)
+
+        XCTAssertEqual(candidates.count, 1, "a recording with no file on disk is still a candidate — just an unavailable one")
+        XCTAssertEqual(candidates.first?.unavailableReason, "audio removed")
+        XCTAssertEqual(candidates.first?.includeInShare, false)
+        XCTAssertNil(candidates.first?.fileURL)
+    }
+
+    func testCandidates_subSecondBlipExcluded() {
+        let start = DateFactory.makeDate(2024, 6, 15, 9, 5, 0)
+        let recording = WalkDataFactory.makeVoiceRecording(startDate: start, endDate: start.addingTimeInterval(0.4))
+        let walk = WalkDataFactory.makeWalk(voiceRecordings: [recording])
+
+        let candidates = TourBuilder.candidates(for: walk)
+
+        XCTAssertTrue(candidates.isEmpty, "a recording whose start/end truncate to the same Int second must not appear as a candidate at all — not even an unavailable one")
+    }
+
+    func testCandidates_sortedByStartDate() {
+        let early = WalkDataFactory.makeVoiceRecording(
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            endDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 30)
+        )
+        let late = WalkDataFactory.makeVoiceRecording(
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 10, 0),
+            endDate: DateFactory.makeDate(2024, 6, 15, 9, 10, 30)
+        )
+        // Walk stores them out of chronological order.
+        let walk = WalkDataFactory.makeWalk(voiceRecordings: [late, early])
+
+        let candidates = TourBuilder.candidates(for: walk)
+
+        XCTAssertEqual(candidates.map(\.startTs), candidates.map(\.startTs).sorted(), "candidates must come back sorted by start date regardless of storage order")
+        XCTAssertEqual(candidates.first?.startTs, Int(early.startDate.timeIntervalSince1970))
+        XCTAssertEqual(candidates.last?.startTs, Int(late.startDate.timeIntervalSince1970))
+    }
 }

--- a/UnitTests/TourBuilderTests.swift
+++ b/UnitTests/TourBuilderTests.swift
@@ -1,0 +1,82 @@
+import XCTest
+@testable import Pilgrim
+
+final class TourBuilderTests: XCTestCase {
+
+    func testClassify_noTranscriptionIsSpoken() {
+        XCTAssertEqual(TourBuilder.classify(transcription: nil, wpm: nil), .spoken)
+    }
+
+    func testClassify_fewWordsIsAmbient() {
+        XCTAssertEqual(TourBuilder.classify(transcription: "wind and birds", wpm: 200), .ambient)
+    }
+
+    func testClassify_slowSpeechIsAmbient() {
+        let words = Array(repeating: "word", count: 20).joined(separator: " ")
+        XCTAssertEqual(TourBuilder.classify(transcription: words, wpm: 12), .ambient)
+    }
+
+    func testClassify_realSpeechIsSpoken() {
+        let words = Array(repeating: "word", count: 20).joined(separator: " ")
+        XCTAssertEqual(TourBuilder.classify(transcription: words, wpm: 110), .spoken)
+    }
+
+    func testClassify_transcriptionWithoutWpmUsesWordCountOnly() {
+        let words = Array(repeating: "word", count: 20).joined(separator: " ")
+        XCTAssertEqual(TourBuilder.classify(transcription: words, wpm: nil), .spoken)
+    }
+
+    private func candidate(id: Int, bytes: Int = 1_000_000, seconds: Double = 60, included: Bool = true, kind: TourRecordingKind = .spoken) -> TourRecordingCandidate {
+        TourRecordingCandidate(id: id, startTs: 1000 + id * 100, endTs: 1050 + id * 100, duration: seconds, sizeBytes: bytes, transcription: nil, wpm: nil, autoKind: kind, includeInShare: included, kindOverride: nil, fileURL: URL(fileURLWithPath: "/tmp/\(id).m4a"), unavailableReason: nil)
+    }
+
+    func testTourItems_renumbersAfterExclusion() {
+        let candidates = [candidate(id: 0), candidate(id: 1, included: false), candidate(id: 2)]
+        let (tour, files) = TourBuilder.tourItems(candidates: candidates, trimM: 150)
+        XCTAssertEqual(tour.recordings.map(\.n), [1, 2])
+        XCTAssertEqual(tour.recordings[1].startTs, 1200)
+        XCTAssertEqual(tour.trimM, 150)
+        XCTAssertEqual(files.map(\.lastPathComponent), ["0.m4a", "2.m4a"])
+    }
+
+    func testTourItems_kindOverrideWins() {
+        var flipped = candidate(id: 0, kind: .spoken)
+        flipped.kindOverride = .ambient
+        let (tour, _) = TourBuilder.tourItems(candidates: [flipped], trimM: 0)
+        XCTAssertEqual(tour.recordings[0].kind, "ambient")
+    }
+
+    func testTourItems_payloadAndFilesAlwaysAlign() {
+        var urlless = candidate(id: 1)
+        urlless.fileURL = nil
+        let (tour, files) = TourBuilder.tourItems(candidates: [candidate(id: 0), urlless, candidate(id: 2)], trimM: 0)
+        XCTAssertEqual(tour.recordings.count, files.count)
+        XCTAssertEqual(files.map(\.lastPathComponent), ["0.m4a", "2.m4a"])
+    }
+
+    func testValidation_overTwelveRecordingsFails() {
+        let candidates = (0..<13).map { candidate(id: $0) }
+        XCTAssertNotNil(TourBuilder.validationError(for: candidates))
+        XCTAssertNil(TourBuilder.validationError(for: Array(candidates.prefix(12))))
+    }
+
+    func testValidation_totalBytesAndSecondsCaps() {
+        let heavy = (0..<5).map { candidate(id: $0, bytes: 14_000_000) }   // 70MB
+        XCTAssertNotNil(TourBuilder.validationError(for: heavy))
+        let long = (0..<3).map { candidate(id: $0, seconds: 1000) }        // 3000s
+        XCTAssertNotNil(TourBuilder.validationError(for: long))
+    }
+
+    func testValidation_excludedRecordingsDoNotCount() {
+        let candidates = (0..<13).map { candidate(id: $0, included: $0 < 12) }
+        XCTAssertNil(TourBuilder.validationError(for: candidates))
+    }
+
+    func testUnavailableCandidatesNeverEnterTour() {
+        var removed = candidate(id: 1)
+        removed = TourRecordingCandidate(id: 1, startTs: 1100, endTs: 1150, duration: 50, sizeBytes: 0, transcription: "kept transcript", wpm: nil, autoKind: .spoken, includeInShare: false, kindOverride: nil, fileURL: nil, unavailableReason: "audio removed")
+        let (tour, files) = TourBuilder.tourItems(candidates: [candidate(id: 0), removed], trimM: 0)
+        XCTAssertEqual(tour.recordings.count, 1)
+        XCTAssertEqual(files.count, 1)
+    }
+}

--- a/UnitTests/TourBuilderTests.swift
+++ b/UnitTests/TourBuilderTests.swift
@@ -62,6 +62,12 @@ final class TourBuilderTests: XCTestCase {
         XCTAssertEqual(files.map(\.lastPathComponent), ["0.m4a", "2.m4a"])
     }
 
+    func testTourItems_stripsTranscription() {
+        let withTranscript = TourRecordingCandidate(id: 0, startTs: 1000, endTs: 1060, duration: 60, sizeBytes: 1_000_000, transcription: "some real speech", wpm: 120, autoKind: .spoken, includeInShare: true, kindOverride: nil, fileURL: URL(fileURLWithPath: "/tmp/0.m4a"), unavailableReason: nil)
+        let (tour, _) = TourBuilder.tourItems(candidates: [withTranscript], trimM: 0)
+        XCTAssertNil(tour.recordings[0].transcription, "transcripts never leave the device — the page renders none of them")
+    }
+
     func testValidation_overTwelveRecordingsFails() {
         let candidates = (0..<13).map { candidate(id: $0) }
         XCTAssertNotNil(TourBuilder.validationError(for: candidates))

--- a/UnitTests/TourBuilderTests.swift
+++ b/UnitTests/TourBuilderTests.swift
@@ -26,6 +26,14 @@ final class TourBuilderTests: XCTestCase {
         XCTAssertEqual(TourBuilder.classify(transcription: words, wpm: nil), .spoken)
     }
 
+    func testClassify_emptyTranscriptionIsAmbient() {
+        XCTAssertEqual(TourBuilder.classify(transcription: "", wpm: nil), .ambient)
+    }
+
+    func testClassify_whitespaceOnlyTranscriptionIsAmbient() {
+        XCTAssertEqual(TourBuilder.classify(transcription: "  \n ", wpm: 200), .ambient)
+    }
+
     private func candidate(id: Int, bytes: Int = 1_000_000, seconds: Double = 60, included: Bool = true, kind: TourRecordingKind = .spoken) -> TourRecordingCandidate {
         TourRecordingCandidate(id: id, startTs: 1000 + id * 100, endTs: 1050 + id * 100, duration: seconds, sizeBytes: bytes, transcription: nil, wpm: nil, autoKind: kind, includeInShare: included, kindOverride: nil, fileURL: URL(fileURLWithPath: "/tmp/\(id).m4a"), unavailableReason: nil)
     }

--- a/UnitTests/TourPhotoExporterTests.swift
+++ b/UnitTests/TourPhotoExporterTests.swift
@@ -8,7 +8,11 @@ final class TourPhotoExporterTests: XCTestCase {
         return renderer.image { ctx in
             for x in stride(from: 0 as CGFloat, to: side, by: 8) {
                 for y in stride(from: 0 as CGFloat, to: side, by: 8) {
-                    UIColor(hue: .random(in: 0...1), saturation: 0.8, brightness: 0.9, alpha: 1).setFill()
+                    // Deterministic but still fully uncorrelated block-to-block —
+                    // a fixed formula, not `.random`, so the test can't flake
+                    // between runs while still defeating JPEG's neighbor prediction.
+                    let hue = CGFloat((Int(x) * 31 + Int(y) * 17) % 100) / 100.0
+                    UIColor(hue: hue, saturation: 0.8, brightness: 0.9, alpha: 1).setFill()
                     ctx.fill(CGRect(x: x, y: y, width: 8, height: 8))
                 }
             }

--- a/UnitTests/TourPhotoExporterTests.swift
+++ b/UnitTests/TourPhotoExporterTests.swift
@@ -1,0 +1,31 @@
+import XCTest
+@testable import Pilgrim
+
+final class TourPhotoExporterTests: XCTestCase {
+
+    private func noisyImage(side: CGFloat) -> UIImage {
+        let renderer = UIGraphicsImageRenderer(size: CGSize(width: side, height: side))
+        return renderer.image { ctx in
+            for x in stride(from: 0 as CGFloat, to: side, by: 8) {
+                for y in stride(from: 0 as CGFloat, to: side, by: 8) {
+                    UIColor(hue: .random(in: 0...1), saturation: 0.8, brightness: 0.9, alpha: 1).setFill()
+                    ctx.fill(CGRect(x: x, y: y, width: 8, height: 8))
+                }
+            }
+        }
+    }
+
+    // 1600px of fully uncorrelated 8px color blocks is a JPEG worst case (every
+    // block's DC coefficient defeats neighbor prediction): measured output ranges
+    // ~890KB (quality 0.2) to ~2.15MB (quality 0.8), so the cap must clear the
+    // ladder's lowest rung with margin for run-to-run hue randomness.
+    func testLadderProducesDataUnderCap() throws {
+        let data = try XCTUnwrap(TourPhotoExporter.jpegDataUnder(cap: 1_500_000, image: noisyImage(side: 1600)))
+        XCTAssertLessThanOrEqual(data.count, 1_500_000)
+        XCTAssertGreaterThan(data.count, 0)
+    }
+
+    func testLadderReturnsNilWhenImpossible() {
+        XCTAssertNil(TourPhotoExporter.jpegDataUnder(cap: 10, image: noisyImage(side: 1600)))
+    }
+}

--- a/UnitTests/WalkShareInteractiveTests.swift
+++ b/UnitTests/WalkShareInteractiveTests.swift
@@ -176,6 +176,30 @@ final class WalkShareInteractiveTests: XCTestCase {
         XCTAssertTrue(labels.contains("AtUpperBound"), "a waypoint exactly at the kept window's upper bound must be included — ClosedRange.contains is inclusive")
     }
 
+    func testShortRouteTrimIsHonestAndLeavesWaypointsUnfiltered() {
+        let route = longRoute(points: 4) // ~333m total — well under the 4x-150m trim threshold
+        let early = TempV4.Waypoint(
+            uuid: nil,
+            latitude: 48.8566,
+            longitude: 2.3522,
+            label: "Before the first fix",
+            icon: "flag",
+            timestamp: route[0].timestamp.addingTimeInterval(-3600)
+        )
+        let walk = WalkDataFactory.makeWalk(routeData: route, waypoints: [early])
+        let vm = WalkShareViewModel(walk: walk)
+        vm.interactiveEnabled = true
+        vm.trimEnabled = true
+        vm.includeWaypoints = true
+        vm.prepareInteractive()
+
+        let payload = vm.testBuildPayload()
+
+        XCTAssertEqual(payload.tour?.trimM, 0, "a route too short to actually trim must report trimM 0, not the requested 150 — RouteTrimmer silently no-ops on it")
+        let labels = payload.waypoints?.map(\.label) ?? []
+        XCTAssertTrue(labels.contains("Before the first fix"), "no real trim happened, so nothing should be filtered out — not even a waypoint before the first GPS fix")
+    }
+
     func testInteractivePhotoMetaUsesOnlyExportedPhotos() {
         UserPreferences.walkReliquaryEnabled.value = true
         let walk = WalkDataFactory.makeWalk()
@@ -191,6 +215,31 @@ final class WalkShareInteractiveTests: XCTestCase {
 
         let withoutExport = vm.testBuildPayload(tourPhotoMeta: [])
         XCTAssertNil(withoutExport.photos, "the interactive branch must never fall back to mapping pinnedPhotos")
+    }
+
+    func testTourTotalsLabelWording() {
+        let emptyVM = WalkShareViewModel(walk: WalkDataFactory.makeWalk())
+        XCTAssertEqual(emptyVM.tourTotalsLabel, "no recordings included")
+
+        let singularVM = WalkShareViewModel(walk: WalkDataFactory.makeWalk())
+        singularVM.tourCandidates = [
+            TourRecordingCandidate(id: 0, startTs: 1000, endTs: 1060, duration: 60, sizeBytes: 1_000_000, transcription: nil, wpm: nil, autoKind: .spoken, includeInShare: true, kindOverride: nil, fileURL: URL(fileURLWithPath: "/tmp/0.m4a"), unavailableReason: nil)
+        ]
+        XCTAssertTrue(singularVM.tourTotalsLabel.hasPrefix("1 recording ·"), "singular wording must not add a trailing s")
+        XCTAssertFalse(singularVM.tourTotalsLabel.contains("1 recordings"))
+
+        UserPreferences.walkReliquaryEnabled.value = true
+        let walkStart = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+        let walkEnd = DateFactory.makeDate(2024, 6, 15, 9, 30, 0)
+        let manyPhotos = (0..<25).map { i in
+            PhotoCandidate.fixture(localIdentifier: "photo-\(i)", capturedAt: walkStart.addingTimeInterval(Double(i) * 30))
+        }
+        let walk = WalkDataFactory.makeWalk(startDate: walkStart, endDate: walkEnd)
+        let cappedVM = WalkShareViewModel(walk: walk, pinnedPhotos: manyPhotos, isPhotosGranted: { true })
+        cappedVM.includePhotos = true
+
+        XCTAssertEqual(cappedVM.interactivePhotoExportList().count, 20, "the export list itself caps at 20")
+        XCTAssertTrue(cappedVM.tourTotalsLabel.contains("20 hi-res photos"), "the label's photo count must cap at the export list's count, not the full pinned count")
     }
 
     // MARK: - Task 8: share orchestration
@@ -262,6 +311,42 @@ final class WalkShareInteractiveTests: XCTestCase {
         XCTAssertEqual(failedCount, 1)
     }
 
+    // MARK: - geocodeAnchorPoints
+
+    func testGeocodeAnchorPointsInteractiveUsesTrimmedRouteEnds() throws {
+        let route = longRoute(points: 20)
+        let walk = WalkDataFactory.makeWalk(routeData: route)
+        let vm = WalkShareViewModel(walk: walk)
+        vm.interactiveEnabled = true
+        vm.prepareInteractive()
+
+        let anchors = try XCTUnwrap(vm.geocodeAnchorPoints())
+
+        let rawFirstTs = Int(route[0].timestamp.timeIntervalSince1970)
+        let rawLastTs = Int(route[route.count - 1].timestamp.timeIntervalSince1970)
+        XCTAssertNotEqual(anchors.start.ts, rawFirstTs, "interactive anchors must come from the TRIMMED route, not the raw ends")
+        XCTAssertNotEqual(anchors.end.ts, rawLastTs)
+
+        let expectedTrimmed = RouteTrimmer.trim(
+            route.map { SharePayload.RoutePoint(lat: $0.latitude, lon: $0.longitude, alt: $0.altitude, ts: Int($0.timestamp.timeIntervalSince1970)) },
+            meters: Double(WalkShareViewModel.trimMeters)
+        )
+        XCTAssertEqual(anchors.start.ts, expectedTrimmed.first?.ts)
+        XCTAssertEqual(anchors.end.ts, expectedTrimmed.last?.ts)
+    }
+
+    func testGeocodeAnchorPointsClassicUsesRawRouteEnds() throws {
+        let route = longRoute(points: 20)
+        let walk = WalkDataFactory.makeWalk(routeData: route)
+        let vm = WalkShareViewModel(walk: walk)
+        // interactiveEnabled left false — classic share.
+
+        let anchors = try XCTUnwrap(vm.geocodeAnchorPoints())
+
+        XCTAssertEqual(anchors.start.ts, Int(route.first!.timestamp.timeIntervalSince1970))
+        XCTAssertEqual(anchors.end.ts, Int(route.last!.timestamp.timeIntervalSince1970))
+    }
+
     // MARK: - resolveRetryItems (pure identity resolution)
 
     func testResolveRetryItemsMatchesPhotoByIdentityNotIndex() {
@@ -306,12 +391,30 @@ final class WalkShareInteractiveTests: XCTestCase {
         XCTAssertEqual(remaining, cached, "an unresolved item must be carried forward unchanged, not dropped")
     }
 
+    func testResolveRetryItemsUnrecognizedKindGoesToRemaining() {
+        let cached = [ShareService.FailedMediaItem(kind: "video", n: 1, audioStartTs: nil, photoLocalID: nil, photoTs: nil)]
+
+        let (uploadable, remaining) = WalkShareViewModel.resolveRetryItems(
+            cached: cached,
+            currentRecordings: [],
+            currentAudioFiles: [],
+            currentPhotos: []
+        )
+
+        XCTAssertTrue(uploadable.isEmpty)
+        XCTAssertEqual(remaining, cached, "a kind this build no longer recognizes must be carried forward, not dropped or crashed on")
+    }
+
     func testResolveRetryItemsAudioStartTsMismatchGoesToRemaining() {
-        // recordings[0] is now a DIFFERENT recording (startTs 200, not the
-        // cached 100) — the candidate set shifted since the original share.
+        // The cached startTs (100) is absent from EVERY current recording —
+        // not just shifted position, but genuinely gone. Two recordings (not
+        // one) so this can't accidentally pass just because index 0 mismatches.
         let cached = [ShareService.FailedMediaItem(kind: "audio", n: 1, audioStartTs: 100, photoLocalID: nil, photoTs: nil)]
-        let recordings = [SharePayload.TourRecording(n: 1, startTs: 200, endTs: 260, duration: 60, kind: "spoken", transcription: nil, wpm: nil, sizeBytes: 1_000)]
-        let audioFiles = [URL(fileURLWithPath: "/tmp/audio1.m4a")]
+        let recordings = [
+            SharePayload.TourRecording(n: 1, startTs: 200, endTs: 260, duration: 60, kind: "spoken", transcription: nil, wpm: nil, sizeBytes: 1_000),
+            SharePayload.TourRecording(n: 2, startTs: 300, endTs: 360, duration: 60, kind: "spoken", transcription: nil, wpm: nil, sizeBytes: 1_000)
+        ]
+        let audioFiles = [URL(fileURLWithPath: "/tmp/audio1.m4a"), URL(fileURLWithPath: "/tmp/audio2.m4a")]
 
         let (uploadable, remaining) = WalkShareViewModel.resolveRetryItems(
             cached: cached,
@@ -322,6 +425,30 @@ final class WalkShareInteractiveTests: XCTestCase {
 
         XCTAssertTrue(uploadable.isEmpty)
         XCTAssertEqual(remaining, cached)
+    }
+
+    func testResolveRetryItemsAudioFoundAtShiftedIndex() {
+        // The cached failure originally pointed at slot n=3, whose recording
+        // had startTs 500. Since then an earlier recording dropped out of the
+        // candidate set, so that SAME recording (still startTs 500) now sits
+        // at index 0 — an index-locked lookup (index 2) would miss it entirely.
+        let cached = [ShareService.FailedMediaItem(kind: "audio", n: 3, audioStartTs: 500, photoLocalID: nil, photoTs: nil)]
+        let recordings = [
+            SharePayload.TourRecording(n: 1, startTs: 500, endTs: 560, duration: 60, kind: "spoken", transcription: nil, wpm: nil, sizeBytes: 1_000),
+            SharePayload.TourRecording(n: 2, startTs: 600, endTs: 660, duration: 60, kind: "spoken", transcription: nil, wpm: nil, sizeBytes: 1_000)
+        ]
+        let audioFiles = [URL(fileURLWithPath: "/tmp/shifted-0.m4a"), URL(fileURLWithPath: "/tmp/shifted-1.m4a")]
+
+        let (uploadable, remaining) = WalkShareViewModel.resolveRetryItems(
+            cached: cached,
+            currentRecordings: recordings,
+            currentAudioFiles: audioFiles,
+            currentPhotos: []
+        )
+
+        XCTAssertTrue(remaining.isEmpty)
+        XCTAssertEqual(uploadable.first?.n, 3, "must upload under the CACHED slot n, not the recording's shifted array position")
+        XCTAssertEqual(uploadable.first?.kind, .audio)
     }
 
     func testResolveRetryItemsAudioMatchesWhenStartTsAgrees() {
@@ -339,5 +466,35 @@ final class WalkShareInteractiveTests: XCTestCase {
         XCTAssertTrue(remaining.isEmpty)
         XCTAssertEqual(uploadable.first?.n, 1)
         XCTAssertEqual(uploadable.first?.kind, .audio)
+    }
+
+    // MARK: - expectedFailureRecords (kill-safe repair record)
+
+    func testExpectedFailureRecordsMatchIdentityMapping() {
+        let recordings = [
+            SharePayload.TourRecording(n: 1, startTs: 100, endTs: 160, duration: 60, kind: "spoken", transcription: nil, wpm: nil, sizeBytes: 1_000),
+            SharePayload.TourRecording(n: 2, startTs: 200, endTs: 260, duration: 60, kind: "ambient", transcription: nil, wpm: nil, sizeBytes: 2_000)
+        ]
+        let photos = [TourPhoto(meta: SharePayload.Photo(lat: 1, lon: 2, ts: 999, data: nil), jpegData: Data([0xAA]), sourceLocalIdentifier: "photo-1")]
+
+        let records = WalkShareViewModel.expectedFailureRecords(recordings: recordings, photos: photos)
+
+        XCTAssertEqual(records.count, 3, "one record per recording plus one per photo — the FULL upload, not just failures")
+
+        XCTAssertEqual(records[0].kind, "audio")
+        XCTAssertEqual(records[0].n, 1)
+        XCTAssertEqual(records[0].audioStartTs, 100)
+        XCTAssertNil(records[0].photoLocalID)
+        XCTAssertNil(records[0].photoTs)
+
+        XCTAssertEqual(records[1].kind, "audio")
+        XCTAssertEqual(records[1].n, 2)
+        XCTAssertEqual(records[1].audioStartTs, 200)
+
+        XCTAssertEqual(records[2].kind, "photos")
+        XCTAssertEqual(records[2].n, 1)
+        XCTAssertNil(records[2].audioStartTs)
+        XCTAssertEqual(records[2].photoLocalID, "photo-1")
+        XCTAssertEqual(records[2].photoTs, 999)
     }
 }

--- a/UnitTests/WalkShareInteractiveTests.swift
+++ b/UnitTests/WalkShareInteractiveTests.swift
@@ -95,7 +95,9 @@ final class WalkShareInteractiveTests: XCTestCase {
     func testExcludedRecordingLeavesNoTalkInterval() {
         let keptCandidate = TourRecordingCandidate(id: 0, startTs: 1000, endTs: 1060, duration: 60, sizeBytes: 1_000_000, transcription: nil, wpm: nil, autoKind: .spoken, includeInShare: true, kindOverride: nil, fileURL: URL(fileURLWithPath: "/tmp/0.m4a"), unavailableReason: nil)
         let excludedCandidate = TourRecordingCandidate(id: 1, startTs: 2000, endTs: 2090, duration: 90, sizeBytes: 1_500_000, transcription: nil, wpm: nil, autoKind: .spoken, includeInShare: true, kindOverride: nil, fileURL: URL(fileURLWithPath: "/tmp/1.m4a"), unavailableReason: nil)
-        let vm = WalkShareViewModel(walk: WalkDataFactory.makeWalk())
+        // talkDuration must cover the kept candidate's 60s, or the round-2 active-duration clamp
+        // (min(includedSum, walk.talkDuration)) would mask this test's actual target: exclusion filtering.
+        let vm = WalkShareViewModel(walk: WalkDataFactory.makeWalk(talkDuration: 150))
         vm.tourCandidates = [keptCandidate, excludedCandidate]
         vm.interactiveEnabled = true
         vm.toggleInclude(candidateID: excludedCandidate.id)
@@ -122,6 +124,20 @@ final class WalkShareInteractiveTests: XCTestCase {
         XCTAssertEqual(talkIntervals.count, 2, "classic path reads walk.voiceRecordings directly — candidate exclusions must have zero effect")
         XCTAssertEqual(talkIntervals.map(\.startTs).sorted(), [rec1, rec2].map { Int($0.startDate.timeIntervalSince1970) }.sorted())
         XCTAssertEqual(payload.stats.talkDuration, walk.talkDuration)
+    }
+
+    // MARK: - Round 2 review: talk duration clamped to walk.talkDuration
+
+    func testInteractiveTalkDurationClampedToWalkTalkDuration() {
+        let walk = WalkDataFactory.makeWalk(talkDuration: 100)
+        let vm = WalkShareViewModel(walk: walk)
+        vm.interactiveEnabled = true
+        vm.tourCandidates = [
+            TourRecordingCandidate(id: 0, startTs: 1000, endTs: 1060, duration: 60, sizeBytes: 1_000_000, transcription: nil, wpm: nil, autoKind: .spoken, includeInShare: true, kindOverride: nil, fileURL: URL(fileURLWithPath: "/tmp/0.m4a"), unavailableReason: nil),
+            TourRecordingCandidate(id: 1, startTs: 2000, endTs: 2060, duration: 60, sizeBytes: 1_000_000, transcription: nil, wpm: nil, autoKind: .spoken, includeInShare: true, kindOverride: nil, fileURL: URL(fileURLWithPath: "/tmp/1.m4a"), unavailableReason: nil)
+        ]
+        let payload = vm.testBuildPayload()
+        XCTAssertEqual(payload.stats.talkDuration, 100, "the included candidates sum to 120 — must clamp to walk.talkDuration, same reason NewWalk clamps to activeDuration")
     }
 
     // MARK: - Supplementary coverage
@@ -496,5 +512,58 @@ final class WalkShareInteractiveTests: XCTestCase {
         vm.shareState = .photosDropped(prepared: 2, dropped: 1)
         vm.cancelDroppedPhotoShare()
         XCTAssertEqual(vm.shareState, .idle)
+    }
+
+    // MARK: - Round 2 review: completeShare choke point, decline cancels in-flight resume
+
+    func testShareCancelledBeforePostReturnsToIdle() async {
+        let walk = WalkDataFactory.makeWalk(voiceRecordings: [WalkDataFactory.makeVoiceRecording()])
+        let vm = WalkShareViewModel(walk: walk)
+        vm.beginShare()
+        vm.cancelShare()
+        await vm.shareTask?.value
+        XCTAssertEqual(vm.shareState, .idle, "cancelling before the POST must never leave a live-looking state behind")
+    }
+
+    func testShareEntersPhotosDroppedWhenExportComesUpShort() async {
+        UserPreferences.walkReliquaryEnabled.value = true
+        let walk = WalkDataFactory.makeWalk()
+        let vm = WalkShareViewModel(walk: walk, pinnedPhotos: [PhotoCandidate.fixture()], isPhotosGranted: { true })
+        vm.interactiveEnabled = true
+        vm.includePhotos = true
+        vm.prepareInteractive()
+
+        vm.beginShare()
+        await vm.shareTask?.value
+
+        XCTAssertEqual(vm.shareState, .photosDropped(prepared: 0, dropped: 1), "the fixture's localIdentifier never resolves in PHAsset.fetchAssets, so the export comes up short deterministically, without network")
+    }
+
+    func testContinueShareClaimsUploadingSynchronously() async {
+        let vm = WalkShareViewModel(walk: WalkDataFactory.makeWalk())
+        vm.shareState = .photosDropped(prepared: 1, dropped: 1)
+
+        vm.continueShareWithoutDroppedPhotos()
+        XCTAssertEqual(vm.shareState, .uploading, "the prompt's buttons must vanish within the same runloop turn, before any await")
+        XCTAssertNotNil(vm.shareTask, "a resume task must be running")
+
+        vm.continueShareWithoutDroppedPhotos()
+        XCTAssertEqual(vm.shareState, .uploading, "a same-runloop double-tap must be a no-op — the shareTask guard covers it, not a second resume task")
+        XCTAssertNotNil(vm.shareTask, "the no-op call must not have cleared the original task")
+
+        vm.cancelShare()
+        await vm.shareTask?.value
+        XCTAssertEqual(vm.shareState, .idle, "cleanup: the cancelled resume must still land on idle via completeShare's pre-POST checkpoint")
+    }
+
+    func testDeclineCancelsInFlightResume() async {
+        let vm = WalkShareViewModel(walk: WalkDataFactory.makeWalk())
+        vm.shareState = .photosDropped(prepared: 2, dropped: 1)
+
+        vm.continueShareWithoutDroppedPhotos()
+        vm.cancelDroppedPhotoShare()
+
+        await vm.shareTask?.value
+        XCTAssertEqual(vm.shareState, .idle, "declining while a resume is in flight must cancel it — completeShare's pre-POST checkpoint returns idle before geocoding or POSTing ever run")
     }
 }

--- a/UnitTests/WalkShareInteractiveTests.swift
+++ b/UnitTests/WalkShareInteractiveTests.swift
@@ -174,4 +174,67 @@ final class WalkShareInteractiveTests: XCTestCase {
         let withoutExport = vm.testBuildPayload(tourPhotoMeta: [])
         XCTAssertNil(withoutExport.photos, "the interactive branch must never fall back to mapping pinnedPhotos")
     }
+
+    // MARK: - Task 8: share orchestration
+
+    func testShareButtonDisabledWhenTourInvalid() {
+        let vm = WalkShareViewModel(walk: WalkDataFactory.makeWalk())
+        vm.interactiveEnabled = true
+        vm.tourCandidates = (0..<13).map { i in
+            TourRecordingCandidate(id: i, startTs: i, endTs: i + 1, duration: 60, sizeBytes: 1_000_000, transcription: nil, wpm: nil, autoKind: .spoken, includeInShare: true, kindOverride: nil, fileURL: nil, unavailableReason: nil)
+        }
+        XCTAssertNotNil(vm.tourValidationError)
+        XCTAssertFalse(vm.canShare)
+    }
+
+    func testInteractivePayloadPhotoCountMatchesExportedMeta() {
+        UserPreferences.walkReliquaryEnabled.value = true
+        let walk = WalkDataFactory.makeWalk()
+        let vm = WalkShareViewModel(walk: walk, pinnedPhotos: [PhotoCandidate.fixture()], isPhotosGranted: { true })
+        vm.interactiveEnabled = true
+        vm.includePhotos = true
+        vm.prepareInteractive()
+
+        let meta = [
+            SharePayload.Photo(lat: 1, lon: 2, ts: 3, data: nil),
+            SharePayload.Photo(lat: 4, lon: 5, ts: 6, data: nil),
+            SharePayload.Photo(lat: 7, lon: 8, ts: 9, data: nil)
+        ]
+        let payload = vm.testBuildPayload(tourPhotoMeta: meta)
+        XCTAssertEqual(payload.photos?.count, meta.count, "declared payload count must match the exported byte count — that's what authorizes each PUT index")
+    }
+
+    func testPartialAndSuccessBothCountAsShared() {
+        let successID = UUID()
+        let successWalk = WalkDataFactory.makeWalk(uuid: successID)
+        ShareService.cacheShare(
+            ShareService.ShareResult(url: "https://walk.pilgrimapp.org/success1", id: "success1"),
+            walkID: successID,
+            expiryDays: 90,
+            expiryOption: "season"
+        )
+        let successVM = WalkShareViewModel(walk: successWalk)
+        XCTAssertTrue(successVM.isShared)
+        guard case .success = successVM.shareState else {
+            return XCTFail("expected .success when no media failed")
+        }
+
+        let partialID = UUID()
+        let partialWalk = WalkDataFactory.makeWalk(uuid: partialID)
+        ShareService.cacheShare(
+            ShareService.ShareResult(url: "https://walk.pilgrimapp.org/partial1", id: "partial1"),
+            walkID: partialID,
+            expiryDays: 90,
+            expiryOption: "season"
+        )
+        ShareService.cacheFailedMedia([(kind: .audio, n: 1)], walkID: partialID)
+        let partialVM = WalkShareViewModel(walk: partialWalk)
+        XCTAssertTrue(partialVM.isShared, ".partial must count as shared — the page is already live")
+        guard case .partial(_, let failedCount) = partialVM.shareState else {
+            return XCTFail("expected .partial when media failed")
+        }
+        XCTAssertEqual(failedCount, 1)
+
+        ShareService.cacheFailedMedia([], walkID: partialID)
+    }
 }

--- a/UnitTests/WalkShareInteractiveTests.swift
+++ b/UnitTests/WalkShareInteractiveTests.swift
@@ -1,0 +1,157 @@
+import XCTest
+@testable import Pilgrim
+
+@MainActor
+final class WalkShareInteractiveTests: XCTestCase {
+
+    override func tearDown() {
+        super.tearDown()
+        UserPreferences.walkReliquaryEnabled.delete()
+    }
+
+    /// ~111m per 0.001 degree of latitude — the same geometry
+    /// `RouteTrimmerTests` uses, spanning well past the 4x trim-distance
+    /// threshold `RouteTrimmer` requires before it will shorten a route.
+    private func longRoute(points: Int, baseDate: Date = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)) -> [TempV4.RouteDataSample] {
+        (0..<points).map { i in
+            WalkDataFactory.makeRouteDataSample(
+                timestamp: baseDate.addingTimeInterval(Double(i) * 30),
+                latitude: 48.8566 + Double(i) * 0.001,
+                longitude: 2.3522
+            )
+        }
+    }
+
+    // MARK: - Brief's authoritative tests
+
+    func testPayloadWithoutInteractiveHasNoTour() {
+        let vm = WalkShareViewModel(walk: WalkDataFactory.makeWalk())
+        let payload = vm.testBuildPayload()
+        XCTAssertNil(payload.tour)
+    }
+
+    func testInteractivePayloadCarriesTourPausesAndTrim() {
+        let walk = WalkDataFactory.makeWalk(
+            routeData: longRoute(points: 20),
+            pauses: [WalkDataFactory.makePause()],
+            voiceRecordings: [WalkDataFactory.makeVoiceRecording()]
+        )
+        let vm = WalkShareViewModel(walk: walk)
+        vm.interactiveEnabled = true
+        vm.prepareInteractive()
+        let payload = vm.testBuildPayload()
+        XCTAssertNotNil(payload.tour)
+        XCTAssertEqual(payload.tour?.trimM, 150)
+        XCTAssertNotNil(payload.pauses)
+    }
+
+    func testTrimTogglePassesZero() {
+        let walk = WalkDataFactory.makeWalk()
+        let vm = WalkShareViewModel(walk: walk)
+        vm.interactiveEnabled = true
+        vm.trimEnabled = false
+        vm.prepareInteractive()
+        XCTAssertEqual(vm.testBuildPayload().tour?.trimM, 0)
+    }
+
+    func testInteractiveAutoEnablesPhotosOnce() {
+        UserPreferences.walkReliquaryEnabled.value = true
+        let walk = WalkDataFactory.makeWalk()
+        let vm = WalkShareViewModel(walk: walk, pinnedPhotos: [PhotoCandidate.fixture()], isPhotosGranted: { true })
+        vm.interactiveEnabled = true
+        vm.prepareInteractive()
+        XCTAssertTrue(vm.includePhotos)
+        vm.includePhotos = false
+        vm.prepareInteractive()
+        XCTAssertFalse(vm.includePhotos, "auto-enable happens once; the walker's off stays off")
+    }
+
+    func testSubSecondPauseDroppedAfterTruncation() {
+        let goodPause = WalkDataFactory.makePause(
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 10, 0),
+            endDate: DateFactory.makeDate(2024, 6, 15, 9, 15, 0)
+        )
+        let blipStart = DateFactory.makeDate(2024, 6, 15, 9, 20, 0)
+        let subSecondPause = WalkDataFactory.makePause(startDate: blipStart, endDate: blipStart.addingTimeInterval(0.5))
+        let walk = WalkDataFactory.makeWalk(pauses: [goodPause, subSecondPause])
+        let vm = WalkShareViewModel(walk: walk)
+        vm.interactiveEnabled = true
+        vm.prepareInteractive()
+        let payload = vm.testBuildPayload()
+        XCTAssertEqual(payload.pauses?.count, 1, "the truncated-to-zero-length pause must be dropped, not just the good one kept")
+        XCTAssertEqual(payload.pauses?.contains(where: { $0.endTs <= $0.startTs }), false)
+    }
+
+    func testFlipKindTogglesOverride() {
+        let vm = WalkShareViewModel(walk: WalkDataFactory.makeWalk())
+        vm.tourCandidates = [TourRecordingCandidate(id: 0, startTs: 1, endTs: 2, duration: 1, sizeBytes: 1, transcription: nil, wpm: nil, autoKind: .spoken, includeInShare: true, kindOverride: nil, fileURL: nil, unavailableReason: nil)]
+        vm.flipKind(candidateID: 0)
+        XCTAssertEqual(vm.tourCandidates[0].effectiveKind, .ambient)
+        vm.flipKind(candidateID: 0)
+        XCTAssertEqual(vm.tourCandidates[0].effectiveKind, .spoken)
+    }
+
+    // MARK: - Supplementary coverage
+
+    func testToggleIncludeSkipsUnavailableCandidates() {
+        let vm = WalkShareViewModel(walk: WalkDataFactory.makeWalk())
+        let unavailable = TourRecordingCandidate(id: 0, startTs: 1, endTs: 2, duration: 1, sizeBytes: 0, transcription: nil, wpm: nil, autoKind: .spoken, includeInShare: false, kindOverride: nil, fileURL: nil, unavailableReason: "audio removed")
+        let available = TourRecordingCandidate(id: 1, startTs: 1, endTs: 2, duration: 1, sizeBytes: 100, transcription: nil, wpm: nil, autoKind: .spoken, includeInShare: true, kindOverride: nil, fileURL: URL(fileURLWithPath: "/tmp/1.m4a"), unavailableReason: nil)
+        vm.tourCandidates = [unavailable, available]
+
+        vm.toggleInclude(candidateID: 0)
+        XCTAssertFalse(vm.tourCandidates[0].includeInShare, "an unavailable candidate can never be toggled on")
+
+        vm.toggleInclude(candidateID: 1)
+        XCTAssertFalse(vm.tourCandidates[1].includeInShare)
+        vm.toggleInclude(candidateID: 1)
+        XCTAssertTrue(vm.tourCandidates[1].includeInShare)
+    }
+
+    func testCanTrimRouteReflectsRouteLength() {
+        let shortWalk = WalkDataFactory.makeWalk(routeData: longRoute(points: 4))
+        XCTAssertFalse(WalkShareViewModel(walk: shortWalk).canTrimRoute)
+
+        let longWalk = WalkDataFactory.makeWalk(routeData: longRoute(points: 20))
+        XCTAssertTrue(WalkShareViewModel(walk: longWalk).canTrimRoute)
+    }
+
+    func testNonInteractiveKeptWindowIsNil() {
+        let vm = WalkShareViewModel(walk: WalkDataFactory.makeWalk(routeData: longRoute(points: 20)))
+        XCTAssertNil(vm.interactiveKeptWindow())
+    }
+
+    func testInteractiveKeptWindowExcludesTrimmedWaypoints() {
+        let route = longRoute(points: 20)
+        let doorstep = TempV4.Waypoint(uuid: nil, latitude: 48.8566, longitude: 2.3522, label: "Doorstep", icon: "flag", timestamp: route[0].timestamp)
+        let midpoint = TempV4.Waypoint(uuid: nil, latitude: 48.87, longitude: 2.3522, label: "Midpoint", icon: "flag", timestamp: route[10].timestamp)
+        let walk = WalkDataFactory.makeWalk(routeData: route, waypoints: [doorstep, midpoint])
+        let vm = WalkShareViewModel(walk: walk)
+        vm.interactiveEnabled = true
+        vm.includeWaypoints = true
+        vm.prepareInteractive()
+
+        XCTAssertNotNil(vm.interactiveKeptWindow())
+
+        let labels = vm.testBuildPayload().waypoints?.map(\.label) ?? []
+        XCTAssertFalse(labels.contains("Doorstep"), "trim excludes waypoints outside the kept route window")
+        XCTAssertTrue(labels.contains("Midpoint"), "waypoints inside the kept window still ride along")
+    }
+
+    func testInteractivePhotoMetaUsesOnlyExportedPhotos() {
+        UserPreferences.walkReliquaryEnabled.value = true
+        let walk = WalkDataFactory.makeWalk()
+        let vm = WalkShareViewModel(walk: walk, pinnedPhotos: [PhotoCandidate.fixture()], isPhotosGranted: { true })
+        vm.interactiveEnabled = true
+        vm.includePhotos = true
+        vm.prepareInteractive()
+
+        let exported = [SharePayload.Photo(lat: 1, lon: 2, ts: 999, data: nil)]
+        let withExport = vm.testBuildPayload(tourPhotoMeta: exported)
+        XCTAssertEqual(withExport.photos?.count, 1)
+        XCTAssertEqual(withExport.photos?.first?.ts, 999, "metadata must come from the export, not from pinnedPhotos")
+
+        let withoutExport = vm.testBuildPayload(tourPhotoMeta: [])
+        XCTAssertNil(withoutExport.photos, "the interactive branch must never fall back to mapping pinnedPhotos")
+    }
+}

--- a/UnitTests/WalkShareInteractiveTests.swift
+++ b/UnitTests/WalkShareInteractiveTests.swift
@@ -9,9 +9,7 @@ final class WalkShareInteractiveTests: XCTestCase {
         UserPreferences.walkReliquaryEnabled.delete()
     }
 
-    /// ~111m per 0.001 degree of latitude — the same geometry
-    /// `RouteTrimmerTests` uses, spanning well past the 4x trim-distance
-    /// threshold `RouteTrimmer` requires before it will shorten a route.
+    /// ~111m per 0.001 degree of latitude — the same geometry `RouteTrimmerTests` uses, spanning well past the 4x trim-distance threshold `RouteTrimmer` requires before it will shorten a route.
     private func longRoute(points: Int, baseDate: Date = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)) -> [TempV4.RouteDataSample] {
         (0..<points).map { i in
             WalkDataFactory.makeRouteDataSample(
@@ -92,6 +90,40 @@ final class WalkShareInteractiveTests: XCTestCase {
         XCTAssertEqual(vm.tourCandidates[0].effectiveKind, .spoken)
     }
 
+    // MARK: - Review finding #17: excluded recordings leave no trace
+
+    func testExcludedRecordingLeavesNoTalkInterval() {
+        let keptCandidate = TourRecordingCandidate(id: 0, startTs: 1000, endTs: 1060, duration: 60, sizeBytes: 1_000_000, transcription: nil, wpm: nil, autoKind: .spoken, includeInShare: true, kindOverride: nil, fileURL: URL(fileURLWithPath: "/tmp/0.m4a"), unavailableReason: nil)
+        let excludedCandidate = TourRecordingCandidate(id: 1, startTs: 2000, endTs: 2090, duration: 90, sizeBytes: 1_500_000, transcription: nil, wpm: nil, autoKind: .spoken, includeInShare: true, kindOverride: nil, fileURL: URL(fileURLWithPath: "/tmp/1.m4a"), unavailableReason: nil)
+        let vm = WalkShareViewModel(walk: WalkDataFactory.makeWalk())
+        vm.tourCandidates = [keptCandidate, excludedCandidate]
+        vm.interactiveEnabled = true
+        vm.toggleInclude(candidateID: excludedCandidate.id)
+        let payload = vm.testBuildPayload()
+        let talkIntervals = payload.activityIntervals.filter { $0.type == "talk" }
+        XCTAssertEqual(talkIntervals.count, 1, "the excluded candidate's talk interval must not appear")
+        XCTAssertEqual(talkIntervals.first?.startTs, keptCandidate.startTs)
+        XCTAssertEqual(talkIntervals.first?.endTs, keptCandidate.endTs)
+        XCTAssertEqual(payload.stats.talkDuration, keptCandidate.duration, "excluded duration must not count toward the total")
+    }
+
+    func testClassicTalkIntervalsUnchangedByExclusions() {
+        let rec1 = WalkDataFactory.makeVoiceRecording(startDate: DateFactory.makeDate(2024, 6, 15, 9, 5, 0), endDate: DateFactory.makeDate(2024, 6, 15, 9, 6, 0), duration: 60)
+        let rec2 = WalkDataFactory.makeVoiceRecording(startDate: DateFactory.makeDate(2024, 6, 15, 9, 10, 0), endDate: DateFactory.makeDate(2024, 6, 15, 9, 11, 30), duration: 90)
+        let walk = WalkDataFactory.makeWalk(talkDuration: 999, voiceRecordings: [rec1, rec2])
+        let vm = WalkShareViewModel(walk: walk)
+        // interactiveEnabled left false — classic share must ignore tourCandidates exclusions entirely.
+        vm.tourCandidates = [rec1, rec2].enumerated().map { i, rec in
+            TourRecordingCandidate(id: i, startTs: Int(rec.startDate.timeIntervalSince1970), endTs: Int(rec.endDate.timeIntervalSince1970), duration: rec.duration, sizeBytes: 1_000_000, transcription: nil, wpm: nil, autoKind: .spoken, includeInShare: true, kindOverride: nil, fileURL: nil, unavailableReason: nil)
+        }
+        vm.toggleInclude(candidateID: 1)
+        let payload = vm.testBuildPayload()
+        let talkIntervals = payload.activityIntervals.filter { $0.type == "talk" }
+        XCTAssertEqual(talkIntervals.count, 2, "classic path reads walk.voiceRecordings directly — candidate exclusions must have zero effect")
+        XCTAssertEqual(talkIntervals.map(\.startTs).sorted(), [rec1, rec2].map { Int($0.startDate.timeIntervalSince1970) }.sorted())
+        XCTAssertEqual(payload.stats.talkDuration, walk.talkDuration)
+    }
+
     // MARK: - Supplementary coverage
 
     func testToggleIncludeSkipsUnavailableCandidates() {
@@ -110,9 +142,7 @@ final class WalkShareInteractiveTests: XCTestCase {
     }
 
     func testInteractivePayloadJSONContainsNoTranscription() throws {
-        // Guards the whole payload path, not just TourBuilder.tourItems: even
-        // an offerable, transcript-bearing candidate must never put the
-        // transcript's text — or the "transcription" key itself — on the wire.
+        // Guards the whole payload path, not just TourBuilder.tourItems: even an offerable, transcript-bearing candidate must never put the transcript's text — or the "transcription" key itself — on the wire.
         let vm = WalkShareViewModel(walk: WalkDataFactory.makeWalk())
         vm.tourCandidates = [
             TourRecordingCandidate(id: 0, startTs: 1000, endTs: 1060, duration: 60, sizeBytes: 1_000_000, transcription: "some real speech", wpm: 120, autoKind: .spoken, includeInShare: true, kindOverride: nil, fileURL: URL(fileURLWithPath: "/tmp/0.m4a"), unavailableReason: nil)
@@ -350,23 +380,14 @@ final class WalkShareInteractiveTests: XCTestCase {
     // MARK: - resolveRetryItems (pure identity resolution)
 
     func testResolveRetryItemsMatchesPhotoByIdentityNotIndex() {
-        // Cached failure says n=1 for "photo-B" (captured at ts 500). In the
-        // CURRENT export, photo-B sits at array position 1 (index 1), not 0
-        // — an export-order shift. A naive index-based lookup
-        // (currentPhotos[n-1] == currentPhotos[0]) would grab photo-A's
-        // bytes instead and upload them under photo-B's old slot.
+        // Cached failure says n=1 for "photo-B" (captured at ts 500). In the CURRENT export, photo-B sits at array position 1 (index 1), not 0 — an export-order shift. A naive index-based lookup (currentPhotos[n-1] == currentPhotos[0]) would grab photo-A's bytes instead and upload them under photo-B's old slot.
         let cached = [ShareService.FailedMediaItem(kind: "photos", n: 1, audioStartTs: nil, photoLocalID: "photo-B", photoTs: 500)]
         let photos = [
             TourPhoto(meta: SharePayload.Photo(lat: 0, lon: 0, ts: 100, data: nil), jpegData: Data([0xAA]), sourceLocalIdentifier: "photo-A"),
             TourPhoto(meta: SharePayload.Photo(lat: 1, lon: 2, ts: 500, data: nil), jpegData: Data([0xBB]), sourceLocalIdentifier: "photo-B")
         ]
 
-        let (uploadable, remaining) = WalkShareViewModel.resolveRetryItems(
-            cached: cached,
-            currentRecordings: [],
-            currentAudioFiles: [],
-            currentPhotos: photos
-        )
+        let (uploadable, remaining) = WalkShareViewModel.resolveRetryItems(cached: cached, currentRecordings: [], currentAudioFiles: [], currentPhotos: photos)
 
         XCTAssertTrue(remaining.isEmpty)
         guard let resolved = uploadable.first else { return XCTFail("expected photo-B to resolve by identity") }
@@ -375,17 +396,11 @@ final class WalkShareInteractiveTests: XCTestCase {
     }
 
     func testResolveRetryItemsPhotoMissingIdentityGoesToRemaining() {
-        // "photo-gone" was unpinned between the original share and this retry
-        // — it no longer appears anywhere in the current export.
+        // "photo-gone" was unpinned between the original share and this retry — it no longer appears anywhere in the current export.
         let cached = [ShareService.FailedMediaItem(kind: "photos", n: 1, audioStartTs: nil, photoLocalID: "photo-gone", photoTs: 500)]
         let photos = [TourPhoto(meta: SharePayload.Photo(lat: 0, lon: 0, ts: 999, data: nil), jpegData: Data([0xAA]), sourceLocalIdentifier: "photo-other")]
 
-        let (uploadable, remaining) = WalkShareViewModel.resolveRetryItems(
-            cached: cached,
-            currentRecordings: [],
-            currentAudioFiles: [],
-            currentPhotos: photos
-        )
+        let (uploadable, remaining) = WalkShareViewModel.resolveRetryItems(cached: cached, currentRecordings: [], currentAudioFiles: [], currentPhotos: photos)
 
         XCTAssertTrue(uploadable.isEmpty)
         XCTAssertEqual(remaining, cached, "an unresolved item must be carried forward unchanged, not dropped")
@@ -394,21 +409,14 @@ final class WalkShareInteractiveTests: XCTestCase {
     func testResolveRetryItemsUnrecognizedKindGoesToRemaining() {
         let cached = [ShareService.FailedMediaItem(kind: "video", n: 1, audioStartTs: nil, photoLocalID: nil, photoTs: nil)]
 
-        let (uploadable, remaining) = WalkShareViewModel.resolveRetryItems(
-            cached: cached,
-            currentRecordings: [],
-            currentAudioFiles: [],
-            currentPhotos: []
-        )
+        let (uploadable, remaining) = WalkShareViewModel.resolveRetryItems(cached: cached, currentRecordings: [], currentAudioFiles: [], currentPhotos: [])
 
         XCTAssertTrue(uploadable.isEmpty)
         XCTAssertEqual(remaining, cached, "a kind this build no longer recognizes must be carried forward, not dropped or crashed on")
     }
 
     func testResolveRetryItemsAudioStartTsMismatchGoesToRemaining() {
-        // The cached startTs (100) is absent from EVERY current recording —
-        // not just shifted position, but genuinely gone. Two recordings (not
-        // one) so this can't accidentally pass just because index 0 mismatches.
+        // The cached startTs (100) is absent from EVERY current recording — not just shifted position, but genuinely gone. Two recordings (not one) so this can't accidentally pass just because index 0 mismatches.
         let cached = [ShareService.FailedMediaItem(kind: "audio", n: 1, audioStartTs: 100, photoLocalID: nil, photoTs: nil)]
         let recordings = [
             SharePayload.TourRecording(n: 1, startTs: 200, endTs: 260, duration: 60, kind: "spoken", transcription: nil, wpm: nil, sizeBytes: 1_000),
@@ -416,22 +424,14 @@ final class WalkShareInteractiveTests: XCTestCase {
         ]
         let audioFiles = [URL(fileURLWithPath: "/tmp/audio1.m4a"), URL(fileURLWithPath: "/tmp/audio2.m4a")]
 
-        let (uploadable, remaining) = WalkShareViewModel.resolveRetryItems(
-            cached: cached,
-            currentRecordings: recordings,
-            currentAudioFiles: audioFiles,
-            currentPhotos: []
-        )
+        let (uploadable, remaining) = WalkShareViewModel.resolveRetryItems(cached: cached, currentRecordings: recordings, currentAudioFiles: audioFiles, currentPhotos: [])
 
         XCTAssertTrue(uploadable.isEmpty)
         XCTAssertEqual(remaining, cached)
     }
 
     func testResolveRetryItemsAudioFoundAtShiftedIndex() {
-        // The cached failure originally pointed at slot n=3, whose recording
-        // had startTs 500. Since then an earlier recording dropped out of the
-        // candidate set, so that SAME recording (still startTs 500) now sits
-        // at index 0 — an index-locked lookup (index 2) would miss it entirely.
+        // The cached failure originally pointed at slot n=3, whose recording had startTs 500. Since then an earlier recording dropped out of the candidate set, so that SAME recording (still startTs 500) now sits at index 0 — an index-locked lookup (index 2) would miss it entirely.
         let cached = [ShareService.FailedMediaItem(kind: "audio", n: 3, audioStartTs: 500, photoLocalID: nil, photoTs: nil)]
         let recordings = [
             SharePayload.TourRecording(n: 1, startTs: 500, endTs: 560, duration: 60, kind: "spoken", transcription: nil, wpm: nil, sizeBytes: 1_000),
@@ -439,12 +439,7 @@ final class WalkShareInteractiveTests: XCTestCase {
         ]
         let audioFiles = [URL(fileURLWithPath: "/tmp/shifted-0.m4a"), URL(fileURLWithPath: "/tmp/shifted-1.m4a")]
 
-        let (uploadable, remaining) = WalkShareViewModel.resolveRetryItems(
-            cached: cached,
-            currentRecordings: recordings,
-            currentAudioFiles: audioFiles,
-            currentPhotos: []
-        )
+        let (uploadable, remaining) = WalkShareViewModel.resolveRetryItems(cached: cached, currentRecordings: recordings, currentAudioFiles: audioFiles, currentPhotos: [])
 
         XCTAssertTrue(remaining.isEmpty)
         XCTAssertEqual(uploadable.first?.n, 3, "must upload under the CACHED slot n, not the recording's shifted array position")
@@ -456,12 +451,7 @@ final class WalkShareInteractiveTests: XCTestCase {
         let recordings = [SharePayload.TourRecording(n: 1, startTs: 100, endTs: 160, duration: 60, kind: "spoken", transcription: nil, wpm: nil, sizeBytes: 1_000)]
         let fileURL = URL(fileURLWithPath: "/tmp/audio1.m4a")
 
-        let (uploadable, remaining) = WalkShareViewModel.resolveRetryItems(
-            cached: cached,
-            currentRecordings: recordings,
-            currentAudioFiles: [fileURL],
-            currentPhotos: []
-        )
+        let (uploadable, remaining) = WalkShareViewModel.resolveRetryItems(cached: cached, currentRecordings: recordings, currentAudioFiles: [fileURL], currentPhotos: [])
 
         XCTAssertTrue(remaining.isEmpty)
         XCTAssertEqual(uploadable.first?.n, 1)

--- a/UnitTests/WalkShareInteractiveTests.swift
+++ b/UnitTests/WalkShareInteractiveTests.swift
@@ -206,6 +206,7 @@ final class WalkShareInteractiveTests: XCTestCase {
 
     func testPartialAndSuccessBothCountAsShared() {
         let successID = UUID()
+        addTeardownBlock { UserDefaults.standard.removeObject(forKey: "share:\(successID.uuidString)") }
         let successWalk = WalkDataFactory.makeWalk(uuid: successID)
         ShareService.cacheShare(
             ShareService.ShareResult(url: "https://walk.pilgrimapp.org/success1", id: "success1"),
@@ -220,6 +221,10 @@ final class WalkShareInteractiveTests: XCTestCase {
         }
 
         let partialID = UUID()
+        addTeardownBlock {
+            UserDefaults.standard.removeObject(forKey: "share:\(partialID.uuidString)")
+            ShareService.cacheFailedMedia([], walkID: partialID)
+        }
         let partialWalk = WalkDataFactory.makeWalk(uuid: partialID)
         ShareService.cacheShare(
             ShareService.ShareResult(url: "https://walk.pilgrimapp.org/partial1", id: "partial1"),
@@ -227,14 +232,94 @@ final class WalkShareInteractiveTests: XCTestCase {
             expiryDays: 90,
             expiryOption: "season"
         )
-        ShareService.cacheFailedMedia([(kind: .audio, n: 1)], walkID: partialID)
+        ShareService.cacheFailedMedia(
+            [ShareService.FailedMediaItem(kind: "audio", n: 1, audioStartTs: 100, photoLocalID: nil, photoTs: nil)],
+            walkID: partialID
+        )
         let partialVM = WalkShareViewModel(walk: partialWalk)
         XCTAssertTrue(partialVM.isShared, ".partial must count as shared — the page is already live")
         guard case .partial(_, let failedCount) = partialVM.shareState else {
             return XCTFail("expected .partial when media failed")
         }
         XCTAssertEqual(failedCount, 1)
+    }
 
-        ShareService.cacheFailedMedia([], walkID: partialID)
+    // MARK: - resolveRetryItems (pure identity resolution)
+
+    func testResolveRetryItemsMatchesPhotoByIdentityNotIndex() {
+        // Cached failure says n=1 for "photo-B" (captured at ts 500). In the
+        // CURRENT export, photo-B sits at array position 1 (index 1), not 0
+        // — an export-order shift. A naive index-based lookup
+        // (currentPhotos[n-1] == currentPhotos[0]) would grab photo-A's
+        // bytes instead and upload them under photo-B's old slot.
+        let cached = [ShareService.FailedMediaItem(kind: "photos", n: 1, audioStartTs: nil, photoLocalID: "photo-B", photoTs: 500)]
+        let photos = [
+            TourPhoto(meta: SharePayload.Photo(lat: 0, lon: 0, ts: 100, data: nil), jpegData: Data([0xAA]), sourceLocalIdentifier: "photo-A"),
+            TourPhoto(meta: SharePayload.Photo(lat: 1, lon: 2, ts: 500, data: nil), jpegData: Data([0xBB]), sourceLocalIdentifier: "photo-B")
+        ]
+
+        let (uploadable, remaining) = WalkShareViewModel.resolveRetryItems(
+            cached: cached,
+            currentRecordings: [],
+            currentAudioFiles: [],
+            currentPhotos: photos
+        )
+
+        XCTAssertTrue(remaining.isEmpty)
+        guard let resolved = uploadable.first else { return XCTFail("expected photo-B to resolve by identity") }
+        XCTAssertEqual(resolved.n, 1, "must upload under the CACHED slot n, not photo-B's current array position")
+        XCTAssertEqual(try? resolved.data(), Data([0xBB]), "must upload photo-B's bytes (matched by identity), never photo-A's (which sat at the naive index)")
+    }
+
+    func testResolveRetryItemsPhotoMissingIdentityGoesToRemaining() {
+        // "photo-gone" was unpinned between the original share and this retry
+        // — it no longer appears anywhere in the current export.
+        let cached = [ShareService.FailedMediaItem(kind: "photos", n: 1, audioStartTs: nil, photoLocalID: "photo-gone", photoTs: 500)]
+        let photos = [TourPhoto(meta: SharePayload.Photo(lat: 0, lon: 0, ts: 999, data: nil), jpegData: Data([0xAA]), sourceLocalIdentifier: "photo-other")]
+
+        let (uploadable, remaining) = WalkShareViewModel.resolveRetryItems(
+            cached: cached,
+            currentRecordings: [],
+            currentAudioFiles: [],
+            currentPhotos: photos
+        )
+
+        XCTAssertTrue(uploadable.isEmpty)
+        XCTAssertEqual(remaining, cached, "an unresolved item must be carried forward unchanged, not dropped")
+    }
+
+    func testResolveRetryItemsAudioStartTsMismatchGoesToRemaining() {
+        // recordings[0] is now a DIFFERENT recording (startTs 200, not the
+        // cached 100) — the candidate set shifted since the original share.
+        let cached = [ShareService.FailedMediaItem(kind: "audio", n: 1, audioStartTs: 100, photoLocalID: nil, photoTs: nil)]
+        let recordings = [SharePayload.TourRecording(n: 1, startTs: 200, endTs: 260, duration: 60, kind: "spoken", transcription: nil, wpm: nil, sizeBytes: 1_000)]
+        let audioFiles = [URL(fileURLWithPath: "/tmp/audio1.m4a")]
+
+        let (uploadable, remaining) = WalkShareViewModel.resolveRetryItems(
+            cached: cached,
+            currentRecordings: recordings,
+            currentAudioFiles: audioFiles,
+            currentPhotos: []
+        )
+
+        XCTAssertTrue(uploadable.isEmpty)
+        XCTAssertEqual(remaining, cached)
+    }
+
+    func testResolveRetryItemsAudioMatchesWhenStartTsAgrees() {
+        let cached = [ShareService.FailedMediaItem(kind: "audio", n: 1, audioStartTs: 100, photoLocalID: nil, photoTs: nil)]
+        let recordings = [SharePayload.TourRecording(n: 1, startTs: 100, endTs: 160, duration: 60, kind: "spoken", transcription: nil, wpm: nil, sizeBytes: 1_000)]
+        let fileURL = URL(fileURLWithPath: "/tmp/audio1.m4a")
+
+        let (uploadable, remaining) = WalkShareViewModel.resolveRetryItems(
+            cached: cached,
+            currentRecordings: recordings,
+            currentAudioFiles: [fileURL],
+            currentPhotos: []
+        )
+
+        XCTAssertTrue(remaining.isEmpty)
+        XCTAssertEqual(uploadable.first?.n, 1)
+        XCTAssertEqual(uploadable.first?.kind, .audio)
     }
 }

--- a/UnitTests/WalkShareInteractiveTests.swift
+++ b/UnitTests/WalkShareInteractiveTests.swift
@@ -109,6 +109,24 @@ final class WalkShareInteractiveTests: XCTestCase {
         XCTAssertTrue(vm.tourCandidates[1].includeInShare)
     }
 
+    func testInteractivePayloadJSONContainsNoTranscription() throws {
+        // Guards the whole payload path, not just TourBuilder.tourItems: even
+        // an offerable, transcript-bearing candidate must never put the
+        // transcript's text — or the "transcription" key itself — on the wire.
+        let vm = WalkShareViewModel(walk: WalkDataFactory.makeWalk())
+        vm.tourCandidates = [
+            TourRecordingCandidate(id: 0, startTs: 1000, endTs: 1060, duration: 60, sizeBytes: 1_000_000, transcription: "some real speech", wpm: 120, autoKind: .spoken, includeInShare: true, kindOverride: nil, fileURL: URL(fileURLWithPath: "/tmp/0.m4a"), unavailableReason: nil)
+        ]
+        vm.interactiveEnabled = true
+        vm.prepareInteractive()
+
+        let data = try JSONEncoder().encode(vm.testBuildPayload())
+        let json = try XCTUnwrap(String(data: data, encoding: .utf8))
+
+        XCTAssertFalse(json.contains("some real speech"), "transcript content must never leave the device")
+        XCTAssertFalse(json.contains("transcription"), "the transcription key itself must never appear in the payload")
+    }
+
     func testCanTrimRouteReflectsRouteLength() {
         let shortWalk = WalkDataFactory.makeWalk(routeData: longRoute(points: 4))
         XCTAssertFalse(WalkShareViewModel(walk: shortWalk).canTrimRoute)

--- a/UnitTests/WalkShareInteractiveTests.swift
+++ b/UnitTests/WalkShareInteractiveTests.swift
@@ -28,6 +28,7 @@ final class WalkShareInteractiveTests: XCTestCase {
         let vm = WalkShareViewModel(walk: WalkDataFactory.makeWalk())
         let payload = vm.testBuildPayload()
         XCTAssertNil(payload.tour)
+        XCTAssertNil(payload.pauses)
     }
 
     func testInteractivePayloadCarriesTourPausesAndTrim() {
@@ -136,6 +137,25 @@ final class WalkShareInteractiveTests: XCTestCase {
         let labels = vm.testBuildPayload().waypoints?.map(\.label) ?? []
         XCTAssertFalse(labels.contains("Doorstep"), "trim excludes waypoints outside the kept route window")
         XCTAssertTrue(labels.contains("Midpoint"), "waypoints inside the kept window still ride along")
+    }
+
+    func testInteractiveKeptWindowIncludesWaypointsAtExactBoundary() {
+        let route = longRoute(points: 20)
+        let routePoints = route.map {
+            SharePayload.RoutePoint(lat: $0.latitude, lon: $0.longitude, alt: $0.altitude, ts: Int($0.timestamp.timeIntervalSince1970))
+        }
+        let trimmed = RouteTrimmer.trim(routePoints, meters: Double(WalkShareViewModel.trimMeters))
+        let atLowerBound = TempV4.Waypoint(uuid: nil, latitude: 48.86, longitude: 2.3522, label: "AtLowerBound", icon: "flag", timestamp: Date(timeIntervalSince1970: Double(trimmed.first!.ts)))
+        let atUpperBound = TempV4.Waypoint(uuid: nil, latitude: 48.86, longitude: 2.3522, label: "AtUpperBound", icon: "flag", timestamp: Date(timeIntervalSince1970: Double(trimmed.last!.ts)))
+        let walk = WalkDataFactory.makeWalk(routeData: route, waypoints: [atLowerBound, atUpperBound])
+        let vm = WalkShareViewModel(walk: walk)
+        vm.interactiveEnabled = true
+        vm.includeWaypoints = true
+        vm.prepareInteractive()
+
+        let labels = vm.testBuildPayload().waypoints?.map(\.label) ?? []
+        XCTAssertTrue(labels.contains("AtLowerBound"), "a waypoint exactly at the kept window's lower bound must be included — ClosedRange.contains is inclusive")
+        XCTAssertTrue(labels.contains("AtUpperBound"), "a waypoint exactly at the kept window's upper bound must be included — ClosedRange.contains is inclusive")
     }
 
     func testInteractivePhotoMetaUsesOnlyExportedPhotos() {

--- a/UnitTests/WalkShareInteractiveTests.swift
+++ b/UnitTests/WalkShareInteractiveTests.swift
@@ -487,4 +487,14 @@ final class WalkShareInteractiveTests: XCTestCase {
         XCTAssertEqual(records[2].photoLocalID, "photo-1")
         XCTAssertEqual(records[2].photoTs, 999)
     }
+
+    // MARK: - Fix #11: dropped-photo consent moment
+    // (testPhotosDroppedCountsAsInFlightForFormFreeze omitted: `isShareInFlight` is `private` on `WalkShareView`, not VM-exposed — nothing here to assert against.)
+
+    func testCancelDroppedPhotoShareReturnsToIdle() {
+        let vm = WalkShareViewModel(walk: WalkDataFactory.makeWalk())
+        vm.shareState = .photosDropped(prepared: 2, dropped: 1)
+        vm.cancelDroppedPhotoShare()
+        XCTAssertEqual(vm.shareState, .idle)
+    }
 }

--- a/docs/superpowers/plans/2026-08-11-walk-with-me-tour-ios.md
+++ b/docs/superpowers/plans/2026-08-11-walk-with-me-tour-ios.md
@@ -551,7 +551,8 @@ enum TourPhotoExporter {
 // cancels the UNDERLYING Photos request, so wall-clock is genuinely bounded —
 // a task-group race cannot bound it because withTaskGroup awaits cancelled
 // children and PHImageManager fetches are not cancellation-aware. (Amended
-// during implementation; empirically verified 1s deadline → 1.009s elapsed.)
+// during implementation; mechanism verified via synthetic probes — real-device
+// PhotoKit behavior still needs the Task 9 / hardware pass.)
 ```
 
 - [ ] **Step 1: Write the failing test**

--- a/docs/superpowers/plans/2026-08-11-walk-with-me-tour-ios.md
+++ b/docs/superpowers/plans/2026-08-11-walk-with-me-tour-ios.md
@@ -31,7 +31,7 @@
 - Consumes: nothing new.
 - Produces: `SharePayload.Tour`, `SharePayload.TourRecording`, `SharePayload.Pause`, `SharePayload.Photo.data: String?`, `SharePayload.tour: Tour?`, `SharePayload.pauses: [Pause]?` — exact shapes below; Tasks 2/6 build these.
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```swift
 import XCTest
@@ -108,12 +108,12 @@ final class SharePayloadTourTests: XCTestCase {
 }
 ```
 
-- [ ] **Step 2: Run to verify failure**
+- [x] **Step 2: Run to verify failure**
 
 Run: `xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/SharePayloadTourTests`
 Expected: FAIL — `Tour`, `Pause` types don't exist; `Photo.data` is non-optional.
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 In `SharePayload.swift`:
 
@@ -161,8 +161,8 @@ Change `Photo.data` to `let data: String?`, add `var tour: Tour? = nil` and `var
 
 The one existing `Photo(...)` construction site (`WalkShareViewModel.loadSharePhoto`) passes `data:` explicitly, so the optional change compiles without edits there.
 
-- [ ] **Step 4: Run tests to verify pass** (same command)
-- [ ] **Step 5: Commit** — `feat(share): payload learns tour, pauses, and PUT-uploaded photos`
+- [x] **Step 4: Run tests to verify pass** (same command)
+- [x] **Step 5: Commit** — `feat(share): payload learns tour, pauses, and PUT-uploaded photos`
 
 ---
 
@@ -207,7 +207,7 @@ enum TourBuilder {
 
 Caps as constants: `maxRecordings = 12`, `maxFileBytes = 15 * 1024 * 1024`, `maxTotalBytes = 60 * 1024 * 1024`, `maxTotalSeconds: Double = 2700`.
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```swift
 import XCTest
@@ -294,9 +294,9 @@ final class TourBuilderTests: XCTestCase {
 }
 ```
 
-- [ ] **Step 2: Run to verify failure** (`-only-testing:UnitTests/TourBuilderTests`)
+- [x] **Step 2: Run to verify failure** (`-only-testing:UnitTests/TourBuilderTests`)
 
-- [ ] **Step 3: Implement `TourBuilder.swift`**
+- [x] **Step 3: Implement `TourBuilder.swift`**
 
 ```swift
 import Foundation
@@ -415,8 +415,8 @@ enum TourBuilder {
 
 Note `transcription: nil` in the payload: the page never renders transcripts and omitting them keeps the POST body small (transcripts of a 45-minute walk approach the 2 MB payload cap).
 
-- [ ] **Step 4: Run tests to verify pass**
-- [ ] **Step 5: Commit** — `feat(share): TourBuilder classifies, caps, and renumbers recordings`
+- [x] **Step 4: Run tests to verify pass**
+- [x] **Step 5: Commit** — `feat(share): TourBuilder classifies, caps, and renumbers recordings`
 
 ---
 
@@ -429,7 +429,7 @@ Note `transcription: nil` in the payload: the page never renders transcripts and
 **Interfaces:**
 - Produces: `RouteTrimmer.trim(_:meters:)` and `RouteTrimmer.canTrim(_ route: [SharePayload.RoutePoint], meters: Double) -> Bool` — `canTrim` is the UI's honesty check (Task 7 disables the toggle and says so when trimming cannot apply) — used by Task 6. Trims cumulative haversine distance from each end; always returns at least the innermost 2 points when the route is long enough to trim, and returns the route unchanged when `meters <= 0` or total distance `< 4 * meters` (a walk too short to trim meaningfully shares untrimmed — matches the spec's "trim is a courtesy, not a guarantee").
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```swift
 import XCTest
@@ -470,9 +470,9 @@ final class RouteTrimmerTests: XCTestCase {
 }
 ```
 
-- [ ] **Step 2: Run to verify failure**
+- [x] **Step 2: Run to verify failure**
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 ```swift
 import Foundation
@@ -520,8 +520,8 @@ enum RouteTrimmer {
 }
 ```
 
-- [ ] **Step 4: Run tests to verify pass**
-- [ ] **Step 5: Commit** — `feat(share): RouteTrimmer keeps doorsteps off shared pages`
+- [x] **Step 4: Run tests to verify pass**
+- [x] **Step 5: Commit** — `feat(share): RouteTrimmer keeps doorsteps off shared pages`
 
 ---
 
@@ -555,7 +555,7 @@ enum TourPhotoExporter {
 // PhotoKit behavior still needs the Task 9 / hardware pass.)
 ```
 
-- [ ] **Step 1: Write the failing test**
+- [x] **Step 1: Write the failing test**
 
 ```swift
 import XCTest
@@ -587,9 +587,9 @@ final class TourPhotoExporterTests: XCTestCase {
 }
 ```
 
-- [ ] **Step 2: Run to verify failure**
+- [x] **Step 2: Run to verify failure**
 
-- [ ] **Step 3: Implement**
+- [x] **Step 3: Implement**
 
 ```swift
 import Photos
@@ -683,8 +683,8 @@ enum TourPhotoExporter {
 
 Notes: `isNetworkAccessAllowed = true` (unlike the classic 600px path) because interactive shares are deliberate enough to wait for iCloud originals; the whole export runs on a background queue — never on main (resource-safety rule).
 
-- [ ] **Step 4: Run tests to verify pass**
-- [ ] **Step 5: Commit** — `feat(share): hi-res tour photo export with 2MB quality ladder`
+- [x] **Step 4: Run tests to verify pass**
+- [x] **Step 5: Commit** — `feat(share): hi-res tour photo export with 2MB quality ladder`
 
 ---
 
@@ -742,7 +742,7 @@ Internally, one requestable unit — injectable for tests:
 static func mediaUploadRequest(shareID: String, kind: MediaKind, n: Int, contentLength: Int) -> URLRequest
 ```
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 ```swift
 import XCTest
@@ -767,9 +767,9 @@ final class ShareMediaUploadTests: XCTestCase {
 }
 ```
 
-- [ ] **Step 2: Run to verify failure**
+- [x] **Step 2: Run to verify failure**
 
-- [ ] **Step 3: Implement** in `ShareService.swift` (add `import UIKit` for the background-task assertion):
+- [x] **Step 3: Implement** in `ShareService.swift` (add `import UIKit` for the background-task assertion):
 
 ```swift
 // MARK: - Interactive media uploads
@@ -899,8 +899,8 @@ extension ShareService {
 
 Make the existing `private static let baseURL` and `private static func deviceToken()` accessible to the extension (same file — already fine).
 
-- [ ] **Step 4: Run tests to verify pass**
-- [ ] **Step 5: Commit** — `feat(share): sequential media PUTs with per-file retry and progress`
+- [x] **Step 4: Run tests to verify pass**
+- [x] **Step 5: Commit** — `feat(share): sequential media PUTs with per-file retry and progress`
 
 ---
 
@@ -927,7 +927,7 @@ func flipKind(candidateID: Int)
 static let trimMeters = 150
 ```
 
-- [ ] **Step 1: Write the failing tests**
+- [x] **Step 1: Write the failing tests**
 
 Use `WalkDataFactory` (existing fixtures) to make a walk with voice recordings and pauses. If the factory lacks a recordings-capable maker, extend the test with the factory's existing `makeVoiceRecording`/`makeWalk` helpers (check `UnitTests/Support/` for the factory before writing; follow its patterns exactly).
 
@@ -996,9 +996,9 @@ final class WalkShareInteractiveTests: XCTestCase {
 
 Expose `func testBuildPayload() -> SharePayload` as an internal passthrough to `buildPayload(placeStart:placeEnd:)` guarded by `#if DEBUG` if needed (tests import `@testable`, so plain `internal` suffices — just drop the `private` on `buildPayload` instead; simplest and honest).
 
-- [ ] **Step 2: Run to verify failure**
+- [x] **Step 2: Run to verify failure**
 
-- [ ] **Step 3: Implement in the view model**
+- [x] **Step 3: Implement in the view model**
 
 ```swift
 @Published var interactiveEnabled = false
@@ -1114,8 +1114,8 @@ let photoPayload: [SharePayload.Photo]? = {
 
 (Check `walk.pauses` element type for the exact date property names — `WalkPauseInterface` — and adjust `startDate/endDate` accessors to what the interface actually exposes before writing; the factory tests will catch a mismatch.)
 
-- [ ] **Step 4: Run tests to verify pass**
-- [ ] **Step 5: Commit** — `feat(share): view model builds interactive payloads — tour, pauses, trim, hi-res photo metadata`
+- [x] **Step 4: Run tests to verify pass**
+- [x] **Step 5: Commit** — `feat(share): view model builds interactive payloads — tour, pauses, trim, hi-res photo metadata`
 
 ---
 
@@ -1129,9 +1129,9 @@ let photoPayload: [SharePayload.Photo]? = {
 - Consumes: Task 6's published state.
 - Produces: UI only.
 
-- [ ] **Step 0: Demo recordings get real audio** — the seeder creates recording rows pointing at `demo/recording-N.m4a` but writes no files, so every later visual/E2E check would show "No recordings on this walk." Extend `ScreenshotDataSeeder` (DEBUG/demo-mode only): when seeding voice recordings, copy any short bundled `.m4a` asset into `Documents/demo/recording-<n>.m4a` via FileManager if absent, so `TourBuilder.candidates(for:)` resolves real files with nonzero sizes. Commit: `chore(demo): demo recordings carry real audio files`.
+- [x] **Step 0: Demo recordings get real audio** — the seeder creates recording rows pointing at `demo/recording-N.m4a` but writes no files, so every later visual/E2E check would show "No recordings on this walk." Extend `ScreenshotDataSeeder` (DEBUG/demo-mode only): when seeding voice recordings, copy any short bundled `.m4a` asset into `Documents/demo/recording-<n>.m4a` via FileManager if absent, so `TourBuilder.candidates(for:)` resolves real files with nonzero sizes. Commit: `chore(demo): demo recordings carry real audio files`.
 
-- [ ] **Step 1: Build `InteractiveShareSection`**
+- [x] **Step 1: Build `InteractiveShareSection`**
 
 ```swift
 import SwiftUI
@@ -1287,7 +1287,7 @@ private struct TourRecordingRow: View {
 
 Adjust color names (`moss`, `rust`) to the asset-catalog names actually present (grep `Color("` in the project and match); same for `Constants.UI.Padding` members.
 
-- [ ] **Step 2: Insert into WalkShareView**
+- [x] **Step 2: Insert into WalkShareView**
 
 In the main VStack after `statToggles` (before `journalSection`):
 
@@ -1297,14 +1297,14 @@ InteractiveShareSection(viewModel: viewModel)
 
 with the same section framing the neighbors use (`sectionLabel("Walk with me")` above it if the design reads better with the label — match `statToggles`' visual rhythm).
 
-- [ ] **Step 3: Build**
+- [x] **Step 3: Build**
 
 Run: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build`
 Expected: BUILD SUCCEEDED.
 
-- [ ] **Step 4: Visual check** — simulator, demo mode (`--demo-mode` seeds walks with recordings): open a walk → share → flip Interactive on → recordings list shows with sizes; exclusion dims a row; kind chip flips voice ⇄ ambience; totals update; over-cap state shows the rust message and the share button disables (Task 8 wires the disable).
+- [x] **Step 4: Visual check** — simulator, demo mode (`--demo-mode` seeds walks with recordings): open a walk → share → flip Interactive on → recordings list shows with sizes; exclusion dims a row; kind chip flips voice ⇄ ambience; totals update; over-cap state shows the rust message and the share button disables (Task 8 wires the disable).
 
-- [ ] **Step 5: Commit** — `feat(share): Interactive section — recordings disclosure, kind flip, trim`
+- [x] **Step 5: Commit** — `feat(share): Interactive section — recordings disclosure, kind flip, trim`
 
 ---
 
@@ -1331,7 +1331,7 @@ enum ShareState: Equatable {
 }
 ```
 
-- [ ] **Step 1: Write the failing test** — state math only (network stays untested here):
+- [x] **Step 1: Write the failing test** — state math only (network stays untested here):
 
 ```swift
 func testShareButtonDisabledWhenTourInvalid() {
@@ -1359,9 +1359,9 @@ func testInteractivePayloadPhotoCountMatchesExportedMeta() {
 
 (`testBuildPayload` passes `tourPhotoMeta` through to `buildPayload`.)
 
-- [ ] **Step 2: Run to verify failure**
+- [x] **Step 2: Run to verify failure**
 
-- [ ] **Step 3: Extend `share()`**
+- [x] **Step 3: Extend `share()`**
 
 ```swift
 func share() async {
@@ -1424,7 +1424,7 @@ func share() async {
 
 Photo/audio ordering invariants (worker contract): audio URLs are already payload-ordered by `TourBuilder`; `tourPhotos` order defines both `payload.photos` and the PUT sequence 1..N — never reorder between the two.
 
-- [ ] **Step 4: Progress + partial UI in WalkShareView**
+- [x] **Step 4: Progress + partial UI in WalkShareView**
 
 Where the view switches on `shareState`, add:
 - `.preparingPhotos(let done, let total)`: spinner with `Text("Preparing photos… \(done)/\(total)")`.
@@ -1435,12 +1435,12 @@ Where the view switches on `shareState`, add:
 - **No abandoning a live upload:** hide the toolbar Cancel and set `.interactiveDismissDisabled(true)` while `shareState` is `.preparingPhotos`, `.uploading`, or `.uploadingMedia` — the POST already created a live page; the sheet closes only from a terminal state.
 - **Repair on re-entry:** in `init`, when a cached share exists and `ShareService.failedMedia(for:)` is non-empty, restore `.partial(url:failedCount:)` instead of `.success`, so the "Carry the missing files" affordance survives leaving the screen. `retryFailedMedia()` filters the current audio URLs/re-exported photos to the failed `(kind, n)` list, calls `ShareService.uploadSpecific`, then updates the cache via `cacheFailedMedia` with whatever still failed.
 
-- [ ] **Step 5: Run all new unit tests + build**
+- [x] **Step 5: Run all new unit tests + build**
 
 Run: `xcodebuild test ... -only-testing:UnitTests/SharePayloadTourTests -only-testing:UnitTests/TourBuilderTests -only-testing:UnitTests/RouteTrimmerTests -only-testing:UnitTests/TourPhotoExporterTests -only-testing:UnitTests/WalkShareInteractiveTests`
 Expected: PASS.
 
-- [ ] **Step 6: Commit** — `feat(share): interactive share flow — POST, sequential media, progress, partial results`
+- [x] **Step 6: Commit** — `feat(share): interactive share flow — POST, sequential media, progress, partial results`
 
 ---
 
@@ -1449,12 +1449,12 @@ Expected: PASS.
 **Files:**
 - Modify: only what the checklist shakes out.
 
-- [ ] **Step 1: Full unit test suite** — `xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` → all green.
-- [ ] **Step 2: Full-repo SwiftLint** (per project memory: pre-commit only checks staged files) — `swiftlint --strict` clean, especially `type_body_length` on `WalkShareView` and `WalkShareViewModel`.
-- [ ] **Step 3: Simulator end-to-end against production worker** — demo-mode walk with recordings → Interactive on → share → watch progress → open the returned URL in Safari: story page renders, voices play at their places (macOS Safari on the shared URL is acceptable here; the phone hardware pass is deferred by decision 2026-08-11).
-- [ ] **Step 3.5: Privacy manifest** — this is the first flow moving recorded voice off the device: add an audio-data entry to `Pilgrim/PrivacyInfo.xcprivacy` `NSPrivacyCollectedDataTypes` (`NSPrivacyCollectedDataTypeAudioData`; not linked to identity, not used for tracking, purpose: app functionality), and update the App Store Connect App Privacy questionnaire to match before release.
-- [ ] **Step 4: Privacy sanity** — confirm the payload omits transcriptions (`tour.recordings[].transcription == nil` in a captured request body), classic (non-interactive) shares are byte-identical to before (no `tour`, no `pauses` keys), and trim actually shortens the route in the page.
-- [ ] **Step 5: Commit any fixes; update `docs/superpowers/plans/2026-08-11-walk-with-me-tour-ios.md` statuses; remove plan file only when shipped.**
+- [x] **Step 1: Full unit test suite** — `xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro'` → all green.
+- [x] **Step 2: Full-repo SwiftLint** (per project memory: pre-commit only checks staged files) — `swiftlint --strict` clean, especially `type_body_length` on `WalkShareView` and `WalkShareViewModel`.
+- [x] **Step 3: Simulator end-to-end against production worker** — demo-mode walk with recordings → Interactive on → share → watch progress → open the returned URL in Safari: story page renders, voices play at their places (macOS Safari on the shared URL is acceptable here; the phone hardware pass is deferred by decision 2026-08-11).
+- [x] **Step 3.5: Privacy manifest** — this is the first flow moving recorded voice off the device: add an audio-data entry to `Pilgrim/PrivacyInfo.xcprivacy` `NSPrivacyCollectedDataTypes` (`NSPrivacyCollectedDataTypeAudioData`; not linked to identity, not used for tracking, purpose: app functionality), and update the App Store Connect App Privacy questionnaire to match before release.
+- [x] **Step 4: Privacy sanity** — confirm the payload omits transcriptions (`tour.recordings[].transcription == nil` in a captured request body), classic (non-interactive) shares are byte-identical to before (no `tour`, no `pauses` keys), and trim actually shortens the route in the page.
+- [x] **Step 5: Commit any fixes; update `docs/superpowers/plans/2026-08-11-walk-with-me-tour-ios.md` statuses; remove plan file only when shipped.**
 
 ---
 

--- a/docs/superpowers/plans/2026-08-11-walk-with-me-tour-ios.md
+++ b/docs/superpowers/plans/2026-08-11-walk-with-me-tour-ios.md
@@ -546,9 +546,12 @@ enum TourPhotoExporter {
     static func jpegDataUnder(cap: Int, image: UIImage) -> Data?   // quality ladder, testable
 }
 // export reports (completed, total) after each photo and applies a 20s
-// per-photo deadline: an iCloud fetch that exceeds it is skipped (dropped
-// photos surface in Task 8's notice), so the share can never hang forever
-// behind a single unreachable original.
+// per-photo deadline via PHImageRequestID cancellation (isSynchronous=false,
+// cancelImageRequest on deadline, one-shot continuation resume): the deadline
+// cancels the UNDERLYING Photos request, so wall-clock is genuinely bounded —
+// a task-group race cannot bound it because withTaskGroup awaits cancelled
+// children and PHImageManager fetches are not cancellation-aware. (Amended
+// during implementation; empirically verified 1s deadline → 1.009s elapsed.)
 ```
 
 - [ ] **Step 1: Write the failing test**


### PR DESCRIPTION
*The app learns to hand the page its voice.*

The share screen gains an **Interactive** toggle: flip it on and the share carries voice recordings, hi-res photos, and pauses to the story-page worker (shipped in pilgrim-worker#21). Default off — classic shares are wire-identical to before, verified byte-for-byte by tests and a final review trace.

## What the walker sees

- **Interactive toggle** with honest copy (what viewers get, and that recordings/photos upload over your connection), auto-enabling photos once when pinned photos exist (never re-flipping an explicit off).
- **Recordings disclosure**: every recording as a four-field row (index · duration · start time, local transcript preview, size) with per-recording include ✓ and a voice⇄ambience chip (auto-classified by the wpm gate: <8 words or <30 wpm → ambience; no transcript → voice; walker overrides). Deleted/oversize recordings show grayed with a reason instead of vanishing. Totals + cap warnings (12 recordings / 60 MB / 45 min). The spec's consent line — *"Voices will be audible to anyone with the link."* — appears whenever a voice is included, styled like the photos warning.
- **Trim start & end** (150 m, default on) — honestly disabled with "This walk is too short to trim." when it can't apply; trimming also excludes waypoints and photos whose coordinates fall in the trimmed zones (a doorstep photo can't defeat the trim).
- **Share flow**: Preparing photos… → sharing → Carrying your walk… n/m → done. Partial failures persist and offer **"Carry the missing files"** — repair works for the share's whole life, verified by identity so a changed library can never put the wrong file in a slot. The form freezes while a share is in flight.

## Engineering notes

- **Structural invariants over tested ones**: payload index n and uploaded file order derive from one filtered pass (`TourBuilder.tourItems`); photo metadata and bytes travel in one array (`TourPhoto`); `canTrim` delegates to `trim`; repair resolves by identity (`FailedMediaItem`: audio startTs / photo localIdentifier+ts) through a pure, unit-tested resolver — wrong-slot uploads are impossible by construction.
- **Photo export** at 1600px with a quality ladder under the worker's 2 MB cap; per-photo 20 s deadline via `PHImageRequestID` cancellation plus a PhotoKit-independent force-resume backstop (the plan's original task-group race was empirically disproven — task groups await uncooperative children).
- **Uploads**: sequential PUTs, photos before audio (photos gate the server's keepsake window), one retry per file, both entry points wrapped in a shared expiring background-task assertion.
- **Privacy**: transcripts never leave the device (payload hard-nils them; E2E-verified absent from the served page); pauses filtered on truncated timestamps; the privacy manifest already declares audio (podcast-era) — the App Store Connect questionnaire needs updating before release (no code artifact; carried on the release checklist).

## Verification

- 1158 unit tests green (45 new across payload encoding, TourBuilder, RouteTrimmer, export ladder, upload requests, VM integration, retry resolution, state machine).
- Nine tasks executed subagent-driven with a spec+quality review gate per task — every task surfaced and fixed a real finding (empty-transcript misclassification, canTrim divergence counterexample, unbounded timeout, unprotected retry path, wrong-slot retry Critical, in-flight form edits).
- Final whole-branch review: **READY TO MERGE**.
- E2E against the production worker from the simulator: real share at walk.pilgrimapp.org/1Ll184smAU — story page renders, voice plays at its place, audio serves 200 audio/mp4, trim active, transcript text absent.

## Deferred by decision

Real-device pass (gesture unlock, Range playback, PhotoKit timeout behavior) before TestFlight; plan Open Questions (upgrading an already-shared walk to interactive, auto-pause sharing, spec cleanup); TestFlight dispatch awaits explicit approval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
