### PR TITLE
feat(share): tours may carry 108 minutes of voice

### DIFF
--- a/Pilgrim/Models/Share/TourBuilder.swift
+++ b/Pilgrim/Models/Share/TourBuilder.swift
@@ -24,7 +24,7 @@ enum TourBuilder {
     static let maxRecordings = 12
     static let maxFileBytes = 15 * 1024 * 1024
     static let maxTotalBytes = 60 * 1024 * 1024
-    static let maxTotalSeconds: Double = 2700
+    static let maxTotalSeconds: Double = 6480  // 108 minutes — the eternal cairn's number
 
     /// A deliberate recording is presumed to be a voice: only a transcription
     /// that reads as non-speech (too few words) files the recording as
@@ -89,7 +89,7 @@ enum TourBuilder {
         let (count, bytes, seconds) = totals(of: candidates)
         if count > maxRecordings { return "A walk page carries at most \(maxRecordings) recordings — leave some out." }
         if bytes > maxTotalBytes { return "Recordings total \(bytes / 1_048_576) MB — the page carries at most 60 MB." }
-        if seconds > maxTotalSeconds { return "Recordings total \(Int(seconds / 60)) minutes — the page carries at most 45." }
+        if seconds > maxTotalSeconds { return "Recordings total \(Int(seconds / 60)) minutes — the page carries at most \(Int(maxTotalSeconds / 60))." }
         return nil
     }
 
@@ -103,7 +103,7 @@ enum TourBuilder {
                 duration: c.duration,
                 kind: c.effectiveKind.rawValue,
                 // Transcripts never leave the device: the page renders none, and
-                // a 45-minute walk's transcripts would blow the 2MB POST budget.
+                // a 108-minute walk's transcripts would blow the 2MB POST budget.
                 // Deliberate — do not wire c.transcription through.
                 transcription: nil,
                 wpm: c.wpm,

--- a/UnitTests/TourBuilderTests.swift
+++ b/UnitTests/TourBuilderTests.swift
@@ -74,8 +74,10 @@ final class TourBuilderTests: XCTestCase {
     func testValidation_totalBytesAndSecondsCaps() {
         let heavy = (0..<5).map { candidate(id: $0, bytes: 14_000_000) }   // 70MB
         XCTAssertNotNil(TourBuilder.validationError(for: heavy))
-        let long = (0..<3).map { candidate(id: $0, seconds: 1000) }        // 3000s
+        let long = (0..<7).map { candidate(id: $0, seconds: 1000) }        // 7000s > 6480
         XCTAssertNotNil(TourBuilder.validationError(for: long))
+        let contemplative = (0..<6).map { candidate(id: $0, seconds: 1000) } // 6000s fits in 108 min
+        XCTAssertNil(TourBuilder.validationError(for: contemplative))
     }
 
     func testValidation_excludedRecordingsDoNotCount() {


### PR DESCRIPTION
Raises `TourBuilder.maxTotalSeconds` 2700 → 6480, matching the already-deployed worker raise (pilgrim-worker#29). Byte caps unchanged as the true resource guards. Validation copy now derives from the constant. Rides the next build — not part of 1.10.0 (101) in review.

Suite 1180/0 (over-cap test moved to 7000s, under-cap acceptance added at 6000s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)