### PR TITLE
fix(share): soundscape URL uses the app's own download formula

### DIFF
--- a/Pilgrim/Models/Share/TourBuilder.swift
+++ b/Pilgrim/Models/Share/TourBuilder.swift
@@ -93,13 +93,19 @@ enum TourBuilder {
         return nil
     }
 
-    /// Resolves the walker's chosen soundscape to its public CDN URL.
-    /// nil in = silence chosen = nil out; an id the manifest no longer
-    /// carries also resolves to nil rather than a dead link.
+    /// Resolves the walker's chosen soundscape to its public CDN URL,
+    /// using the same base/type/{id}.aac formula AudioDownloadManager
+    /// fetches with — NOT r2Key, whose bucket-relative path already
+    /// contains the audio/ prefix and would double it. nil in = silence
+    /// chosen = nil out; a retired id also resolves to nil, never a
+    /// dead link.
     static func soundscapeUrl(selectedId: String?, manifest: AudioManifest?) -> String? {
         guard let selectedId,
               let asset = manifest?.soundscapes.first(where: { $0.id == selectedId }) else { return nil }
-        return Config.Audio.r2BaseURL.appendingPathComponent(asset.r2Key).absoluteString
+        return Config.Audio.r2BaseURL
+            .appendingPathComponent(asset.type.rawValue)
+            .appendingPathComponent("\(asset.id).aac")
+            .absoluteString
     }
 
     static func tourItems(candidates: [TourRecordingCandidate], trimM: Int, soundscapeUrl: String? = nil) -> (tour: SharePayload.Tour, files: [URL]) {

--- a/UnitTests/TourBuilderTests.swift
+++ b/UnitTests/TourBuilderTests.swift
@@ -64,9 +64,11 @@ final class TourBuilderTests: XCTestCase {
             AudioAsset(id: "stream-1", type: .soundscape, name: "stream", displayName: "Stream",
                        durationSec: 300, r2Key: "soundscape/stream.m4a", fileSizeBytes: 1_000_000, usageTags: [])
         ])
+        // base/type/{id}.aac — the formula AudioDownloadManager fetches
+        // with; r2Key would double the audio/ prefix (caught live: 404).
         XCTAssertEqual(
             TourBuilder.soundscapeUrl(selectedId: "stream-1", manifest: manifest),
-            "https://cdn.pilgrimapp.org/audio/soundscape/stream.m4a"
+            "https://cdn.pilgrimapp.org/audio/soundscape/stream-1.aac"
         )
         XCTAssertNil(TourBuilder.soundscapeUrl(selectedId: nil, manifest: manifest),
                      "silence chosen stays silence")


### PR DESCRIPTION
Probing the real CDN caught my resolution appending `r2Key` (bucket-relative, already prefixed with `audio/`) to a base ending in `/audio` — doubled path, 404, dead bed. `AudioDownloadManager` has always fetched `base/type/{id}.aac`; the share-time resolution now mirrors that formula exactly, verified 200 against production (`audio/soundscape/ocean-waves.aac`). Still pre-build-103, so no shipped payload ever carried the bad URL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)