### PR TITLE
fix(share): drop the wpm ambience gate — contemplative talks are voices

### DIFF
--- a/Pilgrim/Models/Share/TourBuilder.swift
+++ b/Pilgrim/Models/Share/TourBuilder.swift
@@ -27,15 +27,16 @@ enum TourBuilder {
     static let maxTotalSeconds: Double = 2700
 
     /// A deliberate recording is presumed to be a voice: only a transcription
-    /// that reads as non-speech (too few words, or implausibly slow) files
-    /// the recording as ambience. The walker can override either way.
-    static func classify(transcription: String?, wpm: Double?) -> TourRecordingKind {
+    /// that reads as non-speech (too few words) files the recording as
+    /// ambience. The walker can override either way. No words-per-minute
+    /// gate: contemplative talks — a thought, then a long silence — measure
+    /// ~25 wpm on real walks, and slow speech is still speech.
+    static func classify(transcription: String?) -> TourRecordingKind {
         guard let text = transcription?.trimmingCharacters(in: .whitespacesAndNewlines) else {
             return .spoken
         }
         let wordCount = text.split(whereSeparator: \.isWhitespace).count
         if wordCount < 8 { return .ambient }
-        if let wpm, wpm < 30 { return .ambient }
         return .spoken
     }
 
@@ -68,7 +69,7 @@ enum TourBuilder {
                 sizeBytes: size ?? 0,
                 transcription: rec.transcription,
                 wpm: rec.wordsPerMinute,
-                autoKind: classify(transcription: rec.transcription, wpm: rec.wordsPerMinute),
+                autoKind: classify(transcription: rec.transcription),
                 includeInShare: unavailableReason == nil,
                 kindOverride: nil,
                 fileURL: unavailableReason == nil ? url : nil,

--- a/UnitTests/TourBuilderTests.swift
+++ b/UnitTests/TourBuilderTests.swift
@@ -4,34 +4,31 @@ import XCTest
 final class TourBuilderTests: XCTestCase {
 
     func testClassify_noTranscriptionIsSpoken() {
-        XCTAssertEqual(TourBuilder.classify(transcription: nil, wpm: nil), .spoken)
+        XCTAssertEqual(TourBuilder.classify(transcription: nil), .spoken)
     }
 
     func testClassify_fewWordsIsAmbient() {
-        XCTAssertEqual(TourBuilder.classify(transcription: "wind and birds", wpm: 200), .ambient)
+        XCTAssertEqual(TourBuilder.classify(transcription: "wind and birds"), .ambient)
     }
 
-    func testClassify_slowSpeechIsAmbient() {
-        let words = Array(repeating: "word", count: 20).joined(separator: " ")
-        XCTAssertEqual(TourBuilder.classify(transcription: words, wpm: 12), .ambient)
+    func testClassify_slowContemplativeSpeechIsSpoken() {
+        // 25 wpm over a 5-minute talk is a real pattern on real walks —
+        // sparse words must not demote a deliberate talk to ambience.
+        let words = Array(repeating: "word", count: 120).joined(separator: " ")
+        XCTAssertEqual(TourBuilder.classify(transcription: words), .spoken)
     }
 
     func testClassify_realSpeechIsSpoken() {
         let words = Array(repeating: "word", count: 20).joined(separator: " ")
-        XCTAssertEqual(TourBuilder.classify(transcription: words, wpm: 110), .spoken)
-    }
-
-    func testClassify_transcriptionWithoutWpmUsesWordCountOnly() {
-        let words = Array(repeating: "word", count: 20).joined(separator: " ")
-        XCTAssertEqual(TourBuilder.classify(transcription: words, wpm: nil), .spoken)
+        XCTAssertEqual(TourBuilder.classify(transcription: words), .spoken)
     }
 
     func testClassify_emptyTranscriptionIsAmbient() {
-        XCTAssertEqual(TourBuilder.classify(transcription: "", wpm: nil), .ambient)
+        XCTAssertEqual(TourBuilder.classify(transcription: ""), .ambient)
     }
 
     func testClassify_whitespaceOnlyTranscriptionIsAmbient() {
-        XCTAssertEqual(TourBuilder.classify(transcription: "  \n ", wpm: 200), .ambient)
+        XCTAssertEqual(TourBuilder.classify(transcription: "  \n "), .ambient)
     }
 
     private func candidate(id: Int, bytes: Int = 1_000_000, seconds: Double = 60, included: Bool = true, kind: TourRecordingKind = .spoken) -> TourRecordingCandidate {


### PR DESCRIPTION
The first real interactive walk (Qoi4YmPHLN) filed 2 of its 3 talks as ambience: real transcripts at 25.7 / 25.3 wpm — a thought, then a long silence, the most natural talk pattern for this app's users — fell under the 30 wpm floor meant to catch transcribed street noise.

The `<8 words` gate already catches noise (Whisper on wind yields near-empty transcripts). A deliberate recording with a real transcript now always defaults to voice. The kind chip in the share sheet still overrides either way.

Companion worker fixes (pilgrim-worker#23, deployed): enrich no longer clobbers the interactive poster og, orphaned ambience gets a listening chapter, story colophon drops the passport link.

Suite: 1180/0 (one redundant wpm test removed, slow-speech expectation inverted with a comment pinning why).

🤖 Generated with [Claude Code](https://claude.com/claude-code)