### PR TITLE
fix(share): trim toggle shows the outcome, not the intent

### DIFF
--- a/Pilgrim/Scenes/WalkShare/InteractiveShareSection.swift
+++ b/Pilgrim/Scenes/WalkShare/InteractiveShareSection.swift
@@ -53,7 +53,10 @@ struct InteractiveShareSection: View {
                         .foregroundColor(.rust)
                 }
 
-                Toggle(isOn: $viewModel.trimEnabled) {
+                Toggle(isOn: Binding(
+                    get: { viewModel.trimEnabled && viewModel.canTrimRoute },
+                    set: { viewModel.trimEnabled = $0 }
+                )) {
                     VStack(alignment: .leading, spacing: 4) {
                         Text("Trim start & end")
                             .font(Constants.Typography.body)


### PR DESCRIPTION
User-reported on a real short walk (Qu-_dqNPnR): the trim toggle was disabled with "too short to trim" but still rendered ON. The wire was always honest — `trim_m: 0` by outcome — the knob now matches: display binding is `trimEnabled && canTrimRoute`, so an untrimmable walk shows the switch off. Suite 1182/0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)