### PR TITLE
feat(share): the tour carries the walker's soundscape

### DIFF
--- a/Pilgrim/Models/Share/SharePayload.swift
+++ b/Pilgrim/Models/Share/SharePayload.swift
@@ -89,10 +89,14 @@ struct SharePayload: Encodable {
     struct Tour: Encodable {
         let recordings: [TourRecording]
         let trimM: Int
+        /// The walker's own meditation soundscape (cdn URL). nil when the
+        /// walker sits in silence — the page then stays silent too.
+        let soundscapeUrl: String?
 
         enum CodingKeys: String, CodingKey {
             case recordings
             case trimM = "trim_m"
+            case soundscapeUrl = "soundscape_url"
         }
     }
 

--- a/Pilgrim/Models/Share/TourBuilder.swift
+++ b/Pilgrim/Models/Share/TourBuilder.swift
@@ -93,7 +93,16 @@ enum TourBuilder {
         return nil
     }
 
-    static func tourItems(candidates: [TourRecordingCandidate], trimM: Int) -> (tour: SharePayload.Tour, files: [URL]) {
+    /// Resolves the walker's chosen soundscape to its public CDN URL.
+    /// nil in = silence chosen = nil out; an id the manifest no longer
+    /// carries also resolves to nil rather than a dead link.
+    static func soundscapeUrl(selectedId: String?, manifest: AudioManifest?) -> String? {
+        guard let selectedId,
+              let asset = manifest?.soundscapes.first(where: { $0.id == selectedId }) else { return nil }
+        return Config.Audio.r2BaseURL.appendingPathComponent(asset.r2Key).absoluteString
+    }
+
+    static func tourItems(candidates: [TourRecordingCandidate], trimM: Int, soundscapeUrl: String? = nil) -> (tour: SharePayload.Tour, files: [URL]) {
         let included = candidates.filter { $0.includeInShare && $0.unavailableReason == nil && $0.fileURL != nil }
         let recordings = included.enumerated().map { index, c in
             SharePayload.TourRecording(
@@ -111,6 +120,6 @@ enum TourBuilder {
             )
         }
         let files = included.compactMap(\.fileURL)
-        return (SharePayload.Tour(recordings: recordings, trimM: trimM), files)
+        return (SharePayload.Tour(recordings: recordings, trimM: trimM, soundscapeUrl: soundscapeUrl), files)
     }
 }

--- a/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
+++ b/Pilgrim/Scenes/WalkShare/WalkShareViewModel.swift
@@ -440,7 +440,14 @@ final class WalkShareViewModel: ObservableObject {
     }
 
     private func applyInteractiveTourAndPauses(to payload: inout SharePayload, trimM: Int) {
-        payload.tour = TourBuilder.tourItems(candidates: tourCandidates, trimM: trimM).tour
+        payload.tour = TourBuilder.tourItems(
+            candidates: tourCandidates,
+            trimM: trimM,
+            soundscapeUrl: TourBuilder.soundscapeUrl(
+                selectedId: UserPreferences.selectedSoundscapeId.value,
+                manifest: AudioManifestService.shared.manifest
+            )
+        ).tour
         // The worker validates TRUNCATED integers: filter after truncation or a
         // sub-second pause 400s the whole share.
         payload.pauses = Array(

--- a/UnitTests/SharePayloadTourTests.swift
+++ b/UnitTests/SharePayloadTourTests.swift
@@ -34,11 +34,13 @@ final class SharePayloadTourTests: XCTestCase {
                 .init(n: 1, startTs: 1100, endTs: 1400, duration: 300, kind: "spoken", transcription: nil, wpm: 120, sizeBytes: 2_400_000),
                 .init(n: 2, startTs: 1450, endTs: 1500, duration: 50, kind: "ambient", transcription: nil, wpm: nil, sizeBytes: 800_000),
             ],
-            trimM: 150
+            trimM: 150,
+            soundscapeUrl: "https://cdn.pilgrimapp.org/audio/soundscape/stream.m4a"
         )
         let json = try encodeToJSON(minimalPayload(tour: tour))
         let tourJSON = try XCTUnwrap(json["tour"] as? [String: Any])
         XCTAssertEqual(tourJSON["trim_m"] as? Int, 150)
+        XCTAssertEqual(tourJSON["soundscape_url"] as? String, "https://cdn.pilgrimapp.org/audio/soundscape/stream.m4a")
         let recs = try XCTUnwrap(tourJSON["recordings"] as? [[String: Any]])
         XCTAssertEqual(recs.count, 2)
         XCTAssertEqual(recs[0]["n"] as? Int, 1)

--- a/UnitTests/TourBuilderTests.swift
+++ b/UnitTests/TourBuilderTests.swift
@@ -59,6 +59,30 @@ final class TourBuilderTests: XCTestCase {
         XCTAssertEqual(files.map(\.lastPathComponent), ["0.m4a", "2.m4a"])
     }
 
+    func testSoundscapeUrl_resolvesThroughManifest() {
+        let manifest = AudioManifest(version: "1", assets: [
+            AudioAsset(id: "stream-1", type: .soundscape, name: "stream", displayName: "Stream",
+                       durationSec: 300, r2Key: "soundscape/stream.m4a", fileSizeBytes: 1_000_000, usageTags: [])
+        ])
+        XCTAssertEqual(
+            TourBuilder.soundscapeUrl(selectedId: "stream-1", manifest: manifest),
+            "https://cdn.pilgrimapp.org/audio/soundscape/stream.m4a"
+        )
+        XCTAssertNil(TourBuilder.soundscapeUrl(selectedId: nil, manifest: manifest),
+                     "silence chosen stays silence")
+        XCTAssertNil(TourBuilder.soundscapeUrl(selectedId: "retired-id", manifest: manifest),
+                     "a retired id must not become a dead link")
+        XCTAssertNil(TourBuilder.soundscapeUrl(selectedId: "stream-1", manifest: nil))
+    }
+
+    func testTourItems_carriesSoundscapeUrl() {
+        let (tour, _) = TourBuilder.tourItems(candidates: [candidate(id: 0)], trimM: 0,
+                                              soundscapeUrl: "https://cdn.pilgrimapp.org/audio/soundscape/stream.m4a")
+        XCTAssertEqual(tour.soundscapeUrl, "https://cdn.pilgrimapp.org/audio/soundscape/stream.m4a")
+        let (bare, _) = TourBuilder.tourItems(candidates: [candidate(id: 0)], trimM: 0)
+        XCTAssertNil(bare.soundscapeUrl)
+    }
+
     func testTourItems_stripsTranscription() {
         let withTranscript = TourRecordingCandidate(id: 0, startTs: 1000, endTs: 1060, duration: 60, sizeBytes: 1_000_000, transcription: "some real speech", wpm: 120, autoKind: .spoken, includeInShare: true, kindOverride: nil, fileURL: URL(fileURLWithPath: "/tmp/0.m4a"), unavailableReason: nil)
         let (tour, _) = TourBuilder.tourItems(candidates: [withTranscript], trimM: 0)


### PR DESCRIPTION
Companion to pilgrim-worker#33 (tour-v4, deployed): optional `soundscape_url` in the tour payload — `selectedSoundscapeId` resolved through the cached audio manifest to its `cdn.pilgrimapp.org/audio/…` URL at share time.

Silence is honored end to end: nil preference → nil field → silent page. A retired id resolves to nil, never a dead link. Worker validates against the cdn whitelist.

Rides the next build (103). Suite 1182/0 (resolution + carry + snake_case encoding tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)