### PR TITLE
feat(threads): the card, the thread view, letting go, and the moon looks back

### DIFF
--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -229,6 +229,7 @@
 		77B84A5DD3344F7995B8F0FB /* ThreadIntentionSuggestions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9493E7AD112D41C6B876DB33 /* ThreadIntentionSuggestions.swift */; };
 		12B4814A464F4B33A4DFDF5E /* ThreadIntentionSuggestionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1177FF093DBC4775929CC150 /* ThreadIntentionSuggestionsTests.swift */; };
 		4D8F2B7A1C9E4E33B6A5D014 /* ThreadsBackfillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1E5F82D3B44A61A7E2C905 /* ThreadsBackfillTests.swift */; };
+		D52773868F67D01927C78847 /* ThreadsReleaseFilteringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAD4465FB34B28A145AA426 /* ThreadsReleaseFilteringTests.swift */; };
 		50A16B63C6F23E2D1E6210BA /* Pods_Pilgrim.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */; };
 		510A5ED79C24B905DDD597A7 /* ScrollHapticEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F12E1FE28A875629DBD34C /* ScrollHapticEngineTests.swift */; };
 		52C6F28B0AAB6E494591E8EF /* VoiceGuideManifestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F883597323B0CE64E69DC9 /* VoiceGuideManifestService.swift */; };
@@ -871,6 +872,7 @@
 		9493E7AD112D41C6B876DB33 /* ThreadIntentionSuggestions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadIntentionSuggestions.swift; sourceTree = "<group>"; };
 		1177FF093DBC4775929CC150 /* ThreadIntentionSuggestionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadIntentionSuggestionsTests.swift; sourceTree = "<group>"; };
 		9C1E5F82D3B44A61A7E2C905 /* ThreadsBackfillTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsBackfillTests.swift; sourceTree = "<group>"; };
+		7CAD4465FB34B28A145AA426 /* ThreadsReleaseFilteringTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsReleaseFilteringTests.swift; sourceTree = "<group>"; };
 		3E5EFD54CACA590B1BE78B75 /* BellPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BellPlayer.swift; sourceTree = "<group>"; };
 		3FE8447AB26F2388EA548BED /* SeekSoundPlayerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SeekSoundPlayerTests.swift; sourceTree = "<group>"; };
 		4181215714A52E71449BC390 /* WalkDataFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkDataFactory.swift; sourceTree = "<group>"; };
@@ -1927,6 +1929,7 @@
 				3C6AF4CB2CDC4F6DA1162CEA /* ThreadsDossierTests.swift */,
 				1177FF093DBC4775929CC150 /* ThreadIntentionSuggestionsTests.swift */,
 				9C1E5F82D3B44A61A7E2C905 /* ThreadsBackfillTests.swift */,
+				7CAD4465FB34B28A145AA426 /* ThreadsReleaseFilteringTests.swift */,
 				C14640E393BDAEC8C4856281 /* PromptAssemblerLanguageTests.swift */,
 				cc51a46c5e27674f5165b409 /* SharePayloadTourTests.swift */,
 				2B3C4D5E6F7A8B9C0D1E2F3A /* TourBuilderTests.swift */,
@@ -3302,6 +3305,7 @@
 				366617D2E2404425A7BB8E0F /* ThreadsDossierTests.swift in Sources */,
 				12B4814A464F4B33A4DFDF5E /* ThreadIntentionSuggestionsTests.swift in Sources */,
 				4D8F2B7A1C9E4E33B6A5D014 /* ThreadsBackfillTests.swift in Sources */,
+				D52773868F67D01927C78847 /* ThreadsReleaseFilteringTests.swift in Sources */,
 				2161BB76D1D8B9E8BBB49B5A /* PromptAssemblerLanguageTests.swift in Sources */,
 				7ac8ee442a1ce6fcb926501a /* SharePayloadTourTests.swift in Sources */,
 				1A2B3C4D5E6F7A8B9C0D1E2F /* TourBuilderTests.swift in Sources */,

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -238,6 +238,8 @@
 		4D8F2B7A1C9E4E33B6A5D014 /* ThreadsBackfillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1E5F82D3B44A61A7E2C905 /* ThreadsBackfillTests.swift */; };
 		D52773868F67D01927C78847 /* ThreadsReleaseFilteringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAD4465FB34B28A145AA426 /* ThreadsReleaseFilteringTests.swift */; };
 		7BFB56F11953470F8D5DF41A /* ThreadHistoryModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C642300D15AD44EA99B4FC6D /* ThreadHistoryModelTests.swift */; };
+		1BD1E96A084348F19A83EA07 /* LunationCalendarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F0FCF0F88F406D8DECECA9 /* LunationCalendarTests.swift */; };
+		A250CB53C9A74F1184AE2F2D /* LunationRecapStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E7CCD261729470B9FFFEB8D /* LunationRecapStateTests.swift */; };
 		50A16B63C6F23E2D1E6210BA /* Pods_Pilgrim.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */; };
 		510A5ED79C24B905DDD597A7 /* ScrollHapticEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F12E1FE28A875629DBD34C /* ScrollHapticEngineTests.swift */; };
 		52C6F28B0AAB6E494591E8EF /* VoiceGuideManifestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F883597323B0CE64E69DC9 /* VoiceGuideManifestService.swift */; };
@@ -463,6 +465,8 @@
 		CC00000200000000INKSCR01 /* InkScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000INKSCR01 /* InkScrollView.swift */; };
 		CC00000200000000LANTRN01 /* LanternShape.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000LANTRN01 /* LanternShape.swift */; };
 		CC00000200000000LUNRPH01 /* LunarPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000LUNRPH01 /* LunarPhase.swift */; };
+		6974E7EAF5A14C6CAA88085C /* LunationCalendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CAC84DBE9A24323906E2A32 /* LunationCalendar.swift */; };
+		D1E7C0F08C6D49B5BD8569CF /* LunationRecapState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0BCF0EB1C954E0DB321DEE9 /* LunationRecapState.swift */; };
 		CC00000200000000LUNRTST1 /* LunarPhaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000LUNRTST1 /* LunarPhaseTests.swift */; };
 		CC00000200000000MAINTB01 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000MAINTB01 /* MainTabView.swift */; };
 		CC00000200000000MILEST01 /* MilestoneMarkerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000MILEST01 /* MilestoneMarkerView.swift */; };
@@ -892,6 +896,8 @@
 		9C1E5F82D3B44A61A7E2C905 /* ThreadsBackfillTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsBackfillTests.swift; sourceTree = "<group>"; };
 		7CAD4465FB34B28A145AA426 /* ThreadsReleaseFilteringTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsReleaseFilteringTests.swift; sourceTree = "<group>"; };
 		C642300D15AD44EA99B4FC6D /* ThreadHistoryModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadHistoryModelTests.swift; sourceTree = "<group>"; };
+		F5F0FCF0F88F406D8DECECA9 /* LunationCalendarTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LunationCalendarTests.swift; sourceTree = "<group>"; };
+		8E7CCD261729470B9FFFEB8D /* LunationRecapStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LunationRecapStateTests.swift; sourceTree = "<group>"; };
 		3E5EFD54CACA590B1BE78B75 /* BellPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BellPlayer.swift; sourceTree = "<group>"; };
 		3FE8447AB26F2388EA548BED /* SeekSoundPlayerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SeekSoundPlayerTests.swift; sourceTree = "<group>"; };
 		4181215714A52E71449BC390 /* WalkDataFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkDataFactory.swift; sourceTree = "<group>"; };
@@ -1130,6 +1136,8 @@
 		CC00000100000000INKSCR01 /* InkScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InkScrollView.swift; sourceTree = "<group>"; };
 		CC00000100000000LANTRN01 /* LanternShape.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanternShape.swift; sourceTree = "<group>"; };
 		CC00000100000000LUNRPH01 /* LunarPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LunarPhase.swift; sourceTree = "<group>"; };
+		5CAC84DBE9A24323906E2A32 /* LunationCalendar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LunationCalendar.swift; sourceTree = "<group>"; };
+		E0BCF0EB1C954E0DB321DEE9 /* LunationRecapState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LunationRecapState.swift; sourceTree = "<group>"; };
 		CC00000100000000LUNRTST1 /* LunarPhaseTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LunarPhaseTests.swift; sourceTree = "<group>"; };
 		CC00000100000000MAINTB01 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		CC00000100000000MILEST01 /* MilestoneMarkerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneMarkerView.swift; sourceTree = "<group>"; };
@@ -1954,6 +1962,8 @@
 				9C1E5F82D3B44A61A7E2C905 /* ThreadsBackfillTests.swift */,
 				7CAD4465FB34B28A145AA426 /* ThreadsReleaseFilteringTests.swift */,
 				C642300D15AD44EA99B4FC6D /* ThreadHistoryModelTests.swift */,
+				F5F0FCF0F88F406D8DECECA9 /* LunationCalendarTests.swift */,
+				8E7CCD261729470B9FFFEB8D /* LunationRecapStateTests.swift */,
 				77462A5F095C4E4CA47D91CF /* ReleasedThreadsInteractionTests.swift */,
 				C14640E393BDAEC8C4856281 /* PromptAssemblerLanguageTests.swift */,
 				cc51a46c5e27674f5165b409 /* SharePayloadTourTests.swift */,
@@ -2325,6 +2335,8 @@
 				1E3FC6223746420D820D537F /* ThreadsDossierFormatter.swift */,
 				1060C3B913FD4DA88015D30D /* ThreadsDossierBuilder.swift */,
 				9493E7AD112D41C6B876DB33 /* ThreadIntentionSuggestions.swift */,
+				5CAC84DBE9A24323906E2A32 /* LunationCalendar.swift */,
+				E0BCF0EB1C954E0DB321DEE9 /* LunationRecapState.swift */,
 			);
 			path = Threads;
 			sourceTree = "<group>";
@@ -3057,6 +3069,8 @@
 				CC00000200000000WKSTRT01 /* WalkStartView.swift in Sources */,
 				CC00000200000000WKMODE01 /* WalkMode.swift in Sources */,
 				CC00000200000000LUNRPH01 /* LunarPhase.swift in Sources */,
+				6974E7EAF5A14C6CAA88085C /* LunationCalendar.swift in Sources */,
+				D1E7C0F08C6D49B5BD8569CF /* LunationRecapState.swift in Sources */,
 				CC00000200000000SEEDRG01 /* SeededRNG.swift in Sources */,
 				CC00000200000000MOONPV01 /* MoonPhaseView.swift in Sources */,
 				CC00000200000000SETTVW01 /* SettingsView.swift in Sources */,
@@ -3349,6 +3363,8 @@
 				4D8F2B7A1C9E4E33B6A5D014 /* ThreadsBackfillTests.swift in Sources */,
 				D52773868F67D01927C78847 /* ThreadsReleaseFilteringTests.swift in Sources */,
 				7BFB56F11953470F8D5DF41A /* ThreadHistoryModelTests.swift in Sources */,
+				1BD1E96A084348F19A83EA07 /* LunationCalendarTests.swift in Sources */,
+				A250CB53C9A74F1184AE2F2D /* LunationRecapStateTests.swift in Sources */,
 				B4BB6C15735F478E9E296F6C /* ReleasedThreadsInteractionTests.swift in Sources */,
 				2161BB76D1D8B9E8BBB49B5A /* PromptAssemblerLanguageTests.swift in Sources */,
 				7ac8ee442a1ce6fcb926501a /* SharePayloadTourTests.swift in Sources */,

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -219,8 +219,11 @@
 		E66DD877BDBA458E95E4347F /* TranscriptContextAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE8A0304E2A421E8707E109 /* TranscriptContextAnalyzer.swift */; };
 		CF635D421DBD437A8A75B616 /* ThreadsBackfill.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0523495072F4F50ACDEF645 /* ThreadsBackfill.swift */; };
 		DFB954198A242EE69B14806B /* ThreadStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2063941AD76F5A42ABCEB5D5 /* ThreadStore.swift */; };
+		EFCD11E778754DE2A369A79A /* ThreadsTexture.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA610B7C7F364A1C9AE514A0 /* ThreadsTexture.swift */; };
+		E0F1767D04764B35AF21D2D3 /* ThreadsCardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD772824C494BD8AB4FE370 /* ThreadsCardModel.swift */; };
 		3A9D73B10C5444B1AE84AAB6 /* ReleasedThreadsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2368779D0FD441D9871826F /* ReleasedThreadsStore.swift */; };
 		BC41523122F44D908CD01FF4 /* ReleasedThreadsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9665AA4903D4E27B8B2ED00 /* ReleasedThreadsStoreTests.swift */; };
+		D3FD9359147B417CAD13958B /* ThreadsCardModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3D08345F1E4F12A8823657 /* ThreadsCardModelTests.swift */; };
 		1143DC90344F45EFAFDAAC23 /* ReleasedThreadsPackageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EBA375CB284A57A169D5EC /* ReleasedThreadsPackageTests.swift */; };
 		23795691640A42D0872CBC91 /* TranscriptContextAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F837FC0ECF4D4ED1BA756517 /* TranscriptContextAnalyzerTests.swift */; };
 		DDB1779FC0D3496A894799E5 /* ThreadsDossierFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3FC6223746420D820D537F /* ThreadsDossierFormatter.swift */; };
@@ -410,6 +413,8 @@
 		BBBB00000000000000001F /* PhotoCarouselView.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB00000000000000001E /* PhotoCarouselView.swift */; };
 		BBBB000000000000000021 /* PhotoPreviewSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000000000020 /* PhotoPreviewSheet.swift */; };
 		BBBB000000000000000023 /* WalkSummaryView+Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000000000022 /* WalkSummaryView+Map.swift */; };
+		F52F97270EBD4F8688BC7D6C /* ThreadsCardSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0901C4D1764F482982F54637 /* ThreadsCardSection.swift */; };
+		75D65204CDD344D0847CE5AA /* WalkSummaryView+Threads.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A525D381BA42798281A07F /* WalkSummaryView+Threads.swift */; };
 		BBBB000000000000000025 /* PilgrimPackagePhotoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000000000024 /* PilgrimPackagePhotoTests.swift */; };
 		BBBB000000000000000027 /* PilgrimPackagePhotoConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000000000026 /* PilgrimPackagePhotoConverter.swift */; };
 		BBBB000000000000000029 /* PilgrimPhotoEmbedder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000000000028 /* PilgrimPhotoEmbedder.swift */; };
@@ -857,6 +862,7 @@
 		871968A73E694CE1A7813792 /* DataManagerThreadsDeletionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataManagerThreadsDeletionTests.swift; sourceTree = "<group>"; };
 		D44E1DA26DB135B0837E447F /* ThreadStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadStoreTests.swift; sourceTree = "<group>"; };
 		C9665AA4903D4E27B8B2ED00 /* ReleasedThreadsStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReleasedThreadsStoreTests.swift; sourceTree = "<group>"; };
+		6F3D08345F1E4F12A8823657 /* ThreadsCardModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsCardModelTests.swift; sourceTree = "<group>"; };
 		45EBA375CB284A57A169D5EC /* ReleasedThreadsPackageTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReleasedThreadsPackageTests.swift; sourceTree = "<group>"; };
 		25F8773000AC4CCC93F68DAF /* FieldGateReportTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FieldGateReportTests.swift; sourceTree = "<group>"; };
 		5ABD94794DC646449548E6FE /* TranscriptContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TranscriptContext.swift; sourceTree = "<group>"; };
@@ -864,6 +870,8 @@
 		AEE8A0304E2A421E8707E109 /* TranscriptContextAnalyzer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TranscriptContextAnalyzer.swift; sourceTree = "<group>"; };
 		E0523495072F4F50ACDEF645 /* ThreadsBackfill.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsBackfill.swift; sourceTree = "<group>"; };
 		2063941AD76F5A42ABCEB5D5 /* ThreadStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadStore.swift; sourceTree = "<group>"; };
+		FA610B7C7F364A1C9AE514A0 /* ThreadsTexture.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsTexture.swift; sourceTree = "<group>"; };
+		FAD772824C494BD8AB4FE370 /* ThreadsCardModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsCardModel.swift; sourceTree = "<group>"; };
 		A2368779D0FD441D9871826F /* ReleasedThreadsStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReleasedThreadsStore.swift; sourceTree = "<group>"; };
 		F837FC0ECF4D4ED1BA756517 /* TranscriptContextAnalyzerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TranscriptContextAnalyzerTests.swift; sourceTree = "<group>"; };
 		1E3FC6223746420D820D537F /* ThreadsDossierFormatter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsDossierFormatter.swift; sourceTree = "<group>"; };
@@ -1062,6 +1070,8 @@
 		BBBB00000000000000001E /* PhotoCarouselView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoCarouselView.swift; sourceTree = "<group>"; };
 		BBBB000000000000000020 /* PhotoPreviewSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPreviewSheet.swift; sourceTree = "<group>"; };
 		BBBB000000000000000022 /* WalkSummaryView+Map.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalkSummaryView+Map.swift"; sourceTree = "<group>"; };
+		0901C4D1764F482982F54637 /* ThreadsCardSection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsCardSection.swift; sourceTree = "<group>"; };
+		F1A525D381BA42798281A07F /* WalkSummaryView+Threads.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "WalkSummaryView+Threads.swift"; sourceTree = "<group>"; };
 		BBBB000000000000000024 /* PilgrimPackagePhotoTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PilgrimPackagePhotoTests.swift; sourceTree = "<group>"; };
 		BBBB000000000000000026 /* PilgrimPackagePhotoConverter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PilgrimPackagePhotoConverter.swift; sourceTree = "<group>"; };
 		BBBB000000000000000028 /* PilgrimPhotoEmbedder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PilgrimPhotoEmbedder.swift; sourceTree = "<group>"; };
@@ -1924,6 +1934,7 @@
 				871968A73E694CE1A7813792 /* DataManagerThreadsDeletionTests.swift */,
 				D44E1DA26DB135B0837E447F /* ThreadStoreTests.swift */,
 				C9665AA4903D4E27B8B2ED00 /* ReleasedThreadsStoreTests.swift */,
+				6F3D08345F1E4F12A8823657 /* ThreadsCardModelTests.swift */,
 				45EBA375CB284A57A169D5EC /* ReleasedThreadsPackageTests.swift */,
 				25F8773000AC4CCC93F68DAF /* FieldGateReportTests.swift */,
 				3C6AF4CB2CDC4F6DA1162CEA /* ThreadsDossierTests.swift */,
@@ -2293,6 +2304,8 @@
 				E0523495072F4F50ACDEF645 /* ThreadsBackfill.swift */,
 				2063941AD76F5A42ABCEB5D5 /* ThreadStore.swift */,
 				A2368779D0FD441D9871826F /* ReleasedThreadsStore.swift */,
+				FA610B7C7F364A1C9AE514A0 /* ThreadsTexture.swift */,
+				FAD772824C494BD8AB4FE370 /* ThreadsCardModel.swift */,
 				1E3FC6223746420D820D537F /* ThreadsDossierFormatter.swift */,
 				1060C3B913FD4DA88015D30D /* ThreadsDossierBuilder.swift */,
 				9493E7AD112D41C6B876DB33 /* ThreadIntentionSuggestions.swift */,
@@ -2346,6 +2359,8 @@
 			children = (
 				AA0001010000000000000006 /* WalkSummaryView.swift */,
 				BBBB000000000000000022 /* WalkSummaryView+Map.swift */,
+				F1A525D381BA42798281A07F /* WalkSummaryView+Threads.swift */,
+				0901C4D1764F482982F54637 /* ThreadsCardSection.swift */,
 				LR00000100000000LRWSRS01 /* WalkSummaryRecordingsSection.swift */,
 				AA00040100000000000001 /* VoiceRecordingRow.swift */,
 				AA00040100000000000003 /* AudioPlayerModel.swift */,
@@ -3059,6 +3074,8 @@
 				BB00031300000000000002 /* SoundscapePickerSheet.swift in Sources */,
 				AAAA0000000000000000FB /* WalkOptionsSheet.swift in Sources */,
 				AA0001010000000000000016 /* WalkSummaryView.swift in Sources */,
+				F52F97270EBD4F8688BC7D6C /* ThreadsCardSection.swift in Sources */,
+				75D65204CDD344D0847CE5AA /* WalkSummaryView+Threads.swift in Sources */,
 				AA00040100000000000002 /* VoiceRecordingRow.swift in Sources */,
 				AA00040100000000000004 /* AudioPlayerModel.swift in Sources */,
 				AAAA00000000000000000EL1 /* ElevationProfileView.swift in Sources */,
@@ -3271,6 +3288,8 @@
 				E66DD877BDBA458E95E4347F /* TranscriptContextAnalyzer.swift in Sources */,
 				CF635D421DBD437A8A75B616 /* ThreadsBackfill.swift in Sources */,
 				DFB954198A242EE69B14806B /* ThreadStore.swift in Sources */,
+				EFCD11E778754DE2A369A79A /* ThreadsTexture.swift in Sources */,
+				E0F1767D04764B35AF21D2D3 /* ThreadsCardModel.swift in Sources */,
 				3A9D73B10C5444B1AE84AAB6 /* ReleasedThreadsStore.swift in Sources */,
 				DDB1779FC0D3496A894799E5 /* ThreadsDossierFormatter.swift in Sources */,
 				4BCC1742561447DFBD59EF01 /* ThreadsDossierBuilder.swift in Sources */,
@@ -3300,6 +3319,7 @@
 				9199078D805D40A087270BF5 /* DataManagerThreadsDeletionTests.swift in Sources */,
 				4A874B223DF94F32AE65A3B2 /* ThreadStoreTests.swift in Sources */,
 				BC41523122F44D908CD01FF4 /* ReleasedThreadsStoreTests.swift in Sources */,
+				D3FD9359147B417CAD13958B /* ThreadsCardModelTests.swift in Sources */,
 				1143DC90344F45EFAFDAAC23 /* ReleasedThreadsPackageTests.swift in Sources */,
 				AB27642252E24998A3ABFA3B /* FieldGateReportTests.swift in Sources */,
 				366617D2E2404425A7BB8E0F /* ThreadsDossierTests.swift in Sources */,

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -223,6 +223,9 @@
 		E0F1767D04764B35AF21D2D3 /* ThreadsCardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD772824C494BD8AB4FE370 /* ThreadsCardModel.swift */; };
 		DF1D856E510A4199B572A5E6 /* ThreadHistoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC356D9E4F8431DB4CCD192 /* ThreadHistoryModel.swift */; };
 		3A9D73B10C5444B1AE84AAB6 /* ReleasedThreadsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2368779D0FD441D9871826F /* ReleasedThreadsStore.swift */; };
+		290FAD426253428DA5471752 /* ReleasedThreadsCopy.swift in Sources */ = {isa = PBXBuildFile; fileRef = A922130A1B034E01ABD20C6D /* ReleasedThreadsCopy.swift */; };
+		FE227C2D76C04F1B853BA2DA /* ReleasedThreadsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7026624BD82447EA9317EC81 /* ReleasedThreadsListView.swift */; };
+		B4BB6C15735F478E9E296F6C /* ReleasedThreadsInteractionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77462A5F095C4E4CA47D91CF /* ReleasedThreadsInteractionTests.swift */; };
 		BC41523122F44D908CD01FF4 /* ReleasedThreadsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9665AA4903D4E27B8B2ED00 /* ReleasedThreadsStoreTests.swift */; };
 		D3FD9359147B417CAD13958B /* ThreadsCardModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3D08345F1E4F12A8823657 /* ThreadsCardModelTests.swift */; };
 		1143DC90344F45EFAFDAAC23 /* ReleasedThreadsPackageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EBA375CB284A57A169D5EC /* ReleasedThreadsPackageTests.swift */; };
@@ -877,6 +880,9 @@
 		FAD772824C494BD8AB4FE370 /* ThreadsCardModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsCardModel.swift; sourceTree = "<group>"; };
 		DAC356D9E4F8431DB4CCD192 /* ThreadHistoryModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadHistoryModel.swift; sourceTree = "<group>"; };
 		A2368779D0FD441D9871826F /* ReleasedThreadsStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReleasedThreadsStore.swift; sourceTree = "<group>"; };
+		A922130A1B034E01ABD20C6D /* ReleasedThreadsCopy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReleasedThreadsCopy.swift; sourceTree = "<group>"; };
+		7026624BD82447EA9317EC81 /* ReleasedThreadsListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReleasedThreadsListView.swift; sourceTree = "<group>"; };
+		77462A5F095C4E4CA47D91CF /* ReleasedThreadsInteractionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReleasedThreadsInteractionTests.swift; sourceTree = "<group>"; };
 		F837FC0ECF4D4ED1BA756517 /* TranscriptContextAnalyzerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TranscriptContextAnalyzerTests.swift; sourceTree = "<group>"; };
 		1E3FC6223746420D820D537F /* ThreadsDossierFormatter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsDossierFormatter.swift; sourceTree = "<group>"; };
 		1060C3B913FD4DA88015D30D /* ThreadsDossierBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsDossierBuilder.swift; sourceTree = "<group>"; };
@@ -1948,6 +1954,7 @@
 				9C1E5F82D3B44A61A7E2C905 /* ThreadsBackfillTests.swift */,
 				7CAD4465FB34B28A145AA426 /* ThreadsReleaseFilteringTests.swift */,
 				C642300D15AD44EA99B4FC6D /* ThreadHistoryModelTests.swift */,
+				77462A5F095C4E4CA47D91CF /* ReleasedThreadsInteractionTests.swift */,
 				C14640E393BDAEC8C4856281 /* PromptAssemblerLanguageTests.swift */,
 				cc51a46c5e27674f5165b409 /* SharePayloadTourTests.swift */,
 				2B3C4D5E6F7A8B9C0D1E2F3A /* TourBuilderTests.swift */,
@@ -2311,6 +2318,7 @@
 				E0523495072F4F50ACDEF645 /* ThreadsBackfill.swift */,
 				2063941AD76F5A42ABCEB5D5 /* ThreadStore.swift */,
 				A2368779D0FD441D9871826F /* ReleasedThreadsStore.swift */,
+				A922130A1B034E01ABD20C6D /* ReleasedThreadsCopy.swift */,
 				FA610B7C7F364A1C9AE514A0 /* ThreadsTexture.swift */,
 				FAD772824C494BD8AB4FE370 /* ThreadsCardModel.swift */,
 				DAC356D9E4F8431DB4CCD192 /* ThreadHistoryModel.swift */,
@@ -2483,6 +2491,7 @@
 				CC01000100000000SETSGRP1 /* SettingsCards */,
 				0F5581F46A4FFE9ED1D2DCEB /* SoundSettingsView.swift */,
 				D4E5F6A7B8C9D0E1F2A3B4C6 /* RecordingsListView.swift */,
+				7026624BD82447EA9317EC81 /* ReleasedThreadsListView.swift */,
 				567070352F733CB000FD1910 /* JourneyViewerView.swift */,
 				A1B2C3D4E5F6A7B8C9D0E1F2 /* PermissionStatusViewModel.swift */,
 				B4C5D6E7F8A9B0C1D2E3F4A7 /* FeedbackView.swift */,
@@ -3301,6 +3310,8 @@
 				EFCD11E778754DE2A369A79A /* ThreadsTexture.swift in Sources */,
 				E0F1767D04764B35AF21D2D3 /* ThreadsCardModel.swift in Sources */,
 				DF1D856E510A4199B572A5E6 /* ThreadHistoryModel.swift in Sources */,
+				290FAD426253428DA5471752 /* ReleasedThreadsCopy.swift in Sources */,
+				FE227C2D76C04F1B853BA2DA /* ReleasedThreadsListView.swift in Sources */,
 				3A9D73B10C5444B1AE84AAB6 /* ReleasedThreadsStore.swift in Sources */,
 				DDB1779FC0D3496A894799E5 /* ThreadsDossierFormatter.swift in Sources */,
 				4BCC1742561447DFBD59EF01 /* ThreadsDossierBuilder.swift in Sources */,
@@ -3338,6 +3349,7 @@
 				4D8F2B7A1C9E4E33B6A5D014 /* ThreadsBackfillTests.swift in Sources */,
 				D52773868F67D01927C78847 /* ThreadsReleaseFilteringTests.swift in Sources */,
 				7BFB56F11953470F8D5DF41A /* ThreadHistoryModelTests.swift in Sources */,
+				B4BB6C15735F478E9E296F6C /* ReleasedThreadsInteractionTests.swift in Sources */,
 				2161BB76D1D8B9E8BBB49B5A /* PromptAssemblerLanguageTests.swift in Sources */,
 				7ac8ee442a1ce6fcb926501a /* SharePayloadTourTests.swift in Sources */,
 				1A2B3C4D5E6F7A8B9C0D1E2F /* TourBuilderTests.swift in Sources */,

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 		7BFB56F11953470F8D5DF41A /* ThreadHistoryModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C642300D15AD44EA99B4FC6D /* ThreadHistoryModelTests.swift */; };
 		1BD1E96A084348F19A83EA07 /* LunationCalendarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5F0FCF0F88F406D8DECECA9 /* LunationCalendarTests.swift */; };
 		A250CB53C9A74F1184AE2F2D /* LunationRecapStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8E7CCD261729470B9FFFEB8D /* LunationRecapStateTests.swift */; };
+		9AD6FE386B1E4F5E8C9C9DC5 /* LunationRecapModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE20BA44E2734D3DBA0270CE /* LunationRecapModelTests.swift */; };
 		50A16B63C6F23E2D1E6210BA /* Pods_Pilgrim.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */; };
 		510A5ED79C24B905DDD597A7 /* ScrollHapticEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F12E1FE28A875629DBD34C /* ScrollHapticEngineTests.swift */; };
 		52C6F28B0AAB6E494591E8EF /* VoiceGuideManifestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F883597323B0CE64E69DC9 /* VoiceGuideManifestService.swift */; };
@@ -467,6 +468,9 @@
 		CC00000200000000LUNRPH01 /* LunarPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000LUNRPH01 /* LunarPhase.swift */; };
 		6974E7EAF5A14C6CAA88085C /* LunationCalendar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CAC84DBE9A24323906E2A32 /* LunationCalendar.swift */; };
 		D1E7C0F08C6D49B5BD8569CF /* LunationRecapState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0BCF0EB1C954E0DB321DEE9 /* LunationRecapState.swift */; };
+		941FFDB60FFB4841897D0A88 /* LunationRecapModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F945A0A6043749C681A2A0EC /* LunationRecapModel.swift */; };
+		BDED6E0C048C42AABD18992C /* LunationRecapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 564348D4E1584021AFE338B6 /* LunationRecapView.swift */; };
+		175825FFE997434E87BC66C4 /* PastRecapsListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D0BADFD98F423EBE90F92A /* PastRecapsListView.swift */; };
 		CC00000200000000LUNRTST1 /* LunarPhaseTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000LUNRTST1 /* LunarPhaseTests.swift */; };
 		CC00000200000000MAINTB01 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000MAINTB01 /* MainTabView.swift */; };
 		CC00000200000000MILEST01 /* MilestoneMarkerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC00000100000000MILEST01 /* MilestoneMarkerView.swift */; };
@@ -898,6 +902,7 @@
 		C642300D15AD44EA99B4FC6D /* ThreadHistoryModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadHistoryModelTests.swift; sourceTree = "<group>"; };
 		F5F0FCF0F88F406D8DECECA9 /* LunationCalendarTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LunationCalendarTests.swift; sourceTree = "<group>"; };
 		8E7CCD261729470B9FFFEB8D /* LunationRecapStateTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LunationRecapStateTests.swift; sourceTree = "<group>"; };
+		FE20BA44E2734D3DBA0270CE /* LunationRecapModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LunationRecapModelTests.swift; sourceTree = "<group>"; };
 		3E5EFD54CACA590B1BE78B75 /* BellPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BellPlayer.swift; sourceTree = "<group>"; };
 		3FE8447AB26F2388EA548BED /* SeekSoundPlayerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SeekSoundPlayerTests.swift; sourceTree = "<group>"; };
 		4181215714A52E71449BC390 /* WalkDataFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkDataFactory.swift; sourceTree = "<group>"; };
@@ -1138,6 +1143,9 @@
 		CC00000100000000LUNRPH01 /* LunarPhase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LunarPhase.swift; sourceTree = "<group>"; };
 		5CAC84DBE9A24323906E2A32 /* LunationCalendar.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LunationCalendar.swift; sourceTree = "<group>"; };
 		E0BCF0EB1C954E0DB321DEE9 /* LunationRecapState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LunationRecapState.swift; sourceTree = "<group>"; };
+		F945A0A6043749C681A2A0EC /* LunationRecapModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LunationRecapModel.swift; sourceTree = "<group>"; };
+		564348D4E1584021AFE338B6 /* LunationRecapView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LunationRecapView.swift; sourceTree = "<group>"; };
+		24D0BADFD98F423EBE90F92A /* PastRecapsListView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PastRecapsListView.swift; sourceTree = "<group>"; };
 		CC00000100000000LUNRTST1 /* LunarPhaseTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = LunarPhaseTests.swift; sourceTree = "<group>"; };
 		CC00000100000000MAINTB01 /* MainTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainTabView.swift; sourceTree = "<group>"; };
 		CC00000100000000MILEST01 /* MilestoneMarkerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MilestoneMarkerView.swift; sourceTree = "<group>"; };
@@ -1964,6 +1972,7 @@
 				C642300D15AD44EA99B4FC6D /* ThreadHistoryModelTests.swift */,
 				F5F0FCF0F88F406D8DECECA9 /* LunationCalendarTests.swift */,
 				8E7CCD261729470B9FFFEB8D /* LunationRecapStateTests.swift */,
+				FE20BA44E2734D3DBA0270CE /* LunationRecapModelTests.swift */,
 				77462A5F095C4E4CA47D91CF /* ReleasedThreadsInteractionTests.swift */,
 				C14640E393BDAEC8C4856281 /* PromptAssemblerLanguageTests.swift */,
 				cc51a46c5e27674f5165b409 /* SharePayloadTourTests.swift */,
@@ -2337,6 +2346,7 @@
 				9493E7AD112D41C6B876DB33 /* ThreadIntentionSuggestions.swift */,
 				5CAC84DBE9A24323906E2A32 /* LunationCalendar.swift */,
 				E0BCF0EB1C954E0DB321DEE9 /* LunationRecapState.swift */,
+				F945A0A6043749C681A2A0EC /* LunationRecapModel.swift */,
 			);
 			path = Threads;
 			sourceTree = "<group>";
@@ -2390,6 +2400,7 @@
 				F1A525D381BA42798281A07F /* WalkSummaryView+Threads.swift */,
 				0901C4D1764F482982F54637 /* ThreadsCardSection.swift */,
 				7E4DA7EF8CEE45E1BFA114E9 /* ThreadHistoryView.swift */,
+				564348D4E1584021AFE338B6 /* LunationRecapView.swift */,
 				LR00000100000000LRWSRS01 /* WalkSummaryRecordingsSection.swift */,
 				AA00040100000000000001 /* VoiceRecordingRow.swift */,
 				AA00040100000000000003 /* AudioPlayerModel.swift */,
@@ -2504,6 +2515,7 @@
 				0F5581F46A4FFE9ED1D2DCEB /* SoundSettingsView.swift */,
 				D4E5F6A7B8C9D0E1F2A3B4C6 /* RecordingsListView.swift */,
 				7026624BD82447EA9317EC81 /* ReleasedThreadsListView.swift */,
+				24D0BADFD98F423EBE90F92A /* PastRecapsListView.swift */,
 				567070352F733CB000FD1910 /* JourneyViewerView.swift */,
 				A1B2C3D4E5F6A7B8C9D0E1F2 /* PermissionStatusViewModel.swift */,
 				B4C5D6E7F8A9B0C1D2E3F4A7 /* FeedbackView.swift */,
@@ -3071,6 +3083,7 @@
 				CC00000200000000LUNRPH01 /* LunarPhase.swift in Sources */,
 				6974E7EAF5A14C6CAA88085C /* LunationCalendar.swift in Sources */,
 				D1E7C0F08C6D49B5BD8569CF /* LunationRecapState.swift in Sources */,
+				941FFDB60FFB4841897D0A88 /* LunationRecapModel.swift in Sources */,
 				CC00000200000000SEEDRG01 /* SeededRNG.swift in Sources */,
 				CC00000200000000MOONPV01 /* MoonPhaseView.swift in Sources */,
 				CC00000200000000SETTVW01 /* SettingsView.swift in Sources */,
@@ -3109,6 +3122,7 @@
 				F52F97270EBD4F8688BC7D6C /* ThreadsCardSection.swift in Sources */,
 				8B992AFB3A134352AE353EF5 /* ThreadHistoryView.swift in Sources */,
 				75D65204CDD344D0847CE5AA /* WalkSummaryView+Threads.swift in Sources */,
+				BDED6E0C048C42AABD18992C /* LunationRecapView.swift in Sources */,
 				AA00040100000000000002 /* VoiceRecordingRow.swift in Sources */,
 				AA00040100000000000004 /* AudioPlayerModel.swift in Sources */,
 				AAAA00000000000000000EL1 /* ElevationProfileView.swift in Sources */,
@@ -3326,6 +3340,7 @@
 				DF1D856E510A4199B572A5E6 /* ThreadHistoryModel.swift in Sources */,
 				290FAD426253428DA5471752 /* ReleasedThreadsCopy.swift in Sources */,
 				FE227C2D76C04F1B853BA2DA /* ReleasedThreadsListView.swift in Sources */,
+				175825FFE997434E87BC66C4 /* PastRecapsListView.swift in Sources */,
 				3A9D73B10C5444B1AE84AAB6 /* ReleasedThreadsStore.swift in Sources */,
 				DDB1779FC0D3496A894799E5 /* ThreadsDossierFormatter.swift in Sources */,
 				4BCC1742561447DFBD59EF01 /* ThreadsDossierBuilder.swift in Sources */,
@@ -3365,6 +3380,7 @@
 				7BFB56F11953470F8D5DF41A /* ThreadHistoryModelTests.swift in Sources */,
 				1BD1E96A084348F19A83EA07 /* LunationCalendarTests.swift in Sources */,
 				A250CB53C9A74F1184AE2F2D /* LunationRecapStateTests.swift in Sources */,
+				9AD6FE386B1E4F5E8C9C9DC5 /* LunationRecapModelTests.swift in Sources */,
 				B4BB6C15735F478E9E296F6C /* ReleasedThreadsInteractionTests.swift in Sources */,
 				2161BB76D1D8B9E8BBB49B5A /* PromptAssemblerLanguageTests.swift in Sources */,
 				7ac8ee442a1ce6fcb926501a /* SharePayloadTourTests.swift in Sources */,

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@
 		DFB954198A242EE69B14806B /* ThreadStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2063941AD76F5A42ABCEB5D5 /* ThreadStore.swift */; };
 		EFCD11E778754DE2A369A79A /* ThreadsTexture.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA610B7C7F364A1C9AE514A0 /* ThreadsTexture.swift */; };
 		E0F1767D04764B35AF21D2D3 /* ThreadsCardModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAD772824C494BD8AB4FE370 /* ThreadsCardModel.swift */; };
+		DF1D856E510A4199B572A5E6 /* ThreadHistoryModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAC356D9E4F8431DB4CCD192 /* ThreadHistoryModel.swift */; };
 		3A9D73B10C5444B1AE84AAB6 /* ReleasedThreadsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2368779D0FD441D9871826F /* ReleasedThreadsStore.swift */; };
 		BC41523122F44D908CD01FF4 /* ReleasedThreadsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9665AA4903D4E27B8B2ED00 /* ReleasedThreadsStoreTests.swift */; };
 		D3FD9359147B417CAD13958B /* ThreadsCardModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F3D08345F1E4F12A8823657 /* ThreadsCardModelTests.swift */; };
@@ -233,6 +234,7 @@
 		12B4814A464F4B33A4DFDF5E /* ThreadIntentionSuggestionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1177FF093DBC4775929CC150 /* ThreadIntentionSuggestionsTests.swift */; };
 		4D8F2B7A1C9E4E33B6A5D014 /* ThreadsBackfillTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C1E5F82D3B44A61A7E2C905 /* ThreadsBackfillTests.swift */; };
 		D52773868F67D01927C78847 /* ThreadsReleaseFilteringTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CAD4465FB34B28A145AA426 /* ThreadsReleaseFilteringTests.swift */; };
+		7BFB56F11953470F8D5DF41A /* ThreadHistoryModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C642300D15AD44EA99B4FC6D /* ThreadHistoryModelTests.swift */; };
 		50A16B63C6F23E2D1E6210BA /* Pods_Pilgrim.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D2DC1601B9458B3FC1788F0E /* Pods_Pilgrim.framework */; };
 		510A5ED79C24B905DDD597A7 /* ScrollHapticEngineTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E8F12E1FE28A875629DBD34C /* ScrollHapticEngineTests.swift */; };
 		52C6F28B0AAB6E494591E8EF /* VoiceGuideManifestService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74F883597323B0CE64E69DC9 /* VoiceGuideManifestService.swift */; };
@@ -414,6 +416,7 @@
 		BBBB000000000000000021 /* PhotoPreviewSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000000000020 /* PhotoPreviewSheet.swift */; };
 		BBBB000000000000000023 /* WalkSummaryView+Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000000000022 /* WalkSummaryView+Map.swift */; };
 		F52F97270EBD4F8688BC7D6C /* ThreadsCardSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0901C4D1764F482982F54637 /* ThreadsCardSection.swift */; };
+		8B992AFB3A134352AE353EF5 /* ThreadHistoryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4DA7EF8CEE45E1BFA114E9 /* ThreadHistoryView.swift */; };
 		75D65204CDD344D0847CE5AA /* WalkSummaryView+Threads.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A525D381BA42798281A07F /* WalkSummaryView+Threads.swift */; };
 		BBBB000000000000000025 /* PilgrimPackagePhotoTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000000000024 /* PilgrimPackagePhotoTests.swift */; };
 		BBBB000000000000000027 /* PilgrimPackagePhotoConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BBBB000000000000000026 /* PilgrimPackagePhotoConverter.swift */; };
@@ -872,6 +875,7 @@
 		2063941AD76F5A42ABCEB5D5 /* ThreadStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadStore.swift; sourceTree = "<group>"; };
 		FA610B7C7F364A1C9AE514A0 /* ThreadsTexture.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsTexture.swift; sourceTree = "<group>"; };
 		FAD772824C494BD8AB4FE370 /* ThreadsCardModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsCardModel.swift; sourceTree = "<group>"; };
+		DAC356D9E4F8431DB4CCD192 /* ThreadHistoryModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadHistoryModel.swift; sourceTree = "<group>"; };
 		A2368779D0FD441D9871826F /* ReleasedThreadsStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReleasedThreadsStore.swift; sourceTree = "<group>"; };
 		F837FC0ECF4D4ED1BA756517 /* TranscriptContextAnalyzerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TranscriptContextAnalyzerTests.swift; sourceTree = "<group>"; };
 		1E3FC6223746420D820D537F /* ThreadsDossierFormatter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsDossierFormatter.swift; sourceTree = "<group>"; };
@@ -881,6 +885,7 @@
 		1177FF093DBC4775929CC150 /* ThreadIntentionSuggestionsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadIntentionSuggestionsTests.swift; sourceTree = "<group>"; };
 		9C1E5F82D3B44A61A7E2C905 /* ThreadsBackfillTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsBackfillTests.swift; sourceTree = "<group>"; };
 		7CAD4465FB34B28A145AA426 /* ThreadsReleaseFilteringTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsReleaseFilteringTests.swift; sourceTree = "<group>"; };
+		C642300D15AD44EA99B4FC6D /* ThreadHistoryModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadHistoryModelTests.swift; sourceTree = "<group>"; };
 		3E5EFD54CACA590B1BE78B75 /* BellPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BellPlayer.swift; sourceTree = "<group>"; };
 		3FE8447AB26F2388EA548BED /* SeekSoundPlayerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SeekSoundPlayerTests.swift; sourceTree = "<group>"; };
 		4181215714A52E71449BC390 /* WalkDataFactory.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkDataFactory.swift; sourceTree = "<group>"; };
@@ -1071,6 +1076,7 @@
 		BBBB000000000000000020 /* PhotoPreviewSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhotoPreviewSheet.swift; sourceTree = "<group>"; };
 		BBBB000000000000000022 /* WalkSummaryView+Map.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "WalkSummaryView+Map.swift"; sourceTree = "<group>"; };
 		0901C4D1764F482982F54637 /* ThreadsCardSection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsCardSection.swift; sourceTree = "<group>"; };
+		7E4DA7EF8CEE45E1BFA114E9 /* ThreadHistoryView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadHistoryView.swift; sourceTree = "<group>"; };
 		F1A525D381BA42798281A07F /* WalkSummaryView+Threads.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "WalkSummaryView+Threads.swift"; sourceTree = "<group>"; };
 		BBBB000000000000000024 /* PilgrimPackagePhotoTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PilgrimPackagePhotoTests.swift; sourceTree = "<group>"; };
 		BBBB000000000000000026 /* PilgrimPackagePhotoConverter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PilgrimPackagePhotoConverter.swift; sourceTree = "<group>"; };
@@ -1941,6 +1947,7 @@
 				1177FF093DBC4775929CC150 /* ThreadIntentionSuggestionsTests.swift */,
 				9C1E5F82D3B44A61A7E2C905 /* ThreadsBackfillTests.swift */,
 				7CAD4465FB34B28A145AA426 /* ThreadsReleaseFilteringTests.swift */,
+				C642300D15AD44EA99B4FC6D /* ThreadHistoryModelTests.swift */,
 				C14640E393BDAEC8C4856281 /* PromptAssemblerLanguageTests.swift */,
 				cc51a46c5e27674f5165b409 /* SharePayloadTourTests.swift */,
 				2B3C4D5E6F7A8B9C0D1E2F3A /* TourBuilderTests.swift */,
@@ -2306,6 +2313,7 @@
 				A2368779D0FD441D9871826F /* ReleasedThreadsStore.swift */,
 				FA610B7C7F364A1C9AE514A0 /* ThreadsTexture.swift */,
 				FAD772824C494BD8AB4FE370 /* ThreadsCardModel.swift */,
+				DAC356D9E4F8431DB4CCD192 /* ThreadHistoryModel.swift */,
 				1E3FC6223746420D820D537F /* ThreadsDossierFormatter.swift */,
 				1060C3B913FD4DA88015D30D /* ThreadsDossierBuilder.swift */,
 				9493E7AD112D41C6B876DB33 /* ThreadIntentionSuggestions.swift */,
@@ -2361,6 +2369,7 @@
 				BBBB000000000000000022 /* WalkSummaryView+Map.swift */,
 				F1A525D381BA42798281A07F /* WalkSummaryView+Threads.swift */,
 				0901C4D1764F482982F54637 /* ThreadsCardSection.swift */,
+				7E4DA7EF8CEE45E1BFA114E9 /* ThreadHistoryView.swift */,
 				LR00000100000000LRWSRS01 /* WalkSummaryRecordingsSection.swift */,
 				AA00040100000000000001 /* VoiceRecordingRow.swift */,
 				AA00040100000000000003 /* AudioPlayerModel.swift */,
@@ -3075,6 +3084,7 @@
 				AAAA0000000000000000FB /* WalkOptionsSheet.swift in Sources */,
 				AA0001010000000000000016 /* WalkSummaryView.swift in Sources */,
 				F52F97270EBD4F8688BC7D6C /* ThreadsCardSection.swift in Sources */,
+				8B992AFB3A134352AE353EF5 /* ThreadHistoryView.swift in Sources */,
 				75D65204CDD344D0847CE5AA /* WalkSummaryView+Threads.swift in Sources */,
 				AA00040100000000000002 /* VoiceRecordingRow.swift in Sources */,
 				AA00040100000000000004 /* AudioPlayerModel.swift in Sources */,
@@ -3290,6 +3300,7 @@
 				DFB954198A242EE69B14806B /* ThreadStore.swift in Sources */,
 				EFCD11E778754DE2A369A79A /* ThreadsTexture.swift in Sources */,
 				E0F1767D04764B35AF21D2D3 /* ThreadsCardModel.swift in Sources */,
+				DF1D856E510A4199B572A5E6 /* ThreadHistoryModel.swift in Sources */,
 				3A9D73B10C5444B1AE84AAB6 /* ReleasedThreadsStore.swift in Sources */,
 				DDB1779FC0D3496A894799E5 /* ThreadsDossierFormatter.swift in Sources */,
 				4BCC1742561447DFBD59EF01 /* ThreadsDossierBuilder.swift in Sources */,
@@ -3326,6 +3337,7 @@
 				12B4814A464F4B33A4DFDF5E /* ThreadIntentionSuggestionsTests.swift in Sources */,
 				4D8F2B7A1C9E4E33B6A5D014 /* ThreadsBackfillTests.swift in Sources */,
 				D52773868F67D01927C78847 /* ThreadsReleaseFilteringTests.swift in Sources */,
+				7BFB56F11953470F8D5DF41A /* ThreadHistoryModelTests.swift in Sources */,
 				2161BB76D1D8B9E8BBB49B5A /* PromptAssemblerLanguageTests.swift in Sources */,
 				7ac8ee442a1ce6fcb926501a /* SharePayloadTourTests.swift in Sources */,
 				1A2B3C4D5E6F7A8B9C0D1E2F /* TourBuilderTests.swift in Sources */,

--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -219,6 +219,9 @@
 		E66DD877BDBA458E95E4347F /* TranscriptContextAnalyzer.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEE8A0304E2A421E8707E109 /* TranscriptContextAnalyzer.swift */; };
 		CF635D421DBD437A8A75B616 /* ThreadsBackfill.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0523495072F4F50ACDEF645 /* ThreadsBackfill.swift */; };
 		DFB954198A242EE69B14806B /* ThreadStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2063941AD76F5A42ABCEB5D5 /* ThreadStore.swift */; };
+		3A9D73B10C5444B1AE84AAB6 /* ReleasedThreadsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2368779D0FD441D9871826F /* ReleasedThreadsStore.swift */; };
+		BC41523122F44D908CD01FF4 /* ReleasedThreadsStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9665AA4903D4E27B8B2ED00 /* ReleasedThreadsStoreTests.swift */; };
+		1143DC90344F45EFAFDAAC23 /* ReleasedThreadsPackageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45EBA375CB284A57A169D5EC /* ReleasedThreadsPackageTests.swift */; };
 		23795691640A42D0872CBC91 /* TranscriptContextAnalyzerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F837FC0ECF4D4ED1BA756517 /* TranscriptContextAnalyzerTests.swift */; };
 		DDB1779FC0D3496A894799E5 /* ThreadsDossierFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E3FC6223746420D820D537F /* ThreadsDossierFormatter.swift */; };
 		4BCC1742561447DFBD59EF01 /* ThreadsDossierBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1060C3B913FD4DA88015D30D /* ThreadsDossierBuilder.swift */; };
@@ -852,12 +855,15 @@
 		BDFBDD16091E474E8A5067CF /* TranscriptContextStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TranscriptContextStoreTests.swift; sourceTree = "<group>"; };
 		871968A73E694CE1A7813792 /* DataManagerThreadsDeletionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DataManagerThreadsDeletionTests.swift; sourceTree = "<group>"; };
 		D44E1DA26DB135B0837E447F /* ThreadStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadStoreTests.swift; sourceTree = "<group>"; };
+		C9665AA4903D4E27B8B2ED00 /* ReleasedThreadsStoreTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReleasedThreadsStoreTests.swift; sourceTree = "<group>"; };
+		45EBA375CB284A57A169D5EC /* ReleasedThreadsPackageTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReleasedThreadsPackageTests.swift; sourceTree = "<group>"; };
 		25F8773000AC4CCC93F68DAF /* FieldGateReportTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = FieldGateReportTests.swift; sourceTree = "<group>"; };
 		5ABD94794DC646449548E6FE /* TranscriptContext.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TranscriptContext.swift; sourceTree = "<group>"; };
 		21A9DB8ECE2349858CF3747B /* TranscriptContextStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TranscriptContextStore.swift; sourceTree = "<group>"; };
 		AEE8A0304E2A421E8707E109 /* TranscriptContextAnalyzer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TranscriptContextAnalyzer.swift; sourceTree = "<group>"; };
 		E0523495072F4F50ACDEF645 /* ThreadsBackfill.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsBackfill.swift; sourceTree = "<group>"; };
 		2063941AD76F5A42ABCEB5D5 /* ThreadStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadStore.swift; sourceTree = "<group>"; };
+		A2368779D0FD441D9871826F /* ReleasedThreadsStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReleasedThreadsStore.swift; sourceTree = "<group>"; };
 		F837FC0ECF4D4ED1BA756517 /* TranscriptContextAnalyzerTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TranscriptContextAnalyzerTests.swift; sourceTree = "<group>"; };
 		1E3FC6223746420D820D537F /* ThreadsDossierFormatter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsDossierFormatter.swift; sourceTree = "<group>"; };
 		1060C3B913FD4DA88015D30D /* ThreadsDossierBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsDossierBuilder.swift; sourceTree = "<group>"; };
@@ -1915,6 +1921,8 @@
 				F837FC0ECF4D4ED1BA756517 /* TranscriptContextAnalyzerTests.swift */,
 				871968A73E694CE1A7813792 /* DataManagerThreadsDeletionTests.swift */,
 				D44E1DA26DB135B0837E447F /* ThreadStoreTests.swift */,
+				C9665AA4903D4E27B8B2ED00 /* ReleasedThreadsStoreTests.swift */,
+				45EBA375CB284A57A169D5EC /* ReleasedThreadsPackageTests.swift */,
 				25F8773000AC4CCC93F68DAF /* FieldGateReportTests.swift */,
 				3C6AF4CB2CDC4F6DA1162CEA /* ThreadsDossierTests.swift */,
 				1177FF093DBC4775929CC150 /* ThreadIntentionSuggestionsTests.swift */,
@@ -2281,6 +2289,7 @@
 				AEE8A0304E2A421E8707E109 /* TranscriptContextAnalyzer.swift */,
 				E0523495072F4F50ACDEF645 /* ThreadsBackfill.swift */,
 				2063941AD76F5A42ABCEB5D5 /* ThreadStore.swift */,
+				A2368779D0FD441D9871826F /* ReleasedThreadsStore.swift */,
 				1E3FC6223746420D820D537F /* ThreadsDossierFormatter.swift */,
 				1060C3B913FD4DA88015D30D /* ThreadsDossierBuilder.swift */,
 				9493E7AD112D41C6B876DB33 /* ThreadIntentionSuggestions.swift */,
@@ -3259,6 +3268,7 @@
 				E66DD877BDBA458E95E4347F /* TranscriptContextAnalyzer.swift in Sources */,
 				CF635D421DBD437A8A75B616 /* ThreadsBackfill.swift in Sources */,
 				DFB954198A242EE69B14806B /* ThreadStore.swift in Sources */,
+				3A9D73B10C5444B1AE84AAB6 /* ReleasedThreadsStore.swift in Sources */,
 				DDB1779FC0D3496A894799E5 /* ThreadsDossierFormatter.swift in Sources */,
 				4BCC1742561447DFBD59EF01 /* ThreadsDossierBuilder.swift in Sources */,
 				77B84A5DD3344F7995B8F0FB /* ThreadIntentionSuggestions.swift in Sources */,
@@ -3286,6 +3296,8 @@
 				23795691640A42D0872CBC91 /* TranscriptContextAnalyzerTests.swift in Sources */,
 				9199078D805D40A087270BF5 /* DataManagerThreadsDeletionTests.swift in Sources */,
 				4A874B223DF94F32AE65A3B2 /* ThreadStoreTests.swift in Sources */,
+				BC41523122F44D908CD01FF4 /* ReleasedThreadsStoreTests.swift in Sources */,
+				1143DC90344F45EFAFDAAC23 /* ReleasedThreadsPackageTests.swift in Sources */,
 				AB27642252E24998A3ABFA3B /* FieldGateReportTests.swift in Sources */,
 				366617D2E2404425A7BB8E0F /* ThreadsDossierTests.swift in Sources */,
 				12B4814A464F4B33A4DFDF5E /* ThreadIntentionSuggestionsTests.swift in Sources */,

--- a/Pilgrim/Models/Data/DataManager+VoiceRecording.swift
+++ b/Pilgrim/Models/Data/DataManager+VoiceRecording.swift
@@ -193,6 +193,27 @@ extension DataManager {
         return index
     }
 
+    /// Recording UUID → words-per-minute, for the recap's pace texture. A
+    /// two-column `queryAttributes` fetch mirroring the snapshot queries
+    /// above. Main-actor only, like its neighbors.
+    @MainActor
+    public static func voiceRecordingPaceIndex() -> [UUID: Double] {
+        guard let rows = try? dataStack.queryAttributes(
+            From<VoiceRecording>().select(
+                NSDictionary.self,
+                .attribute(\._uuid),
+                .attribute(\._wordsPerMinute)
+            )
+        ) else { return [:] }
+        var index: [UUID: Double] = [:]
+        for row in rows {
+            guard let uuid = row["id"] as? UUID,
+                  let wpm = row["wordsPerMinute"] as? Double else { continue }
+            index[uuid] = wpm
+        }
+        return index
+    }
+
     public static func updateVoiceRecordingWordsPerMinute(
         uuid: UUID,
         wordsPerMinute: Double,

--- a/Pilgrim/Models/Data/DataManager+VoiceRecording.swift
+++ b/Pilgrim/Models/Data/DataManager+VoiceRecording.swift
@@ -130,7 +130,12 @@ extension DataManager {
     /// "transcription" — frozen SQL names) instead of `fetchAll`, which
     /// faulted in every recording row, one SQL round-trip each — mirroring
     /// `voiceRecordingWalkIndex` below. Main-actor only, like the other
-    /// snapshot queries here.
+    /// snapshot queries here. `queryAttributes` returns the raw stored value
+    /// for "id" — CoreStore's `UUID: QueryableAttributeType` declares
+    /// `cs_rawAttributeType = .stringAttributeType`, so the dictionary row
+    /// never carries a bridged `UUID`/`NSUUID`, only the string CoreStore
+    /// wrote. `rowUUID` undoes that encoding explicitly instead of relying
+    /// on a cast that can only ever fail.
     @MainActor
     public static func transcribedRecordingsSnapshot() -> [(uuid: UUID, transcript: String)] {
         guard let rows = try? dataStack.queryAttributes(
@@ -141,7 +146,7 @@ extension DataManager {
             )
         ) else { return [] }
         return rows.compactMap { row in
-            guard let uuid = row["id"] as? UUID,
+            guard let uuid = rowUUID(row["id"]),
                   let transcript = row["transcription"] as? String,
                   !transcript.isEmpty else { return nil }
             return (uuid, transcript)
@@ -205,7 +210,9 @@ extension DataManager {
 
     /// Recording UUID → words-per-minute, for the recap's pace texture. A
     /// two-column `queryAttributes` fetch mirroring the snapshot queries
-    /// above. Main-actor only, like its neighbors.
+    /// above. Main-actor only, like its neighbors. Same string-backed "id"
+    /// column as `transcribedRecordingsSnapshot` above — `rowUUID` undoes
+    /// CoreStore's `.stringAttributeType` encoding for `UUID` explicitly.
     @MainActor
     public static func voiceRecordingPaceIndex() -> [UUID: Double] {
         guard let rows = try? dataStack.queryAttributes(
@@ -217,7 +224,7 @@ extension DataManager {
         ) else { return [:] }
         var index: [UUID: Double] = [:]
         for row in rows {
-            guard let uuid = row["id"] as? UUID,
+            guard let uuid = rowUUID(row["id"]),
                   let wpm = row["wordsPerMinute"] as? Double else { continue }
             index[uuid] = wpm
         }

--- a/Pilgrim/Models/Data/DataManager+VoiceRecording.swift
+++ b/Pilgrim/Models/Data/DataManager+VoiceRecording.swift
@@ -155,6 +155,12 @@ extension DataManager {
     /// queries joined by object ID instead of `fetchAll` — the old path
     /// faulted in every recording row plus its walk, one SQL round-trip
     /// each. Main-actor only, matching the other snapshot queries here.
+    /// `queryAttributes` returns the raw stored value for "id" — CoreStore's
+    /// `UUID: QueryableAttributeType` declares `cs_rawAttributeType =
+    /// .stringAttributeType`, so the dictionary row never carries a bridged
+    /// `UUID`/`NSUUID`, only the string CoreStore wrote. `rowUUID` undoes
+    /// that encoding explicitly instead of relying on a cast that can only
+    /// ever fail.
     @MainActor
     public static func voiceRecordingWalkIndex() -> [UUID: (walkUUID: UUID, date: Date)] {
         guard
@@ -178,19 +184,23 @@ extension DataManager {
         var walksByObjectID: [NSManagedObjectID: (walkUUID: UUID, date: Date)] = [:]
         for row in walkRows {
             guard let objectID = row["objectID"] as? NSManagedObjectID,
-                  let walkUUID = row["id"] as? UUID,
+                  let walkUUID = rowUUID(row["id"]),
                   let startDate = row["startDate"] as? Date else { continue }
             walksByObjectID[objectID] = (walkUUID, startDate)
         }
 
         var index: [UUID: (walkUUID: UUID, date: Date)] = [:]
         for row in recordingRows {
-            guard let uuid = row["id"] as? UUID,
+            guard let uuid = rowUUID(row["id"]),
                   let walkObjectID = row["workout"] as? NSManagedObjectID,
                   let walk = walksByObjectID[walkObjectID] else { continue }
             index[uuid] = walk
         }
         return index
+    }
+
+    private static func rowUUID(_ raw: Any?) -> UUID? {
+        (raw as? String).flatMap(UUID.init(uuidString:))
     }
 
     /// Recording UUID → words-per-minute, for the recap's pace texture. A

--- a/Pilgrim/Models/Data/DataManager+VoiceRecording.swift
+++ b/Pilgrim/Models/Data/DataManager+VoiceRecording.swift
@@ -204,6 +204,29 @@ extension DataManager {
         return index
     }
 
+    /// Same shape as `transcribedRecordingsSnapshot()` above, scoped to the
+    /// given recordings — for callers (ThreadHistoryView) that already know
+    /// exactly which recordings they need and would otherwise pay for a
+    /// full-history fetch to excerpt a handful of entries. Empty input
+    /// short-circuits without a round trip.
+    @MainActor
+    public static func transcribedRecordingsSnapshot(uuids: Set<UUID>) -> [(uuid: UUID, transcript: String)] {
+        guard !uuids.isEmpty else { return [] }
+        guard let rows = try? dataStack.queryAttributes(
+            From<VoiceRecording>().select(
+                NSDictionary.self,
+                .attribute(\._uuid),
+                .attribute(\._transcription)
+            ).where(Where<VoiceRecording>(\._uuid, isMemberOf: uuids))
+        ) else { return [] }
+        return rows.compactMap { row in
+            guard let uuid = rowUUID(row["id"]),
+                  let transcript = row["transcription"] as? String,
+                  !transcript.isEmpty else { return nil }
+            return (uuid, transcript)
+        }
+    }
+
     private static func rowUUID(_ raw: Any?) -> UUID? {
         (raw as? String).flatMap(UUID.init(uuidString:))
     }

--- a/Pilgrim/Models/Data/DataManager.swift
+++ b/Pilgrim/Models/Data/DataManager.swift
@@ -856,6 +856,8 @@ struct DataManager {
                 transcriptContextStore.deleteAll()
                 UserPreferences.clearArchivedRegistry()
                 releasedThreadsStore.clear()
+                LunationRecapState.shared.clear()
+                UserPreferences.threadsReleaseCaptionShown.value = false
                 completion(true, nil)
             case .failure(let error):
                 completion(false, .databaseError(error: error))

--- a/Pilgrim/Models/Data/DataManager.swift
+++ b/Pilgrim/Models/Data/DataManager.swift
@@ -29,6 +29,9 @@ struct DataManager {
     /// Injection seam for tests; production always uses the shared store.
     static var transcriptContextStore: TranscriptContextStore = .shared
 
+    /// Injection seam for tests; production always uses the shared store.
+    static var releasedThreadsStore: ReleasedThreadsStore = .shared
+
     // MARK: - Database setup
 
     /// static optional instance of the local storage holding the walk data
@@ -852,6 +855,7 @@ struct DataManager {
                 transcriptContextStore.insertTombstones(for: allRecordingUUIDs)
                 transcriptContextStore.deleteAll()
                 UserPreferences.clearArchivedRegistry()
+                releasedThreadsStore.clear()
                 completion(true, nil)
             case .failure(let error):
                 completion(false, .databaseError(error: error))

--- a/Pilgrim/Models/Data/DataManager.swift
+++ b/Pilgrim/Models/Data/DataManager.swift
@@ -32,6 +32,9 @@ struct DataManager {
     /// Injection seam for tests; production always uses the shared store.
     static var releasedThreadsStore: ReleasedThreadsStore = .shared
 
+    /// Injection seam for tests; production always uses the shared state.
+    static var lunationRecapState: LunationRecapState = .shared
+
     // MARK: - Database setup
 
     /// static optional instance of the local storage holding the walk data
@@ -856,7 +859,7 @@ struct DataManager {
                 transcriptContextStore.deleteAll()
                 UserPreferences.clearArchivedRegistry()
                 releasedThreadsStore.clear()
-                LunationRecapState.shared.clear()
+                lunationRecapState.clear()
                 UserPreferences.threadsReleaseCaptionShown.value = false
                 completion(true, nil)
             case .failure(let error):

--- a/Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageConverter.swift
+++ b/Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageConverter.swift
@@ -241,7 +241,9 @@ enum PilgrimPackageConverter {
     static func buildManifest(
         walkCount: Int,
         events: [PilgrimEvent],
-        archivedEntries: [PilgrimArchivedWalk] = []
+        archivedEntries: [PilgrimArchivedWalk] = [],
+        releasedThreads: [ReleasedThread] = ReleasedThreadsStore.shared.all,
+        welcomedBackThreads: [WelcomedBackThread] = ReleasedThreadsStore.shared.welcomedBack
     ) -> PilgrimManifest {
         let formatter = MeasurementFormatter()
         let distanceUnit = formatter.string(from: UserPreferences.distanceMeasurementType.safeValue)
@@ -256,7 +258,13 @@ enum PilgrimPackageConverter {
             energyUnit: energyUnit,
             celestialAwareness: UserPreferences.celestialAwarenessEnabled.value,
             zodiacSystem: UserPreferences.zodiacSystem.value,
-            beginWithIntention: UserPreferences.beginWithIntention.value
+            beginWithIntention: UserPreferences.beginWithIntention.value,
+            releasedThreads: releasedThreads.isEmpty ? nil : releasedThreads.map {
+                PilgrimReleasedThread(term: $0.displayTerm, lemmas: $0.lemmas, releasedAt: $0.releasedAt)
+            },
+            welcomedBackThreads: welcomedBackThreads.isEmpty ? nil : welcomedBackThreads.map {
+                PilgrimWelcomedBackThread(term: $0.displayTerm, welcomedBackAt: $0.welcomedBackAt)
+            }
         )
 
         let promptStore = CustomPromptStyleStore()
@@ -485,6 +493,20 @@ enum PilgrimPackageConverter {
                 endDate: event.endDate,
                 workouts: event.walkIds
             )
+        }
+    }
+
+    /// Import-side mapping for the released-threads carve-out. Pure, so the
+    /// importer's merge stays a one-liner and this stays testable.
+    static func releasedThreads(from preferences: PilgrimPreferences) -> [ReleasedThread] {
+        (preferences.releasedThreads ?? []).map {
+            ReleasedThread(displayTerm: $0.term, lemmas: $0.lemmas, releasedAt: $0.releasedAt)
+        }
+    }
+
+    static func welcomedBackThreads(from preferences: PilgrimPreferences) -> [WelcomedBackThread] {
+        (preferences.welcomedBackThreads ?? []).map {
+            WelcomedBackThread(displayTerm: $0.term, welcomedBackAt: $0.welcomedBackAt)
         }
     }
 

--- a/Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageConverter.swift
+++ b/Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageConverter.swift
@@ -497,16 +497,21 @@ enum PilgrimPackageConverter {
     }
 
     /// Import-side mapping for the released-threads carve-out. Pure, so the
-    /// importer's merge stays a one-liner and this stays testable.
-    static func releasedThreads(from preferences: PilgrimPreferences) -> [ReleasedThread] {
+    /// importer's merge stays a one-liner and this stays testable. Clamped
+    /// to `now` here, the one boundary every imported decision crosses on
+    /// its way into the store's types — a clock-skewed exporting device
+    /// could otherwise stamp a future `releasedAt` that wins every merge
+    /// forever, since latest-decision-wins has no other way to recognize
+    /// a date that hasn't happened yet as untrustworthy.
+    static func releasedThreads(from preferences: PilgrimPreferences, now: Date = Date()) -> [ReleasedThread] {
         (preferences.releasedThreads ?? []).map {
-            ReleasedThread(displayTerm: $0.term, lemmas: $0.lemmas, releasedAt: $0.releasedAt)
+            ReleasedThread(displayTerm: $0.term, lemmas: $0.lemmas, releasedAt: min($0.releasedAt, now))
         }
     }
 
-    static func welcomedBackThreads(from preferences: PilgrimPreferences) -> [WelcomedBackThread] {
+    static func welcomedBackThreads(from preferences: PilgrimPreferences, now: Date = Date()) -> [WelcomedBackThread] {
         (preferences.welcomedBackThreads ?? []).map {
-            WelcomedBackThread(displayTerm: $0.term, welcomedBackAt: $0.welcomedBackAt)
+            WelcomedBackThread(displayTerm: $0.term, welcomedBackAt: min($0.welcomedBackAt, now))
         }
     }
 

--- a/Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageImporter.swift
+++ b/Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageImporter.swift
@@ -57,6 +57,8 @@ struct DecodedPackage {
     let archived: [PilgrimArchivedWalk]
     let isTended: Bool
     let skippedWalks: Int
+    let releasedThreads: [ReleasedThread]
+    let welcomedBackThreads: [WelcomedBackThread]
 }
 
 enum PilgrimPackageImporter {
@@ -85,6 +87,10 @@ enum PilgrimPackageImporter {
                     saveData(package: package) { result in
                         if case .success = result {
                             TranscriptContextStore.shared.clearTombstones(for: importedRecordingUUIDs)
+                            ReleasedThreadsStore.shared.merge(
+                                released: package.releasedThreads,
+                                welcomedBack: package.welcomedBackThreads
+                            )
                             ThreadsBackfill.reset()
                         }
                         completion(result)
@@ -149,7 +155,9 @@ enum PilgrimPackageImporter {
             events: tempEvents,
             archived: manifest.archivedOrEmpty,
             isTended: manifest.isTended,
-            skippedWalks: skippedWalks
+            skippedWalks: skippedWalks,
+            releasedThreads: PilgrimPackageConverter.releasedThreads(from: manifest.preferences),
+            welcomedBackThreads: PilgrimPackageConverter.welcomedBackThreads(from: manifest.preferences)
         )
     }
 

--- a/Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageModels.swift
+++ b/Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageModels.swift
@@ -65,6 +65,48 @@ struct PilgrimPreferences: Codable {
     let celestialAwareness: Bool
     let zodiacSystem: String
     let beginWithIntention: Bool
+    /// Released thought threads — the one sanctioned derived-data carve-out
+    /// (walker decisions, like zodiacSystem; the lemmas already appear
+    /// verbatim in the exported transcripts). Welcome-backs ride beside the
+    /// releases: both are decisions, and import merge compares them by date
+    /// so a stale backup's release can never override a later reversal.
+    /// Optional so pre-1.12 files decode and pre-1.12 importers ignore the
+    /// unknown keys.
+    let releasedThreads: [PilgrimReleasedThread]?
+    let welcomedBackThreads: [PilgrimWelcomedBackThread]?
+
+    init(
+        distanceUnit: String,
+        altitudeUnit: String,
+        speedUnit: String,
+        energyUnit: String,
+        celestialAwareness: Bool,
+        zodiacSystem: String,
+        beginWithIntention: Bool,
+        releasedThreads: [PilgrimReleasedThread]? = nil,
+        welcomedBackThreads: [PilgrimWelcomedBackThread]? = nil
+    ) {
+        self.distanceUnit = distanceUnit
+        self.altitudeUnit = altitudeUnit
+        self.speedUnit = speedUnit
+        self.energyUnit = energyUnit
+        self.celestialAwareness = celestialAwareness
+        self.zodiacSystem = zodiacSystem
+        self.beginWithIntention = beginWithIntention
+        self.releasedThreads = releasedThreads
+        self.welcomedBackThreads = welcomedBackThreads
+    }
+}
+
+struct PilgrimReleasedThread: Codable {
+    let term: String
+    let lemmas: [String]
+    let releasedAt: Date
+}
+
+struct PilgrimWelcomedBackThread: Codable {
+    let term: String
+    let welcomedBackAt: Date
 }
 
 struct PilgrimCustomPromptStyle: Codable {

--- a/Pilgrim/Models/LunarPhase.swift
+++ b/Pilgrim/Models/LunarPhase.swift
@@ -15,8 +15,8 @@ struct LunarPhase {
 
     var isWaxing: Bool { age < Self.synodicMonth / 2 }
 
-    private static let synodicMonth = 29.53058770576
-    private static let knownNewMoon = DateComponents(
+    static let synodicMonth = 29.53058770576
+    static let knownNewMoon = DateComponents(
         calendar: .init(identifier: .gregorian),
         timeZone: TimeZone(identifier: "UTC"),
         year: 2000, month: 1, day: 6, hour: 18, minute: 14

--- a/Pilgrim/Models/Preferences/UserPreferences.swift
+++ b/Pilgrim/Models/Preferences/UserPreferences.swift
@@ -93,6 +93,7 @@ struct UserPreferences {
     static let dynamicVoiceEnabled = UserPreference.Required<Bool>(key: "dynamicVoiceEnabled", defaultValue: true)
     static let autoTranscribe = UserPreference.Required<Bool>(key: "autoTranscribe", defaultValue: false)
     static let threadsAfterWalks = UserPreference.Required<Bool>(key: "threadsAfterWalks", defaultValue: true)
+    static let threadsReleaseCaptionShown = UserPreference.Required<Bool>(key: "threadsReleaseCaptionShown", defaultValue: false)
 
     static let podcastConsentGiven = UserPreference.Required<Bool>(key: "podcastConsentGiven", defaultValue: false)
     static let lastPodcastSubmissionDate = UserPreference.Optional<String>(key: "lastPodcastSubmissionDate")

--- a/Pilgrim/Models/Prompt/AttentionDirectives.swift
+++ b/Pilgrim/Models/Prompt/AttentionDirectives.swift
@@ -12,7 +12,14 @@ enum AttentionDirectives {
     /// `detectedLanguageCode` defaults to nil ("detect here") so direct
     /// callers stay unchanged; PromptGenerator.resolvedDerivations passes
     /// its precomputed code so the echo skips its own detection pass.
-    static func detect(context: ActivityContext, detectedLanguageCode: String? = nil) -> [String] {
+    /// `releasedLemmas` feeds only recurringWord — the one surfacing path
+    /// that bypasses ThreadStore; intentionEcho is deliberately exempt
+    /// because it quotes the walker's own stated intention.
+    static func detect(
+        context: ActivityContext,
+        detectedLanguageCode: String? = nil,
+        releasedLemmas: Set<String> = ReleasedThreadsStore.shared.releasedLemmas
+    ) -> [String] {
         // Lemmatizing the full transcript is the expensive step; do it once
         // here and share it between the two detectors that need it.
         let spokenMentions = context.hasSpeech
@@ -22,7 +29,7 @@ enum AttentionDirectives {
             stillness(context),
             paceShift(context),
             intentionEcho(context, spokenMentions: spokenMentions, detectedLanguageCode: detectedLanguageCode),
-            recurringWord(context, spokenMentions: spokenMentions),
+            recurringWord(context, spokenMentions: spokenMentions, releasedLemmas: releasedLemmas),
             firstVersusLast(context)
         ].compactMap { $0 }
         return Array(directives.prefix(maxDirectives))
@@ -105,16 +112,23 @@ enum AttentionDirectives {
     }
 
     /// The most-repeated content lemma across all recordings, excluding any
-    /// lemma the intention already claimed. Shown as its most frequent
-    /// surface form so the walker's own inflection is echoed back.
-    private static func recurringWord(_ context: ActivityContext, spokenMentions mentions: [TranscriptNLP.LemmaMention]) -> String? {
+    /// lemma the intention already claimed and any released lemma — the
+    /// next-ranked candidate is promoted, so a release never silences the
+    /// directive, only redirects it. Shown as its most frequent surface form
+    /// so the walker's own inflection is echoed back.
+    private static func recurringWord(
+        _ context: ActivityContext,
+        spokenMentions mentions: [TranscriptNLP.LemmaMention],
+        releasedLemmas: Set<String>
+    ) -> String? {
         guard context.hasSpeech else { return nil }
         let intentionLemmas = context.intention
             .map { Set(TranscriptNLP.contentLemmas(in: $0)) } ?? []
 
         var counts: [String: Int] = [:]
         var surfaces: [String: [String: Int]] = [:]
-        for mention in mentions where !intentionLemmas.contains(mention.lemma) {
+        for mention in mentions
+        where !intentionLemmas.contains(mention.lemma) && !releasedLemmas.contains(mention.lemma) {
             counts[mention.lemma, default: 0] += 1
             surfaces[mention.lemma, default: [:]][mention.surface, default: 0] += 1
         }

--- a/Pilgrim/Models/ScreenshotDataSeeder.swift
+++ b/Pilgrim/Models/ScreenshotDataSeeder.swift
@@ -11,9 +11,17 @@ enum ScreenshotDataSeeder {
         "Be present"
     ]
 
+    // Screenshot- and QA-facing: the first two share a repeated "river"
+    // mention (twice within each, ThemeExtractor's per-transcript floor) so
+    // demo mode actually forms a cross-walk thread — without it no theme can
+    // ever surface and the threads card, thread view, and chips are all
+    // unreachable in demo mode. See ThreadExtractorTests-adjacent coverage
+    // in SeekDemoSeedTests.
     private static let transcriptions = [
-        "The morning light through the trees was extraordinary. I stopped and just watched it move across the path for a while.",
-        "I keep coming back to this idea that walking is thinking. The rhythm of it loosens something in my mind.",
+        "The morning light through the trees was extraordinary. I stopped where the river bends and just " +
+            "watched it move past for a while, unhurried, the way a river carries only what it must and lets the rest go.",
+        "I keep coming back to this idea that walking is thinking. The rhythm of it loosens something in my " +
+            "mind, the same slow loosening I feel beside a river, the kind of stillness a river only offers once you stop asking it for anything.",
         "Heard a bird I couldn't identify. Something between a whistle and a question. Made me smile.",
         "The wind picked up and I felt completely alive. Not happy or sad, just... present.",
         "There's a bend in the trail where you can see the whole valley. Stood there until my breathing matched the clouds."

--- a/Pilgrim/Models/Threads/LunationCalendar.swift
+++ b/Pilgrim/Models/Threads/LunationCalendar.swift
@@ -1,0 +1,67 @@
+import Foundation
+
+/// One synodic month: the stretch between two new-moon instants, indexed
+/// from the same 2000-01-06 reference LunarPhase uses, so phase math and
+/// lunation arithmetic can never disagree.
+struct Lunation: Equatable, Identifiable {
+    let index: Int
+    let start: Date
+    let end: Date
+    let fullMoon: Date
+
+    var id: Int { index }
+}
+
+enum LunationCalendar {
+
+    private static let lunationLength = LunarPhase.synodicMonth * 86400
+
+    /// Every boundary Date is minted by this one expression, so
+    /// `lunation(at: n).end == lunation(at: n + 1).start` holds exactly —
+    /// never `start + length`, which drifts by a ulp and splits boundaries.
+    private static func newMoonDate(at index: Int) -> Date {
+        LunarPhase.knownNewMoon.addingTimeInterval(Double(index) * lunationLength)
+    }
+
+    static func lunation(at index: Int) -> Lunation {
+        Lunation(
+            index: index,
+            start: newMoonDate(at: index),
+            end: newMoonDate(at: index + 1),
+            fullMoon: newMoonDate(at: index).addingTimeInterval(lunationLength / 2)
+        )
+    }
+
+    /// The floor division can land one off at exact boundary instants
+    /// (Double round-off) — the two correction guards make the close
+    /// instant belong to the next lunation, deterministically.
+    static func lunation(containing date: Date) -> Lunation {
+        var index = Int(floor(date.timeIntervalSince(LunarPhase.knownNewMoon) / lunationLength))
+        if date >= newMoonDate(at: index + 1) { index += 1 }
+        if date < newMoonDate(at: index) { index -= 1 }
+        return lunation(at: index)
+    }
+
+    /// The lunation that most recently closed — the only moon that may
+    /// invite. Once the next one closes, the previous moves to Past recaps.
+    static func mostRecentClosed(asOf date: Date) -> Lunation {
+        lunation(at: lunation(containing: date).index - 1)
+    }
+
+    /// Traditional full-moon month names, January through December.
+    static let monthMoonNames = [
+        "Wolf Moon", "Snow Moon", "Worm Moon", "Pink Moon",
+        "Flower Moon", "Strawberry Moon", "Buck Moon", "Sturgeon Moon",
+        "Corn Moon", "Hunter's Moon", "Beaver Moon", "Cold Moon"
+    ]
+
+    /// The moon's name derives from the calendar month of its full-moon
+    /// instant in the given timezone (spec: timezone moon naming) — the
+    /// same set moon can honestly carry different names in Lisbon and
+    /// Auckland, because the walker's sky is the one that counts.
+    static func moonName(for lunation: Lunation, in timeZone: TimeZone = .current) -> String {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        return monthMoonNames[calendar.component(.month, from: lunation.fullMoon) - 1]
+    }
+}

--- a/Pilgrim/Models/Threads/LunationRecapModel.swift
+++ b/Pilgrim/Models/Threads/LunationRecapModel.swift
@@ -1,0 +1,122 @@
+import Foundation
+
+struct LunationRecapTheme: Equatable, Identifiable, Hashable {
+    let displayTerm: String
+    let lemmas: [String]
+    let walkCount: Int
+    let isNewThisMoon: Bool
+
+    var id: String { displayTerm }
+}
+
+struct LunationRecapModel: Equatable {
+    let moonName: String
+    let walkCount: Int
+    let themes: [LunationRecapTheme]
+    let textureLine: String?
+    let quietLine: String?
+}
+
+enum LunationRecapCopy {
+
+    /// Lunation-scoped counts — deliberately a different sentence shape
+    /// from the card's trailing-window ordinals ("third walk now"), so the
+    /// two scopes never read as the same metric disagreeing. Always
+    /// "walks", even for one (spec sparse state: "in 1 of 1 walks").
+    static func themeLine(term: String, walkCount: Int, totalWalks: Int) -> String {
+        "'\(term)' — walked with you in \(walkCount) of \(totalWalks) walks"
+    }
+
+    /// The headline counts only walks with analyzed transcripts, so the
+    /// copy scopes the claim: a walker with fifteen journal walks and three
+    /// transcribed must never read "3 walks this moon" as the journal
+    /// disagreeing with itself. The zero state ("no recorded words walked
+    /// this moon") already carries the same frame.
+    static func headline(walkCount: Int) -> String {
+        walkCount == 1
+            ? "1 walk with recorded words this moon"
+            : "\(walkCount) walks with recorded words this moon"
+    }
+
+    static let newThisMoon = "new this moon"
+    static let nothingHeld = "nothing held on to name this time"
+    static let noWords = "no recorded words walked this moon"
+
+    static func invitation(moonName: String) -> String {
+        "The \(moonName) has set — see what walked with you."
+    }
+}
+
+enum LunationRecapModelBuilder {
+
+    static let maxThemes = 6
+    static let insightFloor = 3
+
+    /// Pure and live-computed at sheet open — its counts may exceed the
+    /// invitation moment's, by design. Window is [start, end): the close
+    /// instant belongs to the next moon.
+    static func model(
+        lunation: Lunation,
+        moonName: String,
+        contexts: [TranscriptContext],
+        walkIndex: [UUID: (walkUUID: UUID, date: Date)],
+        paceByRecording: [UUID: Double],
+        released: Set<String>,
+        backfillComplete: Bool
+    ) -> LunationRecapModel {
+        let inMoon: (Date) -> Bool = { $0 >= lunation.start && $0 < lunation.end }
+        let analyzed = Set(contexts.map(\.recordingUUID))
+        let moonRecordings = walkIndex.filter { analyzed.contains($0.key) && inMoon($0.value.date) }
+        let totalWalks = Set(moonRecordings.values.map(\.walkUUID)).count
+
+        guard totalWalks > 0 else {
+            return LunationRecapModel(
+                moonName: moonName, walkCount: 0, themes: [],
+                textureLine: nil, quietLine: LunationRecapCopy.noWords
+            )
+        }
+
+        let threads = ThreadStore.build(contexts: contexts, walks: walkIndex, released: released)
+        // Cohorts group over ALL threads first — a sibling lemma whose
+        // appearances all predate the moon still joins its cohort, so
+        // isNewThisMoon judges the cohort's full history (mirroring the
+        // card builder) — then only cohorts with at least one appearance
+        // inside the moon are named.
+        let cohorts = Dictionary(grouping: threads, by: \.displayTerm)
+            .filter { $0.value.contains { $0.appearances.contains { inMoon($0.date) } } }
+
+        let themes = cohorts
+            .map { term, cohort -> LunationRecapTheme in
+                let appearances = cohort.flatMap(\.appearances)
+                let walkCount = Set(appearances.filter { inMoon($0.date) }.map(\.walkUUID)).count
+                let earliest = appearances.map(\.date).min()
+                return LunationRecapTheme(
+                    displayTerm: term,
+                    lemmas: cohort.map(\.lemma).sorted(),
+                    walkCount: walkCount,
+                    isNewThisMoon: backfillComplete && earliest.map(inMoon) == true
+                )
+            }
+            .sorted { ($0.walkCount, $1.displayTerm) > ($1.walkCount, $0.displayTerm) }
+            .prefix(maxThemes)
+
+        let moonRecordingSet = Set(moonRecordings.keys)
+        let insightTotal = contexts
+            .filter { moonRecordingSet.contains($0.recordingUUID) }
+            .compactMap(\.markers)
+            .reduce(0) { $0 + $1.insightCount }
+        let wpms = moonRecordingSet.compactMap { paceByRecording[$0] }
+        let meanWPM = wpms.isEmpty ? nil : wpms.reduce(0, +) / Double(wpms.count)
+
+        return LunationRecapModel(
+            moonName: moonName,
+            walkCount: totalWalks,
+            themes: Array(themes),
+            textureLine: ThreadsTexture.line(
+                meanWordsPerMinute: meanWPM,
+                hasInsight: insightTotal >= insightFloor
+            ),
+            quietLine: themes.isEmpty ? LunationRecapCopy.nothingHeld : nil
+        )
+    }
+}

--- a/Pilgrim/Models/Threads/LunationRecapState.swift
+++ b/Pilgrim/Models/Threads/LunationRecapState.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Persistence + eligibility for the lunation recap invitation. The acted
+/// flag records "acted on", not "first opportunity" — pending
+/// transcriptions don't cost the walker the month. Ephemeral by design:
+/// loss on reinstall is accepted (unlike the released set, these are
+/// bookkeeping, not walker decisions).
+final class LunationRecapState {
+
+    static let shared = LunationRecapState(defaults: .standard)
+
+    static let firstCardShownKey = "threadsFirstCardShownAt"
+    static let lastActedKey = "threadsRecapLastActedLunation"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults) {
+        self.defaults = defaults
+    }
+
+    var firstCardShownAt: Date? {
+        guard let epoch = defaults.object(forKey: Self.firstCardShownKey) as? Double else { return nil }
+        return Date(timeIntervalSince1970: epoch)
+    }
+
+    /// Set once, on the first per-walk card the walker ever sees — the card
+    /// shows its work one walk at a time before any aggregate speaks.
+    func markFirstCardShown(now: Date = Date()) {
+        guard firstCardShownAt == nil else { return }
+        defaults.set(now.timeIntervalSince1970, forKey: Self.firstCardShownKey)
+    }
+
+    var lastActedLunationIndex: Int? {
+        defaults.object(forKey: Self.lastActedKey) as? Int
+    }
+
+    /// Monotonic: opening an older moon from Past recaps also marks it
+    /// acted-on, and must never regress the index and resurrect an
+    /// already-dismissed invitation.
+    func markActedOn(_ lunation: Lunation) {
+        defaults.set(max(lunation.index, lastActedLunationIndex ?? Int.min), forKey: Self.lastActedKey)
+    }
+
+    /// The lunation whose set moon may invite from this walk's summary, or
+    /// nil. Re-evaluates on every qualifying post-boundary summary until the
+    /// invitation is tapped or the next lunation closes.
+    func invitation(forWalkDated walkDate: Date, now: Date = Date()) -> Lunation? {
+        guard UserPreferences.threadsAfterWalks.value else { return nil }
+        guard let firstShown = firstCardShownAt else { return nil }
+        let closed = LunationCalendar.mostRecentClosed(asOf: now)
+        guard closed.end > firstShown else { return nil }
+        // An acted index beyond the current lunation can only come from a
+        // forward-set clock (the manual smoke does exactly this) — ignore
+        // it, so months of real invitations aren't silenced after the
+        // clock returns.
+        let currentIndex = LunationCalendar.lunation(containing: now).index
+        let lastActed = lastActedLunationIndex.flatMap { $0 > currentIndex ? nil : $0 }
+        guard closed.index > (lastActed ?? Int.min) else { return nil }
+        guard walkDate >= closed.end else { return nil }
+        return closed
+    }
+
+    /// Delete All Data hook — the first-card gate re-arms exactly as a
+    /// reinstall would. Without this, a surviving firstCardShownAt
+    /// resurrects pre-wipe moons as ghost Past-recap rows and turns the
+    /// first post-wipe walk into a junk "no recorded words" invitation.
+    func clear() {
+        defaults.removeObject(forKey: Self.firstCardShownKey)
+        defaults.removeObject(forKey: Self.lastActedKey)
+    }
+}

--- a/Pilgrim/Models/Threads/ReleasedThreadsCopy.swift
+++ b/Pilgrim/Models/Threads/ReleasedThreadsCopy.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Every release/welcome-back string in one place: the card and the thread
+/// view can never drift apart, and the pre-release gentleness pass (Task 9)
+/// edits one file. The confirm leads with reversibility by design.
+enum ReleasedThreadsCopy {
+
+    static func releaseTitle(_ term: String) -> String { "Let '\(term)' go?" }
+    static let releaseMessage = "You can welcome it back anytime."
+    static let releaseConfirm = "Let it go"
+    static let releaseCancel = "Not now"
+
+    static func welcomeBackTitle(_ term: String) -> String { "Welcome '\(term)' back?" }
+    static let welcomeBackMessage = "Threads will notice it again."
+    static let welcomeBackConfirm = "Welcome it back"
+    static let welcomeBackCancel = "Not now"
+
+    static let caption = "long-press a theme to let it go"
+    static let voiceOverActionName = "Let this go"
+}

--- a/Pilgrim/Models/Threads/ReleasedThreadsStore.swift
+++ b/Pilgrim/Models/Threads/ReleasedThreadsStore.swift
@@ -1,0 +1,177 @@
+import Foundation
+
+/// A walker's decision to stop noticing a thread. Cohort-scoped: releasing a
+/// display term releases every lemma that shared it at release time, and
+/// welcome-back restores the cohort atomically. Releasing is wabi-sabi, not
+/// deletion — the words remain in their transcripts; the app simply stops
+/// noticing.
+struct ReleasedThread: Codable, Equatable {
+    let displayTerm: String
+    let lemmas: [String]
+    let releasedAt: Date
+}
+
+/// A welcome-back is a decision too, recorded with its date so import merge
+/// can honor whichever decision came last. Without the record, a stale
+/// backup's release would silently override the walker's later reversal —
+/// the spec's reversibility promise has to survive backups.
+struct WelcomedBackThread: Codable, Equatable {
+    let displayTerm: String
+    let welcomedBackAt: Date
+}
+
+/// UserDefaults-persisted released set. Releases and welcome-backs are
+/// walker decisions, not derived analysis — they survive relaunch, ride in
+/// the `.pilgrim` preferences block (the sanctioned carve-out), and Delete
+/// All Data clears them with everything else. Analysis and stored contexts
+/// are untouched by release, so it is fully reversible.
+final class ReleasedThreadsStore {
+
+    static let shared = ReleasedThreadsStore(defaults: .standard)
+
+    static let defaultsKey = "releasedThreads"
+    static let welcomedBackKey = "welcomedBackThreads"
+
+    private let defaults: UserDefaults
+    private let lock = NSLock()
+    private var _changeCount = 0
+
+    init(defaults: UserDefaults) {
+        self.defaults = defaults
+    }
+
+    /// Session-scoped memo token, bumped on every mutation — folded into the
+    /// dossier-builder and suggestions memo keys so a release is visible on
+    /// the very next prompt or sheet open.
+    var changeCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _changeCount
+    }
+
+    /// Newest release first, ties broken by term — the settings list order.
+    var all: [ReleasedThread] {
+        lock.lock()
+        defer { lock.unlock() }
+        return loadReleased()
+    }
+
+    /// Welcome-back records, term-ascending — exported beside the released
+    /// list so import merge can compare decisions by date.
+    var welcomedBack: [WelcomedBackThread] {
+        lock.lock()
+        defer { lock.unlock() }
+        return loadWelcomedBack()
+    }
+
+    var releasedLemmas: Set<String> {
+        Set(all.flatMap(\.lemmas))
+    }
+
+    var isEmpty: Bool { all.isEmpty }
+
+    func release(displayTerm: String, lemmas: [String], releasedAt: Date = Date()) {
+        mutate { entries, welcomes in
+            welcomes.removeAll { $0.displayTerm == displayTerm }
+            if let index = entries.firstIndex(where: { $0.displayTerm == displayTerm }) {
+                entries[index] = ReleasedThread(
+                    displayTerm: displayTerm,
+                    lemmas: Set(entries[index].lemmas).union(lemmas).sorted(),
+                    releasedAt: entries[index].releasedAt
+                )
+            } else {
+                entries.append(ReleasedThread(
+                    displayTerm: displayTerm, lemmas: lemmas.sorted(), releasedAt: releasedAt
+                ))
+            }
+        }
+    }
+
+    func welcomeBack(displayTerm: String, at date: Date = Date()) {
+        mutate { entries, welcomes in
+            entries.removeAll { $0.displayTerm == displayTerm }
+            welcomes.removeAll { $0.displayTerm == displayTerm }
+            welcomes.append(WelcomedBackThread(displayTerm: displayTerm, welcomedBackAt: date))
+        }
+    }
+
+    /// Import merge: latest decision wins, per cohort. Two releases union
+    /// their lemmas and keep the earlier date so repeated imports stay
+    /// stable; a release and a welcome-back for the same term are compared
+    /// by date and the older decision yields. On a tie the local state
+    /// stands — re-importing the same package is a no-op.
+    func merge(released importedReleased: [ReleasedThread],
+               welcomedBack importedWelcomedBack: [WelcomedBackThread]) {
+        guard !importedReleased.isEmpty || !importedWelcomedBack.isEmpty else { return }
+        mutate { entries, welcomes in
+            for thread in importedReleased {
+                if let welcome = welcomes.first(where: { $0.displayTerm == thread.displayTerm }),
+                   welcome.welcomedBackAt >= thread.releasedAt {
+                    continue // the walker's welcome-back is the later decision — never silently re-release
+                }
+                welcomes.removeAll { $0.displayTerm == thread.displayTerm }
+                if let index = entries.firstIndex(where: { $0.displayTerm == thread.displayTerm }) {
+                    entries[index] = ReleasedThread(
+                        displayTerm: thread.displayTerm,
+                        lemmas: Set(entries[index].lemmas).union(thread.lemmas).sorted(),
+                        releasedAt: min(entries[index].releasedAt, thread.releasedAt)
+                    )
+                } else {
+                    entries.append(thread)
+                }
+            }
+            for welcome in importedWelcomedBack {
+                if let entry = entries.first(where: { $0.displayTerm == welcome.displayTerm }),
+                   entry.releasedAt >= welcome.welcomedBackAt {
+                    continue // released again after that welcome-back — the newer release stands
+                }
+                entries.removeAll { $0.displayTerm == welcome.displayTerm }
+                if let index = welcomes.firstIndex(where: { $0.displayTerm == welcome.displayTerm }) {
+                    welcomes[index] = WelcomedBackThread(
+                        displayTerm: welcome.displayTerm,
+                        welcomedBackAt: max(welcomes[index].welcomedBackAt, welcome.welcomedBackAt)
+                    )
+                } else {
+                    welcomes.append(welcome)
+                }
+            }
+        }
+    }
+
+    /// Delete All Data hook — walker decisions clear with everything else.
+    func clear() {
+        mutate { entries, welcomes in
+            entries.removeAll()
+            welcomes.removeAll()
+        }
+    }
+
+    private func mutate(_ body: (inout [ReleasedThread], inout [WelcomedBackThread]) -> Void) {
+        lock.lock()
+        defer { lock.unlock() }
+        var entries = loadReleased()
+        var welcomes = loadWelcomedBack()
+        body(&entries, &welcomes)
+        entries.sort { ($0.releasedAt, $1.displayTerm) > ($1.releasedAt, $0.displayTerm) }
+        welcomes.sort { $0.displayTerm < $1.displayTerm }
+        if let data = try? JSONEncoder().encode(entries) {
+            defaults.set(data, forKey: Self.defaultsKey)
+        }
+        if let data = try? JSONEncoder().encode(welcomes) {
+            defaults.set(data, forKey: Self.welcomedBackKey)
+        }
+        _changeCount += 1
+    }
+
+    private func loadReleased() -> [ReleasedThread] {
+        guard let data = defaults.data(forKey: Self.defaultsKey),
+              let entries = try? JSONDecoder().decode([ReleasedThread].self, from: data) else { return [] }
+        return entries
+    }
+
+    private func loadWelcomedBack() -> [WelcomedBackThread] {
+        guard let data = defaults.data(forKey: Self.welcomedBackKey),
+              let entries = try? JSONDecoder().decode([WelcomedBackThread].self, from: data) else { return [] }
+        return entries
+    }
+}

--- a/Pilgrim/Models/Threads/ReleasedThreadsStore.swift
+++ b/Pilgrim/Models/Threads/ReleasedThreadsStore.swift
@@ -96,10 +96,12 @@ final class ReleasedThreadsStore {
     }
 
     /// Import merge: latest decision wins, per cohort. Two releases union
-    /// their lemmas and keep the earlier date so repeated imports stay
-    /// stable; a release and a welcome-back for the same term are compared
-    /// by date and the older decision yields. On a tie the local state
-    /// stands — re-importing the same package is a no-op.
+    /// their lemmas and keep the later date, so a chain of backups — release,
+    /// then welcome back, then release again — never regresses to an earlier
+    /// release date when an older backup is imported afterward; a release and
+    /// a welcome-back for the same term are compared by date and the older
+    /// decision yields. On a tie the local state stands — re-importing the
+    /// same package is a no-op.
     func merge(released importedReleased: [ReleasedThread],
                welcomedBack importedWelcomedBack: [WelcomedBackThread]) {
         guard !importedReleased.isEmpty || !importedWelcomedBack.isEmpty else { return }
@@ -114,7 +116,7 @@ final class ReleasedThreadsStore {
                     entries[index] = ReleasedThread(
                         displayTerm: thread.displayTerm,
                         lemmas: Set(entries[index].lemmas).union(thread.lemmas).sorted(),
-                        releasedAt: min(entries[index].releasedAt, thread.releasedAt)
+                        releasedAt: max(entries[index].releasedAt, thread.releasedAt)
                     )
                 } else {
                     entries.append(thread)

--- a/Pilgrim/Models/Threads/ThreadHistoryModel.swift
+++ b/Pilgrim/Models/Threads/ThreadHistoryModel.swift
@@ -1,0 +1,126 @@
+import Foundation
+import CoreLocation
+
+struct ThreadHistoryEntry: Equatable {
+    let recordingUUID: UUID
+    let walkUUID: UUID
+    let date: Date
+    let excerpt: String?
+    let isOrigin: Bool
+}
+
+enum ThreadHistoryModelBuilder {
+
+    static let excerptRadius = 60
+
+    /// Newest first; the oldest entry carries the origin label — but only
+    /// once the one-time backfill has completed. Until then "where it began"
+    /// would be a claim about walks not yet analyzed, so origin flags are
+    /// suppressed rather than risked (spec), hiding both the footer and the
+    /// origin-map action. One entry per recording — when two cohort lemmas
+    /// appear in the same recording, the strongest theme (mention count,
+    /// then lemma) provides the excerpt.
+    static func entries(
+        cohort: [WalkThread],
+        contextsByRecording: [UUID: TranscriptContext],
+        transcriptsByRecording: [UUID: String],
+        backfillComplete: Bool
+    ) -> [ThreadHistoryEntry] {
+        let lemmas = Set(cohort.map(\.lemma))
+        let appearancesByRecording = Dictionary(
+            grouping: cohort.flatMap(\.appearances), by: \.recordingUUID
+        )
+
+        let sorted: [ThreadHistoryEntry] = appearancesByRecording
+            .map { recordingUUID, appearances in
+                // Same recording ⇒ same walk and date; the excerpt picks the
+                // strongest cohort theme itself, so any element serves.
+                let appearance = appearances[0]
+                return ThreadHistoryEntry(
+                    recordingUUID: recordingUUID,
+                    walkUUID: appearance.walkUUID,
+                    date: appearance.date,
+                    excerpt: excerpt(
+                        for: lemmas,
+                        context: contextsByRecording[recordingUUID],
+                        transcript: transcriptsByRecording[recordingUUID]
+                    ),
+                    isOrigin: false
+                )
+            }
+            .sorted { ($0.date, $0.recordingUUID.uuidString) > ($1.date, $1.recordingUUID.uuidString) }
+
+        guard let oldest = sorted.last else { return [] }
+        guard backfillComplete else { return sorted }
+        return Array(sorted.dropLast()) + [ThreadHistoryEntry(
+            recordingUUID: oldest.recordingUUID,
+            walkUUID: oldest.walkUUID,
+            date: oldest.date,
+            excerpt: oldest.excerpt,
+            isOrigin: true
+        )]
+    }
+
+    static func excerpt(
+        for lemmas: Set<String>,
+        context: TranscriptContext?,
+        transcript: String?
+    ) -> String? {
+        guard let context, let transcript,
+              context.transcriptHash == TranscriptContextStore.hash(of: transcript),
+              let theme = context.themes
+                .filter({ lemmas.contains($0.lemma) })
+                .sorted(by: { ($0.mentionCount, $1.lemma) > ($1.mentionCount, $0.lemma) })
+                .first,
+              let mention = theme.mentions.first else { return nil }
+        return slice(transcript, around: mention, radius: excerptRadius)
+    }
+
+    /// Mention offsets are Character (grapheme) counts, produced by
+    /// `text.distance` at analysis time — sliced back with `limitedBy:` so
+    /// emoji and combining marks can never push an index past either end.
+    static func slice(_ transcript: String, around mention: ThemeMention, radius: Int) -> String? {
+        guard mention.start >= 0, mention.length > 0,
+              let mentionStart = transcript.index(
+                transcript.startIndex, offsetBy: mention.start, limitedBy: transcript.endIndex
+              ),
+              let mentionEnd = transcript.index(
+                mentionStart, offsetBy: mention.length, limitedBy: transcript.endIndex
+              ) else { return nil }
+
+        let start = transcript.index(mentionStart, offsetBy: -radius, limitedBy: transcript.startIndex)
+            ?? transcript.startIndex
+        let end = transcript.index(mentionEnd, offsetBy: radius, limitedBy: transcript.endIndex)
+            ?? transcript.endIndex
+
+        var excerpt = String(transcript[start..<end])
+        if start > transcript.startIndex {
+            excerpt = "…" + String(excerpt.drop(while: { !$0.isWhitespace }))
+                .trimmingCharacters(in: .whitespaces)
+        }
+        if end < transcript.endIndex {
+            excerpt = String(String(excerpt.reversed()).drop(while: { !$0.isWhitespace }).reversed())
+                .trimmingCharacters(in: .whitespaces) + "…"
+        }
+        return excerpt
+    }
+}
+
+enum ThreadOriginResolver {
+
+    static let tolerance: TimeInterval = 120
+
+    /// The route sample nearest the recording's start, within tolerance —
+    /// beyond it the fix is a guess, and the origin-map action hides
+    /// instead of guessing (spec: Return to where it began).
+    static func coordinate(
+        recordingStart: Date,
+        samples: [(timestamp: Date, latitude: Double, longitude: Double)]
+    ) -> CLLocationCoordinate2D? {
+        guard let nearest = samples.min(by: {
+            abs($0.timestamp.timeIntervalSince(recordingStart))
+                < abs($1.timestamp.timeIntervalSince(recordingStart))
+        }), abs(nearest.timestamp.timeIntervalSince(recordingStart)) <= tolerance else { return nil }
+        return CLLocationCoordinate2D(latitude: nearest.latitude, longitude: nearest.longitude)
+    }
+}

--- a/Pilgrim/Models/Threads/ThreadIntentionSuggestions.swift
+++ b/Pilgrim/Models/Threads/ThreadIntentionSuggestions.swift
@@ -7,12 +7,11 @@ import Foundation
 /// field gate alongside the card's themes.
 enum ThreadIntentionSuggestions {
 
-    /// Flipped to false when the human field gate passes. The gate judges
-    /// chip quality AND sensitivity — chips are the feature's first surface
-    /// to render derived words unprompted — alongside the card's themes.
-    /// While true, `current()` returns nothing and the chips section never
-    /// renders; the engine and `select` stay live and tested underneath.
-    static let pendingFieldGate = true
+    /// The human field gate passed 2026-08-24 (spec addendum: "Chips:
+    /// cleared to ship") — chips render in IntentionSettingView from 1.12.0.
+    /// The header ships as "Recurring"; a softer-variant copy pass is a
+    /// tracked fast-follow, judged against real chip words.
+    static let pendingFieldGate = false
 
     static let recurrenceWindow: TimeInterval = 30 * 86400
     static let minimumDistinctWalks = 2

--- a/Pilgrim/Models/Threads/ThreadIntentionSuggestions.swift
+++ b/Pilgrim/Models/Threads/ThreadIntentionSuggestions.swift
@@ -18,7 +18,7 @@ enum ThreadIntentionSuggestions {
     static let minimumDistinctWalks = 2
     static let maxSuggestions = 2
 
-    private static var memo: (changeCount: Int, day: Date, suggestions: [String])?
+    private static var memo: (changeCount: Int, releasedToken: Int, day: Date, suggestions: [String])?
     private static let memoLock = NSLock()
 
     /// Pure core (tested): threads → suggestion phrases. Two lemmas can
@@ -52,26 +52,36 @@ enum ThreadIntentionSuggestions {
     /// loadAll so a mid-read mutation leaves the memo stale and the next
     /// call rebuilds instead of absorbing the mutation unseen.
     @MainActor
-    static func current(asOf: Date = Date(), store: TranscriptContextStore = .shared) async -> [String] {
+    static func current(
+        asOf: Date = Date(),
+        store: TranscriptContextStore = .shared,
+        releasedStore: ReleasedThreadsStore = .shared,
+        walkIndex: [UUID: (walkUUID: UUID, date: Date)]? = nil
+    ) async -> [String] {
         guard !pendingFieldGate else { return [] }
         guard UserPreferences.threadsAfterWalks.value else { return [] }
-        let walkIndex = DataManager.voiceRecordingWalkIndex()
+        // walkIndex is injectable for Task 8's wiring test; production
+        // callers pass nil and read the live CoreStore index on the main actor.
+        let walkIndex = walkIndex ?? DataManager.voiceRecordingWalkIndex()
         guard !walkIndex.isEmpty else { return [] }
 
         let day = Calendar.current.startOfDay(for: asOf)
         let preLoadChangeCount = store.changeCount
+        let releasedToken = releasedStore.changeCount
+        let released = releasedStore.releasedLemmas
         memoLock.lock()
         let cached = memo
         memoLock.unlock()
-        if let cached, cached.changeCount == preLoadChangeCount, cached.day == day {
+        if let cached, cached.changeCount == preLoadChangeCount,
+           cached.releasedToken == releasedToken, cached.day == day {
             return cached.suggestions
         }
 
         return await Task.detached(priority: .userInitiated) {
-            let threads = ThreadStore.build(contexts: store.loadAll(), walks: walkIndex)
+            let threads = ThreadStore.build(contexts: store.loadAll(), walks: walkIndex, released: released)
             let suggestions = select(threads: threads, asOf: asOf)
             memoLock.lock()
-            memo = (preLoadChangeCount, day, suggestions)
+            memo = (preLoadChangeCount, releasedToken, day, suggestions)
             memoLock.unlock()
             return suggestions
         }.value

--- a/Pilgrim/Models/Threads/ThreadStore.swift
+++ b/Pilgrim/Models/Threads/ThreadStore.swift
@@ -33,14 +33,15 @@ enum ThreadStore {
 
     static func build(
         contexts: [TranscriptContext],
-        walks: [UUID: (walkUUID: UUID, date: Date)]
+        walks: [UUID: (walkUUID: UUID, date: Date)],
+        released: Set<String> = []
     ) -> [WalkThread] {
         var appearancesByLemma: [String: [ThreadAppearance]] = [:]
         var displayCounts: [String: [String: Int]] = [:]
 
         for context in contexts {
             guard let walk = walks[context.recordingUUID] else { continue }
-            for theme in context.themes {
+            for theme in context.themes where !released.contains(theme.lemma) {
                 appearancesByLemma[theme.lemma, default: []].append(ThreadAppearance(
                     recordingUUID: context.recordingUUID,
                     walkUUID: walk.walkUUID,

--- a/Pilgrim/Models/Threads/ThreadsBackfill.swift
+++ b/Pilgrim/Models/Threads/ThreadsBackfill.swift
@@ -5,7 +5,14 @@ import Foundation
 /// once history is fully analyzed (spec: ThreadStore).
 enum ThreadsBackfill {
 
-    static let completedKey = "threadsBackfillCompleted"
+    static let completedKey = "threadsBackfillCompletedV2"
+    /// v1.11.0 TestFlight devices could run the sweep, account for zero
+    /// recordings under a snapshot bug (fixed alongside this rename), and
+    /// still set the old flag — stranding those devices on a never-swept
+    /// history forever, since `runIfNeeded` guards on `!isComplete`. The
+    /// key rename re-arms them by construction: the new key is absent, so
+    /// `isComplete` reads false regardless of what the old key holds.
+    private static let legacyCompletedKey = "threadsBackfillCompleted"
     private static var isRunning = false
     private static var generation = 0
 
@@ -70,6 +77,10 @@ enum ThreadsBackfill {
         gate: @escaping @MainActor () -> Bool = { BatteryGate.allowsBackgroundWork() },
         onFinish: (@MainActor () -> Void)? = nil
     ) {
+        // One-time hygiene ahead of the isComplete check below: the pre-V2
+        // key no longer means anything, and removing an absent key is a
+        // harmless no-op on every call after the first.
+        UserDefaults.standard.removeObject(forKey: legacyCompletedKey)
         guard !isComplete, !isRunning, UserPreferences.threadsAfterWalks.value, gate() else {
             onFinish?()
             return

--- a/Pilgrim/Models/Threads/ThreadsCardModel.swift
+++ b/Pilgrim/Models/Threads/ThreadsCardModel.swift
@@ -12,6 +12,7 @@ struct ThreadsCardModel: Equatable {
     let themes: [ThreadsCardTheme]
     let textureLine: String?
     let insightWords: [String]
+    let hasInsight: Bool
 }
 
 enum ThreadsCardCopy {
@@ -99,6 +100,7 @@ enum ThreadsCardModelBuilder {
             .filter { contextsByRecording[$0.uuid]?.languageCode == "en" }
             .map(\.transcript)
         let insightWords = ThreadsTexture.insightWords(in: englishTranscripts)
+        let hasInsight = insightWords.count >= ThreadsTexture.insightFloor
 
         let wpms = recordings.compactMap(\.wordsPerMinute)
         let meanWPM = wpms.isEmpty ? nil : wpms.reduce(0, +) / Double(wpms.count)
@@ -107,9 +109,10 @@ enum ThreadsCardModelBuilder {
             themes: Array(ranked),
             textureLine: ThreadsTexture.line(
                 meanWordsPerMinute: meanWPM,
-                hasInsight: insightWords.count >= ThreadsTexture.insightFloor
+                hasInsight: hasInsight
             ),
-            insightWords: insightWords
+            insightWords: insightWords,
+            hasInsight: hasInsight
         )
     }
 

--- a/Pilgrim/Models/Threads/ThreadsCardModel.swift
+++ b/Pilgrim/Models/Threads/ThreadsCardModel.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+struct ThreadsCardTheme: Equatable, Identifiable {
+    let displayTerm: String
+    let lemmas: [String]
+    let statusNote: String?
+
+    var id: String { displayTerm }
+}
+
+struct ThreadsCardModel: Equatable {
+    let themes: [ThreadsCardTheme]
+    let textureLine: String?
+    let insightWords: [String]
+}
+
+enum ThreadsCardCopy {
+
+    private static let ordinalWords: [Int: String] = [
+        2: "second", 3: "third", 4: "fourth", 5: "fifth", 6: "sixth",
+        7: "seventh", 8: "eighth", 9: "ninth", 10: "tenth",
+        11: "eleventh", 12: "twelfth"
+    ]
+
+    /// Ordinal words, never digits (spec principle 1). Beyond the table the
+    /// copy stays soft instead of inventing "twenty-third"; a bare
+    /// walksInWindow of 1 means the thread recurred outside the 30-day
+    /// window — "returning", not a false ordinal.
+    static func statusNote(for status: ThreadStatus?) -> String? {
+        switch status {
+        case .firstTime:
+            return "first time"
+        case .recurring(let walks):
+            if walks <= 1 { return "returning" }
+            guard let word = ordinalWords[walks] else { return "with you again" }
+            return "\(word) walk now"
+        case nil:
+            return nil
+        }
+    }
+}
+
+enum ThreadsCardModelBuilder {
+
+    static let maxThemes = 4
+
+    /// Pure: threads in, card model out. Nil means no card — the summary
+    /// must stay pixel-identical when nothing was found.
+    static func model(
+        walkUUID: UUID,
+        threads: [WalkThread],
+        recordings: [(uuid: UUID, transcript: String, wordsPerMinute: Double?)],
+        contextsByRecording: [UUID: TranscriptContext],
+        backfillComplete: Bool
+    ) -> ThreadsCardModel? {
+        // Two lemmas can share a display term (move/moving → "the move"):
+        // one chip per term, and release later acts on the whole cohort. The
+        // grouping runs over ALL threads first — a sibling lemma whose
+        // appearances are all in earlier walks still joins its cohort, so
+        // status history and release lemma sets stay cohort-complete — and
+        // only cohorts present in this walk keep a chip. mentions/salience
+        // below filter to walkUUID, so ranking is unaffected.
+        let cohorts = Dictionary(grouping: threads, by: \.displayTerm)
+            .filter { $0.value.contains { $0.appearances.contains { $0.walkUUID == walkUUID } } }
+        guard !cohorts.isEmpty else { return nil }
+
+        let totalWords = recordings
+            .compactMap { contextsByRecording[$0.uuid]?.wordCount }
+            .reduce(0, +)
+
+        let ranked = cohorts
+            .map { term, cohort -> (theme: ThreadsCardTheme, salience: Double, mentions: Int) in
+                let merged = mergedThread(displayTerm: term, cohort: cohort)
+                let mentions = merged.appearances
+                    .filter { $0.walkUUID == walkUUID }
+                    .reduce(0) { $0 + $1.mentionCount }
+                let salience = totalWords > 0 ? Double(mentions) / Double(totalWords) : 0
+                let status = ThreadStore.status(
+                    of: merged, atWalk: walkUUID, backfillComplete: backfillComplete
+                )
+                return (
+                    ThreadsCardTheme(
+                        displayTerm: term,
+                        lemmas: cohort.map(\.lemma).sorted(),
+                        statusNote: ThreadsCardCopy.statusNote(for: status)
+                    ),
+                    salience,
+                    mentions
+                )
+            }
+            .sorted {
+                ($0.salience, $0.mentions, $1.theme.displayTerm)
+                    > ($1.salience, $1.mentions, $0.theme.displayTerm)
+            }
+            .prefix(maxThemes)
+            .map(\.theme)
+
+        let englishTranscripts = recordings
+            .filter { contextsByRecording[$0.uuid]?.languageCode == "en" }
+            .map(\.transcript)
+        let insightWords = ThreadsTexture.insightWords(in: englishTranscripts)
+
+        let wpms = recordings.compactMap(\.wordsPerMinute)
+        let meanWPM = wpms.isEmpty ? nil : wpms.reduce(0, +) / Double(wpms.count)
+
+        return ThreadsCardModel(
+            themes: Array(ranked),
+            textureLine: ThreadsTexture.line(
+                meanWordsPerMinute: meanWPM,
+                hasInsight: insightWords.count >= ThreadsTexture.insightFloor
+            ),
+            insightWords: insightWords
+        )
+    }
+
+    /// One pseudo-thread per cohort so ThreadStore.status sees the cohort's
+    /// full history — a first-time claim is only true if NO lemma in the
+    /// cohort appeared earlier.
+    static func mergedThread(displayTerm: String, cohort: [WalkThread]) -> WalkThread {
+        WalkThread(
+            lemma: cohort.map(\.lemma).sorted().first ?? displayTerm,
+            displayTerm: displayTerm,
+            appearances: cohort.flatMap(\.appearances)
+                .sorted { ($0.date, $0.recordingUUID.uuidString) < ($1.date, $1.recordingUUID.uuidString) }
+        )
+    }
+}

--- a/Pilgrim/Models/Threads/ThreadsCardModel.swift
+++ b/Pilgrim/Models/Threads/ThreadsCardModel.swift
@@ -116,6 +116,20 @@ enum ThreadsCardModelBuilder {
         )
     }
 
+    /// Local, animatable card update after a release — the stores were
+    /// already told; this keeps the on-screen card honest without a reload.
+    static func removing(displayTerm: String, from model: ThreadsCardModel?) -> ThreadsCardModel? {
+        guard let model else { return nil }
+        let remaining = model.themes.filter { $0.displayTerm != displayTerm }
+        guard !remaining.isEmpty else { return nil }
+        return ThreadsCardModel(
+            themes: remaining,
+            textureLine: model.textureLine,
+            insightWords: model.insightWords,
+            hasInsight: model.hasInsight
+        )
+    }
+
     /// One pseudo-thread per cohort so ThreadStore.status sees the cohort's
     /// full history — a first-time claim is only true if NO lemma in the
     /// cohort appeared earlier.

--- a/Pilgrim/Models/Threads/ThreadsDossierBuilder.swift
+++ b/Pilgrim/Models/Threads/ThreadsDossierBuilder.swift
@@ -7,25 +7,32 @@ import Foundation
 /// doesn't re-read the whole context directory.
 enum ThreadsDossierBuilder {
 
-    private static var memo: (changeCount: Int, walkUUID: UUID, backfillComplete: Bool, dossier: String?)?
+    private static var memo: (
+        changeCount: Int, releasedToken: Int, walkUUID: UUID,
+        backfillComplete: Bool, dossier: String?
+    )?
     private static let memoLock = NSLock()
 
     static func build(
         walkUUID: UUID,
         recordings: [RecordingContext],
         walkIndex: [UUID: (walkUUID: UUID, date: Date)],
-        store: TranscriptContextStore = .shared
+        store: TranscriptContextStore = .shared,
+        releasedStore: ReleasedThreadsStore = .shared
     ) -> String? {
         guard UserPreferences.threadsAfterWalks.value, !recordings.isEmpty else { return nil }
         // One consistent read each, captured before any store mutation: a
-        // mid-build mutation leaves the memoized changeCount stale, so the
-        // next call rebuilds instead of absorbing the mutation unseen.
+        // mid-build mutation leaves the memoized tokens stale, so the next
+        // call rebuilds instead of absorbing the mutation unseen.
         let backfillComplete = ThreadsBackfill.isComplete
         let preBuildChangeCount = store.changeCount
+        let releasedToken = releasedStore.changeCount
+        let released = releasedStore.releasedLemmas
         memoLock.lock()
         let cached = memo
         memoLock.unlock()
         if let cached, cached.changeCount == preBuildChangeCount,
+           cached.releasedToken == releasedToken,
            cached.walkUUID == walkUUID, cached.backfillComplete == backfillComplete {
             return cached.dossier
         }
@@ -73,7 +80,7 @@ enum ThreadsDossierBuilder {
         let allContexts = contextsByUUID.values
             .sorted { $0.recordingUUID.uuidString < $1.recordingUUID.uuidString }
 
-        let threads = ThreadStore.build(contexts: allContexts, walks: walkIndex)
+        let threads = ThreadStore.build(contexts: allContexts, walks: walkIndex, released: released)
         let dossier = ThreadsDossierFormatter.dossier(
             currentRecordings: current,
             allContexts: allContexts,
@@ -82,7 +89,7 @@ enum ThreadsDossierBuilder {
             backfillComplete: backfillComplete
         )
         memoLock.lock()
-        memo = (preBuildChangeCount, walkUUID, backfillComplete, dossier)
+        memo = (preBuildChangeCount, releasedToken, walkUUID, backfillComplete, dossier)
         memoLock.unlock()
         return dossier
     }

--- a/Pilgrim/Models/Threads/ThreadsTexture.swift
+++ b/Pilgrim/Models/Threads/ThreadsTexture.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+/// State-only texture: pace derived mechanically from words-per-minute,
+/// insight from exact lexicon words the walker can be shown. No directional
+/// language, no numbers — weak signals are omitted, and the whole line is
+/// omitted when nothing clears threshold (spec: Stage 3 card).
+enum ThreadsTexture {
+
+    /// Mirrors ContextFormatter.speakingPaceLabel's outer buckets: only the
+    /// extremes are remarkable enough to name.
+    static let slowCeiling: Double = 100
+    static let quickFloor: Double = 170
+    static let insightFloor = 2
+
+    /// Insight-word surfaces in spoken order, deduplicated — the exact words
+    /// that earn "with words of insight", revealed on tap (traceability:
+    /// if we can't show the words, we don't show the claim).
+    static func insightWords(in transcripts: [String]) -> [String] {
+        var seen: Set<String> = []
+        return transcripts
+            .flatMap { TranscriptNLP.wordTokens(in: $0) }
+            .filter { MarkerLexicons.insight.contains($0) }
+            .filter { seen.insert($0).inserted }
+    }
+
+    static func paceClause(meanWordsPerMinute: Double?) -> String? {
+        guard let wpm = meanWordsPerMinute else { return nil }
+        if wpm < slowCeiling { return "spoken slowly" }
+        if wpm >= quickFloor { return "spoken quickly" }
+        return nil
+    }
+
+    static func line(meanWordsPerMinute: Double?, hasInsight: Bool) -> String? {
+        var clauses: [String] = []
+        if let pace = paceClause(meanWordsPerMinute: meanWordsPerMinute) {
+            clauses.append(pace)
+        }
+        if hasInsight {
+            clauses.append("with words of insight")
+        }
+        guard let first = clauses.first else { return nil }
+        let capitalized = first.prefix(1).capitalized + String(first.dropFirst())
+        return ([capitalized] + clauses.dropFirst()).joined(separator: ", ") + "."
+    }
+}

--- a/Pilgrim/Scenes/Settings/PastRecapsListView.swift
+++ b/Pilgrim/Scenes/Settings/PastRecapsListView.swift
@@ -1,0 +1,73 @@
+import SwiftUI
+
+/// Closed moons since the walker's first card, newest first — a missed
+/// invitation line never costs the month. Each row opens the same
+/// live-computed recap sheet.
+struct PastRecapsListView: View {
+
+    @State private var lunations: [Lunation] = PastRecapsListView.closedLunations()
+    @State private var selected: Lunation?
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter
+    }()
+
+    static func closedLunations(now: Date = Date(), state: LunationRecapState = .shared) -> [Lunation] {
+        guard let firstShown = state.firstCardShownAt else { return [] }
+        var result: [Lunation] = []
+        var index = LunationCalendar.mostRecentClosed(asOf: now).index
+        while index >= 0 {
+            let lunation = LunationCalendar.lunation(at: index)
+            guard lunation.end > firstShown else { break }
+            result.append(lunation)
+            index -= 1
+        }
+        return result
+    }
+
+    var body: some View {
+        List {
+            ForEach(lunations) { lunation in
+                Button {
+                    // Reading a recap here counts as acting on it — the
+                    // summary's invitation row stops nagging about a moon
+                    // the walker has already seen (spec-consistent: the
+                    // invitation exists to surface the recap, not to be
+                    // tapped for its own sake). markActedOn is monotonic,
+                    // so opening an OLDER moon never regresses the index.
+                    LunationRecapState.shared.markActedOn(lunation)
+                    selected = lunation
+                } label: {
+                    HStack {
+                        Text(LunationCalendar.moonName(for: lunation))
+                            .font(Constants.Typography.body)
+                            .foregroundColor(.ink)
+                        Spacer()
+                        Text(Self.dateFormatter.string(from: lunation.end))
+                            .font(Constants.Typography.caption)
+                            .foregroundColor(.fog)
+                    }
+                    .frame(minHeight: 44)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityHint("Double tap to open this moon's recap")
+                .listRowBackground(Color.parchmentSecondary)
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .canvasBackground()
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                Text("Past recaps")
+                    .font(Constants.Typography.heading)
+                    .foregroundColor(.ink)
+            }
+        }
+        .sheet(item: $selected) { lunation in
+            LunationRecapView(lunation: lunation)
+        }
+    }
+}

--- a/Pilgrim/Scenes/Settings/ReleasedThreadsListView.swift
+++ b/Pilgrim/Scenes/Settings/ReleasedThreadsListView.swift
@@ -1,0 +1,68 @@
+import SwiftUI
+
+/// Released threads, newest first — tapping an entry welcomes the cohort
+/// back. The row that leads here is hidden when this list would be empty.
+struct ReleasedThreadsListView: View {
+
+    @State private var entries: [ReleasedThread] = ReleasedThreadsStore.shared.all
+    @State private var entryToRestore: ReleasedThread?
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter
+    }()
+
+    var body: some View {
+        List {
+            ForEach(entries, id: \.displayTerm) { entry in
+                Button {
+                    entryToRestore = entry
+                } label: {
+                    HStack {
+                        Text(entry.displayTerm)
+                            .font(Constants.Typography.body)
+                            .foregroundColor(.ink)
+                        Spacer()
+                        Text(Self.dateFormatter.string(from: entry.releasedAt))
+                            .font(Constants.Typography.caption)
+                            .foregroundColor(.fog)
+                    }
+                    .frame(minHeight: 44)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityHint("Double tap to welcome this thread back")
+                .listRowBackground(Color.parchmentSecondary)
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .canvasBackground()
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                Text("Released threads")
+                    .font(Constants.Typography.heading)
+                    .foregroundColor(.ink)
+            }
+        }
+        .alert(
+            entryToRestore.map { ReleasedThreadsCopy.welcomeBackTitle($0.displayTerm) } ?? "",
+            isPresented: Binding(
+                get: { entryToRestore != nil },
+                set: { if !$0 { entryToRestore = nil } }
+            ),
+            presenting: entryToRestore
+        ) { entry in
+            Button(ReleasedThreadsCopy.welcomeBackConfirm) {
+                ReleasedThreadsStore.shared.welcomeBack(displayTerm: entry.displayTerm)
+                entries = ReleasedThreadsStore.shared.all
+                entryToRestore = nil
+            }
+            Button(ReleasedThreadsCopy.welcomeBackCancel, role: .cancel) {
+                entryToRestore = nil
+            }
+        } message: { _ in
+            Text(ReleasedThreadsCopy.welcomeBackMessage)
+        }
+    }
+}

--- a/Pilgrim/Scenes/Settings/SettingsCards/VoiceCard.swift
+++ b/Pilgrim/Scenes/Settings/SettingsCards/VoiceCard.swift
@@ -7,6 +7,7 @@ struct VoiceCard: View {
     @State private var autoTranscribe = UserPreferences.autoTranscribe.value
     @State private var threadsAfterWalks = UserPreferences.threadsAfterWalks.value
     @State private var hasReleasedThreads = !ReleasedThreadsStore.shared.isEmpty
+    @State private var hasPastRecaps = !PastRecapsListView.closedLunations().isEmpty
     @State private var recordingCount = 0
     @State private var recordingSizeMB: Double = 0
     @ObservedObject private var transcriptionService = TranscriptionService.shared
@@ -65,6 +66,14 @@ struct VoiceCard: View {
                 }
             }
 
+            if threadsAfterWalks && hasPastRecaps {
+                NavigationLink {
+                    PastRecapsListView()
+                } label: {
+                    settingNavRow(label: "Past recaps")
+                }
+            }
+
             if case .downloadingModel(let progress) = transcriptionService.state {
                 HStack(spacing: 8) {
                     SwiftUI.ProgressView(value: progress)
@@ -94,6 +103,7 @@ struct VoiceCard: View {
         .onAppear {
             voiceGuideEnabled = UserPreferences.voiceGuideEnabled.value
             hasReleasedThreads = !ReleasedThreadsStore.shared.isEmpty
+            hasPastRecaps = !PastRecapsListView.closedLunations().isEmpty
             refreshStats()
         }
     }

--- a/Pilgrim/Scenes/Settings/SettingsCards/VoiceCard.swift
+++ b/Pilgrim/Scenes/Settings/SettingsCards/VoiceCard.swift
@@ -6,6 +6,7 @@ struct VoiceCard: View {
     @State private var dynamicVoiceEnabled = UserPreferences.dynamicVoiceEnabled.value
     @State private var autoTranscribe = UserPreferences.autoTranscribe.value
     @State private var threadsAfterWalks = UserPreferences.threadsAfterWalks.value
+    @State private var hasReleasedThreads = !ReleasedThreadsStore.shared.isEmpty
     @State private var recordingCount = 0
     @State private var recordingSizeMB: Double = 0
     @ObservedObject private var transcriptionService = TranscriptionService.shared
@@ -56,6 +57,14 @@ struct VoiceCard: View {
                 ThreadsBackfill.setEnabled(newValue)
             }
 
+            if threadsAfterWalks && hasReleasedThreads {
+                NavigationLink {
+                    ReleasedThreadsListView()
+                } label: {
+                    settingNavRow(label: "Released threads")
+                }
+            }
+
             if case .downloadingModel(let progress) = transcriptionService.state {
                 HStack(spacing: 8) {
                     SwiftUI.ProgressView(value: progress)
@@ -84,6 +93,7 @@ struct VoiceCard: View {
         .animation(.easeInOut(duration: 0.2), value: voiceGuideEnabled)
         .onAppear {
             voiceGuideEnabled = UserPreferences.voiceGuideEnabled.value
+            hasReleasedThreads = !ReleasedThreadsStore.shared.isEmpty
             refreshStats()
         }
     }

--- a/Pilgrim/Scenes/WalkSummary/LunationRecapView.swift
+++ b/Pilgrim/Scenes/WalkSummary/LunationRecapView.swift
@@ -49,6 +49,7 @@ struct LunationRecapView: View {
             Image(systemName: "moon")
                 .font(.title2)
                 .foregroundColor(.fog)
+                .accessibilityHidden(true)
             Text(LunationRecapCopy.headline(walkCount: model.walkCount))
                 .font(Constants.Typography.body)
                 .foregroundColor(.ink)

--- a/Pilgrim/Scenes/WalkSummary/LunationRecapView.swift
+++ b/Pilgrim/Scenes/WalkSummary/LunationRecapView.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+
+/// The moon's quiet accounting — pulled, never pushed. Content is computed
+/// live at open; themes tap through to their thread views. Deterministic
+/// template copy; the only digits are the spec-sanctioned "in N of M walks".
+struct LunationRecapView: View {
+
+    let lunation: Lunation
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var model: LunationRecapModel?
+    @State private var selectedTheme: LunationRecapTheme?
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                if let model {
+                    content(model)
+                        .padding(Constants.UI.Padding.normal)
+                }
+            }
+            .canvasBackground()
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Text(model?.moonName ?? "")
+                        .font(Constants.Typography.heading)
+                        .foregroundColor(.ink)
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") { dismiss() }
+                        .foregroundColor(.stone)
+                }
+            }
+            .navigationDestination(item: $selectedTheme) { theme in
+                ThreadHistoryView(displayTerm: theme.displayTerm, cohortLemmas: theme.lemmas)
+            }
+            // Re-keyed on the released token: a release made inside the
+            // pushed thread view pops back here, the pop re-evaluates this
+            // body, the id has changed, and load() reruns — the released
+            // theme drops out (the quiet line appears when emptied) and a
+            // re-tap can never open a dead-end empty history view.
+            .task(id: ReleasedThreadsStore.shared.changeCount) { await load() }
+        }
+    }
+
+    private func content(_ model: LunationRecapModel) -> some View {
+        VStack(spacing: Constants.UI.Padding.normal) {
+            Image(systemName: "moon")
+                .font(.title2)
+                .foregroundColor(.fog)
+            Text(LunationRecapCopy.headline(walkCount: model.walkCount))
+                .font(Constants.Typography.body)
+                .foregroundColor(.ink)
+
+            if let quiet = model.quietLine {
+                Text(quiet)
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog)
+                    .multilineTextAlignment(.center)
+            }
+
+            ForEach(model.themes) { theme in
+                themeRow(theme, totalWalks: model.walkCount)
+            }
+
+            if let texture = model.textureLine {
+                Text(texture)
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog)
+                    .multilineTextAlignment(.center)
+            }
+        }
+    }
+
+    private func themeRow(_ theme: LunationRecapTheme, totalWalks: Int) -> some View {
+        Button {
+            selectedTheme = theme
+        } label: {
+            VStack(alignment: .leading, spacing: Constants.UI.Padding.xs) {
+                Text(LunationRecapCopy.themeLine(
+                    term: theme.displayTerm, walkCount: theme.walkCount, totalWalks: totalWalks
+                ))
+                .font(Constants.Typography.body)
+                .foregroundColor(.ink)
+                .multilineTextAlignment(.leading)
+                if theme.isNewThisMoon {
+                    Text(LunationRecapCopy.newThisMoon)
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.moss)
+                }
+            }
+            .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+            .padding(Constants.UI.Padding.normal)
+            .background(Color.parchmentSecondary)
+            .cornerRadius(Constants.UI.CornerRadius.normal)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityHint("Double tap to view this thread's history")
+    }
+
+    @MainActor
+    private func load() async {
+        // The local shadow must precede its first use — Swift resolves the
+        // unqualified name to the local for the WHOLE scope, so referencing
+        // it above its declaration is a compile error, not a property read.
+        let lunation = self.lunation
+        let walkIndex = DataManager.voiceRecordingWalkIndex()
+        let paces = DataManager.voiceRecordingPaceIndex()
+        let released = ReleasedThreadsStore.shared.releasedLemmas
+        let backfillComplete = ThreadsBackfill.isComplete
+        let moonName = LunationCalendar.moonName(for: lunation)
+
+        model = await Task.detached(priority: .userInitiated) {
+            LunationRecapModelBuilder.model(
+                lunation: lunation, moonName: moonName,
+                contexts: TranscriptContextStore.shared.loadAll(),
+                walkIndex: walkIndex, paceByRecording: paces,
+                released: released, backfillComplete: backfillComplete
+            )
+        }.value
+    }
+}

--- a/Pilgrim/Scenes/WalkSummary/ThreadHistoryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/ThreadHistoryView.swift
@@ -53,7 +53,9 @@ struct ThreadHistoryView: View {
     @State private var origin: OriginMapData?
     @State private var selectedWalk: Walk?
     @State private var presentedOriginMap: OriginMapData?
+    @State private var showReleaseConfirm = false
     @StateObject private var placeResolver = ThreadPlaceResolver()
+    @Environment(\.dismiss) private var dismiss
 
     struct OriginMapData: Identifiable {
         let id = UUID()
@@ -70,6 +72,7 @@ struct ThreadHistoryView: View {
     var body: some View {
         ScrollView {
             VStack(alignment: .leading, spacing: Constants.UI.Padding.normal) {
+                termHeader
                 ForEach(entries, id: \.recordingUUID) { entry in
                     entryRow(entry)
                 }
@@ -95,8 +98,32 @@ struct ThreadHistoryView: View {
         .sheet(item: $presentedOriginMap) { data in
             ThreadOriginMapView(displayTerm: displayTerm, data: data)
         }
+        .alert(
+            ReleasedThreadsCopy.releaseTitle(displayTerm),
+            isPresented: $showReleaseConfirm
+        ) {
+            Button(ReleasedThreadsCopy.releaseConfirm) {
+                ReleasedThreadsStore.shared.release(displayTerm: displayTerm, lemmas: cohortLemmas)
+                dismiss()
+            }
+            Button(ReleasedThreadsCopy.releaseCancel, role: .cancel) {}
+        } message: {
+            Text(ReleasedThreadsCopy.releaseMessage)
+        }
         .task { await load() }
         .onDisappear { placeResolver.cancel() }
+    }
+
+    private var termHeader: some View {
+        Text(displayTerm)
+            .font(Constants.Typography.displayMedium)
+            .foregroundColor(.ink)
+            .frame(maxWidth: .infinity, minHeight: 44)
+            .contentShape(Rectangle())
+            .onLongPressGesture { showReleaseConfirm = true }
+            .accessibilityAction(named: ReleasedThreadsCopy.voiceOverActionName) {
+                showReleaseConfirm = true
+            }
     }
 
     private func entryRow(_ entry: ThreadHistoryEntry) -> some View {

--- a/Pilgrim/Scenes/WalkSummary/ThreadHistoryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/ThreadHistoryView.swift
@@ -149,9 +149,13 @@ struct ThreadHistoryView: View {
                 .font(Constants.Typography.caption)
                 .foregroundColor(.moss)
             Spacer()
-            if let origin {
+            if origin != nil {
                 Button {
-                    presentedOriginMap = origin
+                    guard let fresh = resolveOrigin() else {
+                        origin = nil
+                        return
+                    }
+                    presentedOriginMap = fresh
                 } label: {
                     Text("open the map")
                         .font(Constants.Typography.caption)
@@ -194,10 +198,14 @@ struct ThreadHistoryView: View {
         )
     }
 
-    /// Resolution happens when the view opens — never persisted, so a
-    /// deleted origin walk or a fix gap simply hides the action on the next
-    /// open, and the record's earliest surviving appearance becomes "where
-    /// it began" (spec: deletion is deliberate record-editing).
+    /// Called at load (to decide whether the footer's map button renders)
+    /// and again at tap (to fetch a fresh walk + coordinate right before
+    /// presenting) — never persisted, so a walk deleted in between is never
+    /// shown stale: the tap either presents fresh data or, finding nothing,
+    /// hides the action on the spot. A deleted origin walk or a fix gap
+    /// simply means the record's earliest surviving appearance becomes
+    /// "where it began" on the next open (spec: deletion is deliberate
+    /// record-editing).
     @MainActor
     private func resolveOrigin() -> OriginMapData? {
         guard let oldest = entries.last, oldest.isOrigin,

--- a/Pilgrim/Scenes/WalkSummary/ThreadHistoryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/ThreadHistoryView.swift
@@ -172,6 +172,7 @@ struct ThreadHistoryView: View {
             Image(systemName: "leaf")
                 .font(.caption)
                 .foregroundColor(.moss)
+                .accessibilityHidden(true)
             Text("where it began")
                 .font(Constants.Typography.caption)
                 .foregroundColor(.moss)
@@ -193,31 +194,41 @@ struct ThreadHistoryView: View {
         }
     }
 
+    /// The full-history snapshot query only ran here because this thread's
+    /// handful of appearances weren't known until after loading every stored
+    /// context — cheap off-actor work now split out so the main-actor
+    /// transcript fetch below can scope to just the recordings this cohort
+    /// touches, instead of every transcribed recording in the app.
     @MainActor
     private func load() async {
         guard UserPreferences.threadsAfterWalks.value else { return }
         let walkIndex = DataManager.voiceRecordingWalkIndex()
-        let transcripts = Dictionary(
-            uniqueKeysWithValues: DataManager.transcribedRecordingsSnapshot()
-                .map { ($0.uuid, $0.transcript) }
-        )
         let released = ReleasedThreadsStore.shared.releasedLemmas
         let backfillComplete = ThreadsBackfill.isComplete
         let lemmas = Set(cohortLemmas)
 
-        entries = await Task.detached(priority: .userInitiated) { () -> [ThreadHistoryEntry] in
+        let (cohort, contextsByRecording) = await Task.detached(priority: .userInitiated) {
+            () -> ([WalkThread], [UUID: TranscriptContext]) in
             let contexts = TranscriptContextStore.shared.loadAll()
             let contextsByRecording = Dictionary(
                 uniqueKeysWithValues: contexts.map { ($0.recordingUUID, $0) }
             )
             let threads = ThreadStore.build(contexts: contexts, walks: walkIndex, released: released)
-            return ThreadHistoryModelBuilder.entries(
-                cohort: threads.filter { lemmas.contains($0.lemma) },
-                contextsByRecording: contextsByRecording,
-                transcriptsByRecording: transcripts,
-                backfillComplete: backfillComplete
-            )
+            return (threads.filter { lemmas.contains($0.lemma) }, contextsByRecording)
         }.value
+
+        let neededRecordings = Set(cohort.flatMap(\.appearances).map(\.recordingUUID))
+        let transcripts = Dictionary(
+            uniqueKeysWithValues: DataManager.transcribedRecordingsSnapshot(uuids: neededRecordings)
+                .map { ($0.uuid, $0.transcript) }
+        )
+
+        entries = ThreadHistoryModelBuilder.entries(
+            cohort: cohort,
+            contextsByRecording: contextsByRecording,
+            transcriptsByRecording: transcripts,
+            backfillComplete: backfillComplete
+        )
         origin = resolveOrigin()
         var seenWalks: Set<UUID> = []
         placeResolver.resolveAll(

--- a/Pilgrim/Scenes/WalkSummary/ThreadHistoryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/ThreadHistoryView.swift
@@ -1,0 +1,252 @@
+import SwiftUI
+import CoreStore
+import CoreLocation
+
+/// Best-effort reverse geocoding of each walk's starting point — resolved
+/// once per walk, capped per screen, and strictly serialized: CLGeocoder
+/// fails a pending request when a new one is submitted, so concurrent
+/// per-row requests would silently lose most place names. One FIFO Task
+/// awaits each lookup before starting the next; a missing place simply
+/// doesn't render. The Task handle is cancelled when the view disappears.
+@MainActor
+final class ThreadPlaceResolver: ObservableObject {
+
+    @Published private(set) var places: [UUID: String] = [:]
+    private let geocoder = CLGeocoder()
+    private var resolveTask: Task<Void, Never>?
+    private static let maxResolutions = 12
+
+    /// Called exactly once, from load(), with the entries' distinct walk
+    /// UUIDs in display order — never per row.
+    func resolveAll(walkUUIDs: [UUID]) {
+        guard resolveTask == nil else { return }
+        let pending = walkUUIDs.prefix(Self.maxResolutions)
+        resolveTask = Task {
+            for walkUUID in pending {
+                guard !Task.isCancelled else { return }
+                guard let walk = try? DataManager.dataStack.fetchOne(
+                    From<Walk>().where(\._uuid == walkUUID)
+                ), let first = walk.routeData.first else { continue }
+                let location = CLLocation(latitude: first.latitude, longitude: first.longitude)
+                guard let placemark = try? await geocoder.reverseGeocodeLocation(location).first,
+                      let name = placemark.locality ?? placemark.name else { continue }
+                places[walkUUID] = name
+            }
+        }
+    }
+
+    func cancel() {
+        resolveTask?.cancel()
+        resolveTask = nil
+    }
+}
+
+/// A thread's full history, newest first — date, place, and the walker's
+/// own words around each mention. The oldest entry is labeled "where it
+/// began" and offers the origin walk's map when a route fix exists.
+struct ThreadHistoryView: View {
+
+    let displayTerm: String
+    let cohortLemmas: [String]
+
+    @State private var entries: [ThreadHistoryEntry] = []
+    @State private var origin: OriginMapData?
+    @State private var selectedWalk: Walk?
+    @State private var presentedOriginMap: OriginMapData?
+    @StateObject private var placeResolver = ThreadPlaceResolver()
+
+    struct OriginMapData: Identifiable {
+        let id = UUID()
+        let walk: Walk
+        let coordinate: CLLocationCoordinate2D
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter
+    }()
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Constants.UI.Padding.normal) {
+                ForEach(entries, id: \.recordingUUID) { entry in
+                    entryRow(entry)
+                }
+            }
+            .padding(Constants.UI.Padding.normal)
+        }
+        .canvasBackground()
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                Text(displayTerm)
+                    .font(Constants.Typography.heading)
+                    .foregroundColor(.ink)
+            }
+        }
+        .sheet(item: $selectedWalk) { walk in
+            // showsThreadsCard: false is the Task 3 recursion cut — a
+            // tap-through summary must not offer another threads card, or
+            // summary → thread → summary stacks Mapbox-bearing views
+            // without bound.
+            WalkSummaryView(walk: walk, showsThreadsCard: false)
+        }
+        .sheet(item: $presentedOriginMap) { data in
+            ThreadOriginMapView(displayTerm: displayTerm, data: data)
+        }
+        .task { await load() }
+        .onDisappear { placeResolver.cancel() }
+    }
+
+    private func entryRow(_ entry: ThreadHistoryEntry) -> some View {
+        VStack(alignment: .leading, spacing: Constants.UI.Padding.xs) {
+            Button {
+                selectedWalk = try? DataManager.dataStack.fetchOne(
+                    From<Walk>().where(\._uuid == entry.walkUUID)
+                )
+            } label: {
+                VStack(alignment: .leading, spacing: Constants.UI.Padding.xs) {
+                    HStack(spacing: Constants.UI.Padding.xs) {
+                        Text(Self.dateFormatter.string(from: entry.date))
+                            .font(Constants.Typography.caption)
+                            .foregroundColor(.fog)
+                        if let place = placeResolver.places[entry.walkUUID] {
+                            Text("· \(place)")
+                                .font(Constants.Typography.caption)
+                                .foregroundColor(.fog)
+                        }
+                    }
+                    if let excerpt = entry.excerpt {
+                        Text(excerpt)
+                            .font(Constants.Typography.body)
+                            .foregroundColor(.ink)
+                            .multilineTextAlignment(.leading)
+                    }
+                }
+                .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityElement(children: .combine)
+            .accessibilityHint("Double tap to open this walk's summary")
+
+            if entry.isOrigin {
+                originFooter
+            }
+        }
+        .padding(Constants.UI.Padding.normal)
+        .background(Color.parchmentSecondary)
+        .cornerRadius(Constants.UI.CornerRadius.normal)
+    }
+
+    private var originFooter: some View {
+        HStack(spacing: Constants.UI.Padding.xs) {
+            Image(systemName: "leaf")
+                .font(.caption)
+                .foregroundColor(.moss)
+            Text("where it began")
+                .font(Constants.Typography.caption)
+                .foregroundColor(.moss)
+            Spacer()
+            if let origin {
+                Button {
+                    presentedOriginMap = origin
+                } label: {
+                    Text("open the map")
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.stone)
+                        .frame(minHeight: 44)
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func load() async {
+        guard UserPreferences.threadsAfterWalks.value else { return }
+        let walkIndex = DataManager.voiceRecordingWalkIndex()
+        let transcripts = Dictionary(
+            uniqueKeysWithValues: DataManager.transcribedRecordingsSnapshot()
+                .map { ($0.uuid, $0.transcript) }
+        )
+        let released = ReleasedThreadsStore.shared.releasedLemmas
+        let backfillComplete = ThreadsBackfill.isComplete
+        let lemmas = Set(cohortLemmas)
+
+        entries = await Task.detached(priority: .userInitiated) { () -> [ThreadHistoryEntry] in
+            let contexts = TranscriptContextStore.shared.loadAll()
+            let contextsByRecording = Dictionary(
+                uniqueKeysWithValues: contexts.map { ($0.recordingUUID, $0) }
+            )
+            let threads = ThreadStore.build(contexts: contexts, walks: walkIndex, released: released)
+            return ThreadHistoryModelBuilder.entries(
+                cohort: threads.filter { lemmas.contains($0.lemma) },
+                contextsByRecording: contextsByRecording,
+                transcriptsByRecording: transcripts,
+                backfillComplete: backfillComplete
+            )
+        }.value
+        origin = resolveOrigin()
+        var seenWalks: Set<UUID> = []
+        placeResolver.resolveAll(
+            walkUUIDs: entries.map(\.walkUUID).filter { seenWalks.insert($0).inserted }
+        )
+    }
+
+    /// Resolution happens when the view opens — never persisted, so a
+    /// deleted origin walk or a fix gap simply hides the action on the next
+    /// open, and the record's earliest surviving appearance becomes "where
+    /// it began" (spec: deletion is deliberate record-editing).
+    @MainActor
+    private func resolveOrigin() -> OriginMapData? {
+        guard let oldest = entries.last, oldest.isOrigin,
+              let walk = try? DataManager.dataStack.fetchOne(
+                From<Walk>().where(\._uuid == oldest.walkUUID)
+              ),
+              let recording = walk.voiceRecordings.first(where: { $0.uuid == oldest.recordingUUID }),
+              let coordinate = ThreadOriginResolver.coordinate(
+                recordingStart: recording.startDate,
+                samples: walk.routeData.map { ($0.timestamp, $0.latitude, $0.longitude) }
+              ) else { return nil }
+        return OriginMapData(walk: walk, coordinate: coordinate)
+    }
+}
+
+/// The origin walk's map — the existing historical summary map, static and
+/// read-only, no live-walk controls — centered on where the thread first
+/// found words.
+struct ThreadOriginMapView: View {
+
+    let displayTerm: String
+    let data: ThreadHistoryView.OriginMapData
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            PilgrimMapView(
+                isInteractive: false,
+                showsUserLocation: false,
+                routeSegments: WalkSummaryView.computeSegments(for: data.walk),
+                pinAnnotations: [PilgrimAnnotation(
+                    coordinate: data.coordinate,
+                    kind: .voiceRecording(label: "where it began")
+                )],
+                initialCamera: MapCameraSeed.Seed(center: data.coordinate, zoom: 15)
+            )
+            .ignoresSafeArea(edges: .bottom)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Text("Where '\(displayTerm)' began")
+                        .font(Constants.Typography.heading)
+                        .foregroundColor(.ink)
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") { dismiss() }
+                        .foregroundColor(.stone)
+                }
+            }
+        }
+    }
+}

--- a/Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift
+++ b/Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift
@@ -77,6 +77,9 @@ struct ThreadsCardSection: View {
         .frame(maxWidth: .infinity)
         .background(Color.parchmentSecondary)
         .cornerRadius(Constants.UI.CornerRadius.normal)
+        .onAppear {
+            LunationRecapState.shared.markFirstCardShown()
+        }
         .alert(
             themeToRelease.map { ReleasedThreadsCopy.releaseTitle($0.displayTerm) } ?? "",
             isPresented: Binding(

--- a/Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift
+++ b/Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift
@@ -49,6 +49,7 @@ enum ThreadsCardLoader {
 struct ThreadsCardSection: View {
 
     let model: ThreadsCardModel
+    var onThemeTap: ((ThreadsCardTheme) -> Void)?
 
     @State private var showInsightWords = false
 
@@ -73,24 +74,31 @@ struct ThreadsCardSection: View {
     }
 
     private func chip(_ theme: ThreadsCardTheme) -> some View {
-        VStack(spacing: 2) {
-            Text(theme.displayTerm)
-                .font(Constants.Typography.body)
-                .foregroundColor(.ink)
-            if let note = theme.statusNote {
-                Text(note)
-                    .font(Constants.Typography.caption)
-                    .foregroundColor(.fog)
+        Button {
+            onThemeTap?(theme)
+        } label: {
+            VStack(spacing: 2) {
+                Text(theme.displayTerm)
+                    .font(Constants.Typography.body)
+                    .foregroundColor(.ink)
+                if let note = theme.statusNote {
+                    Text(note)
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.fog)
+                }
             }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .frame(minHeight: 44)
+            .background(Capsule().fill(Color.moss.opacity(0.1)))
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 8)
-        .frame(minHeight: 44)
-        .background(Capsule().fill(Color.moss.opacity(0.1)))
+        .buttonStyle(.plain)
+        .disabled(onThemeTap == nil)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(
             theme.statusNote.map { "\(theme.displayTerm), \($0)" } ?? theme.displayTerm
         )
+        .accessibilityHint(onThemeTap == nil ? "" : "Double tap to view history")
     }
 
     private func textureLine(_ texture: String) -> some View {

--- a/Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift
+++ b/Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift
@@ -95,7 +95,7 @@ struct ThreadsCardSection: View {
 
     private func textureLine(_ texture: String) -> some View {
         Button {
-            guard !model.insightWords.isEmpty else { return }
+            guard model.hasInsight else { return }
             showInsightWords.toggle()
         } label: {
             VStack(spacing: Constants.UI.Padding.xs) {
@@ -103,7 +103,7 @@ struct ThreadsCardSection: View {
                     .font(Constants.Typography.caption)
                     .foregroundColor(.fog)
                     .multilineTextAlignment(.center)
-                if showInsightWords, !model.insightWords.isEmpty {
+                if showInsightWords, model.hasInsight {
                     Text(model.insightWords.map { "'\($0)'" }.joined(separator: ", "))
                         .font(Constants.Typography.caption)
                         .foregroundColor(.moss)
@@ -115,7 +115,7 @@ struct ThreadsCardSection: View {
         }
         .buttonStyle(.plain)
         .accessibilityHint(
-            model.insightWords.isEmpty ? "" : "Double tap to see the words of insight"
+            model.hasInsight ? "Double tap to see the words of insight" : ""
         )
     }
 }

--- a/Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift
+++ b/Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift
@@ -36,13 +36,19 @@ enum ThreadsCardLoader {
             // each current-walk recording against its stored context and
             // re-analyze inline on mismatch — the ThreadsDossierBuilder
             // discipline — so a stale context never reaches ThreadStore.build.
+            // In-memory only: `analyze`, never `analyzeAndStore`. The
+            // transcription choke point (DataManager
+            // .updateVoiceRecordingTranscription) is the sole persistent
+            // writer, because it alone carries the ASR flaggedFragments
+            // needed to filter hallucinated themes — a card rebuild racing
+            // that choke point must not persist an unfiltered context over
+            // it.
             for recording in recordings {
                 let hash = TranscriptContextStore.hash(of: recording.transcript)
                 if store.context(for: recording.uuid, matching: hash) == nil {
-                    let result = TranscriptContextAnalyzer.analyzeAndStore(
-                        recordingUUID: recording.uuid, transcript: recording.transcript, store: store
+                    contextsByRecording[recording.uuid] = TranscriptContextAnalyzer.analyze(
+                        recordingUUID: recording.uuid, transcript: recording.transcript
                     )
-                    contextsByRecording[recording.uuid] = result.context
                 }
             }
             let threads = ThreadStore.build(

--- a/Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift
+++ b/Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift
@@ -50,8 +50,11 @@ struct ThreadsCardSection: View {
 
     let model: ThreadsCardModel
     var onThemeTap: ((ThreadsCardTheme) -> Void)?
+    var onRelease: ((ThreadsCardTheme) -> Void)?
 
     @State private var showInsightWords = false
+    @State private var themeToRelease: ThreadsCardTheme?
+    @State private var captionDismissed = UserPreferences.threadsReleaseCaptionShown.value
 
     var body: some View {
         VStack(spacing: Constants.UI.Padding.small) {
@@ -66,39 +69,85 @@ struct ThreadsCardSection: View {
             if let texture = model.textureLine {
                 textureLine(texture)
             }
+            if onRelease != nil, !captionDismissed {
+                captionRow
+            }
         }
         .padding(Constants.UI.Padding.normal)
         .frame(maxWidth: .infinity)
         .background(Color.parchmentSecondary)
         .cornerRadius(Constants.UI.CornerRadius.normal)
+        .alert(
+            themeToRelease.map { ReleasedThreadsCopy.releaseTitle($0.displayTerm) } ?? "",
+            isPresented: Binding(
+                get: { themeToRelease != nil },
+                set: { if !$0 { themeToRelease = nil } }
+            ),
+            presenting: themeToRelease
+        ) { theme in
+            Button(ReleasedThreadsCopy.releaseConfirm) {
+                onRelease?(theme)
+                themeToRelease = nil
+            }
+            Button(ReleasedThreadsCopy.releaseCancel, role: .cancel) {
+                themeToRelease = nil
+            }
+        } message: { _ in
+            Text(ReleasedThreadsCopy.releaseMessage)
+        }
+    }
+
+    private var captionRow: some View {
+        HStack(spacing: Constants.UI.Padding.xs) {
+            Text(ReleasedThreadsCopy.caption)
+                .font(Constants.Typography.caption)
+                .foregroundColor(.fog.opacity(0.7))
+            Button {
+                UserPreferences.threadsReleaseCaptionShown.value = true
+                captionDismissed = true
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.caption2)
+                    .foregroundColor(.fog)
+                    .frame(minWidth: 44, minHeight: 44)
+            }
+            .accessibilityLabel("Dismiss hint")
+        }
     }
 
     private func chip(_ theme: ThreadsCardTheme) -> some View {
-        Button {
-            onThemeTap?(theme)
-        } label: {
-            VStack(spacing: 2) {
-                Text(theme.displayTerm)
-                    .font(Constants.Typography.body)
-                    .foregroundColor(.ink)
-                if let note = theme.statusNote {
-                    Text(note)
-                        .font(Constants.Typography.caption)
-                        .foregroundColor(.fog)
-                }
+        VStack(spacing: 2) {
+            Text(theme.displayTerm)
+                .font(Constants.Typography.body)
+                .foregroundColor(.ink)
+            if let note = theme.statusNote {
+                Text(note)
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog)
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 8)
-            .frame(minHeight: 44)
-            .background(Capsule().fill(Color.moss.opacity(0.1)))
         }
-        .buttonStyle(.plain)
-        .disabled(onThemeTap == nil)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .frame(minHeight: 44)
+        .background(Capsule().fill(Color.moss.opacity(0.1)))
+        .contentShape(Rectangle())
+        .onTapGesture {
+            onThemeTap?(theme)
+        }
+        .onLongPressGesture(minimumDuration: 0.4) {
+            guard onRelease != nil else { return }
+            themeToRelease = theme
+        }
         .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
         .accessibilityLabel(
             theme.statusNote.map { "\(theme.displayTerm), \($0)" } ?? theme.displayTerm
         )
         .accessibilityHint(onThemeTap == nil ? "" : "Double tap to view history")
+        .accessibilityAction(named: ReleasedThreadsCopy.voiceOverActionName) {
+            guard onRelease != nil else { return }
+            themeToRelease = theme
+        }
     }
 
     private func textureLine(_ texture: String) -> some View {

--- a/Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift
+++ b/Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift
@@ -1,0 +1,121 @@
+import SwiftUI
+
+/// Loads the card model off the summary's hot path: CoreStore reads on the
+/// main actor, store I/O and thread aggregation detached, plain values
+/// across the boundary (the ThreadsDossierBuilder discipline).
+enum ThreadsCardLoader {
+
+    @MainActor
+    static func load(
+        walk: WalkInterface,
+        transcriptions: [UUID: String],
+        store: TranscriptContextStore = .shared,
+        releasedStore: ReleasedThreadsStore = .shared
+    ) async -> ThreadsCardModel? {
+        guard UserPreferences.threadsAfterWalks.value,
+              let walkUUID = walk.uuid,
+              !transcriptions.isEmpty else { return nil }
+
+        let recordings = walk.voiceRecordings.compactMap { recording -> (uuid: UUID, transcript: String, wordsPerMinute: Double?)? in
+            guard let uuid = recording.uuid, let text = transcriptions[uuid] else { return nil }
+            return (uuid, text, recording.wordsPerMinute)
+        }
+        guard !recordings.isEmpty else { return nil }
+
+        let walkIndex = DataManager.voiceRecordingWalkIndex()
+        let released = releasedStore.releasedLemmas
+        let backfillComplete = ThreadsBackfill.isComplete
+
+        return await Task.detached(priority: .userInitiated) {
+            let contexts = store.loadAll()
+            let contextsByRecording = Dictionary(
+                uniqueKeysWithValues: contexts.map { ($0.recordingUUID, $0) }
+            )
+            let threads = ThreadStore.build(contexts: contexts, walks: walkIndex, released: released)
+            return ThreadsCardModelBuilder.model(
+                walkUUID: walkUUID,
+                threads: threads,
+                recordings: recordings,
+                contextsByRecording: contextsByRecording,
+                backfillComplete: backfillComplete
+            )
+        }.value
+    }
+}
+
+/// "What walked with you" — the quiet card naming the themes of this walk.
+/// Rendered only when a model exists: at least one transcribed recording,
+/// at least one surviving theme, toggle on.
+struct ThreadsCardSection: View {
+
+    let model: ThreadsCardModel
+
+    @State private var showInsightWords = false
+
+    var body: some View {
+        VStack(spacing: Constants.UI.Padding.small) {
+            Text("What walked with you")
+                .font(Constants.Typography.caption)
+                .foregroundColor(.fog)
+            FlowLayout(spacing: Constants.UI.Padding.small) {
+                ForEach(model.themes) { theme in
+                    chip(theme)
+                }
+            }
+            if let texture = model.textureLine {
+                textureLine(texture)
+            }
+        }
+        .padding(Constants.UI.Padding.normal)
+        .frame(maxWidth: .infinity)
+        .background(Color.parchmentSecondary)
+        .cornerRadius(Constants.UI.CornerRadius.normal)
+    }
+
+    private func chip(_ theme: ThreadsCardTheme) -> some View {
+        VStack(spacing: 2) {
+            Text(theme.displayTerm)
+                .font(Constants.Typography.body)
+                .foregroundColor(.ink)
+            if let note = theme.statusNote {
+                Text(note)
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .frame(minHeight: 44)
+        .background(Capsule().fill(Color.moss.opacity(0.1)))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            theme.statusNote.map { "\(theme.displayTerm), \($0)" } ?? theme.displayTerm
+        )
+    }
+
+    private func textureLine(_ texture: String) -> some View {
+        Button {
+            guard !model.insightWords.isEmpty else { return }
+            showInsightWords.toggle()
+        } label: {
+            VStack(spacing: Constants.UI.Padding.xs) {
+                Text(texture)
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog)
+                    .multilineTextAlignment(.center)
+                if showInsightWords, !model.insightWords.isEmpty {
+                    Text(model.insightWords.map { "'\($0)'" }.joined(separator: ", "))
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.moss)
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .frame(maxWidth: .infinity, minHeight: 44)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityHint(
+            model.insightWords.isEmpty ? "" : "Double tap to see the words of insight"
+        )
+    }
+}

--- a/Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift
+++ b/Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift
@@ -28,10 +28,26 @@ enum ThreadsCardLoader {
 
         return await Task.detached(priority: .userInitiated) {
             let contexts = store.loadAll()
-            let contextsByRecording = Dictionary(
+            var contextsByRecording = Dictionary(
                 uniqueKeysWithValues: contexts.map { ($0.recordingUUID, $0) }
             )
-            let threads = ThreadStore.build(contexts: contexts, walks: walkIndex, released: released)
+            // An in-place edit lands via an async CoreStore write completion;
+            // this load can win the race and read the pre-edit context. Hash
+            // each current-walk recording against its stored context and
+            // re-analyze inline on mismatch — the ThreadsDossierBuilder
+            // discipline — so a stale context never reaches ThreadStore.build.
+            for recording in recordings {
+                let hash = TranscriptContextStore.hash(of: recording.transcript)
+                if store.context(for: recording.uuid, matching: hash) == nil {
+                    let result = TranscriptContextAnalyzer.analyzeAndStore(
+                        recordingUUID: recording.uuid, transcript: recording.transcript, store: store
+                    )
+                    contextsByRecording[recording.uuid] = result.context
+                }
+            }
+            let threads = ThreadStore.build(
+                contexts: Array(contextsByRecording.values), walks: walkIndex, released: released
+            )
             return ThreadsCardModelBuilder.model(
                 walkUUID: walkUUID,
                 threads: threads,

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift
@@ -10,14 +10,47 @@ extension WalkSummaryView {
 
     @ViewBuilder
     var threadsCardSlot: some View {
-        if showsThreadsCard, let threadsCardModel {
-            ThreadsCardSection(
-                model: threadsCardModel,
-                onThemeTap: { selectedCardTheme = $0 },
-                onRelease: { releaseTheme($0) }
-            )
-            .transition(.opacity)
+        if showsThreadsCard {
+            if let recapInvitation {
+                lunationInvitationRow(recapInvitation)
+            }
+            if let threadsCardModel {
+                ThreadsCardSection(
+                    model: threadsCardModel,
+                    onThemeTap: { selectedCardTheme = $0 },
+                    onRelease: { releaseTheme($0) }
+                )
+                .transition(.opacity)
+            }
         }
+    }
+
+    func lunationInvitationRow(_ lunation: Lunation) -> some View {
+        Button {
+            LunationRecapState.shared.markActedOn(lunation)
+            recapInvitation = nil
+            recapSheet = lunation
+        } label: {
+            HStack(spacing: Constants.UI.Padding.small) {
+                Image(systemName: "moon")
+                    .font(.caption)
+                    .foregroundColor(.fog)
+                Text(LunationRecapCopy.invitation(
+                    moonName: LunationCalendar.moonName(for: lunation)
+                ))
+                .font(Constants.Typography.caption)
+                .foregroundColor(.ink)
+                .multilineTextAlignment(.leading)
+                Spacer()
+            }
+            .padding(Constants.UI.Padding.normal)
+            .frame(maxWidth: .infinity, minHeight: 44)
+            .background(Color.parchmentSecondary)
+            .cornerRadius(Constants.UI.CornerRadius.normal)
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityHint("Double tap to open the moon's recap")
     }
 
     func loadThreadsCard() async {

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+// MARK: - Thought Threads card glue
+//
+// Extracted from `WalkSummaryView.swift` like the +Map extension, to keep
+// the main type body under SwiftLint's type_body_length limit. Stored
+// state stays in the struct; everything else lives here.
+
+extension WalkSummaryView {
+
+    @ViewBuilder
+    var threadsCardSlot: some View {
+        if showsThreadsCard, let threadsCardModel {
+            ThreadsCardSection(model: threadsCardModel)
+        }
+    }
+
+    func loadThreadsCard() async {
+        guard showsThreadsCard else { return }
+        threadsCardModel = await ThreadsCardLoader.load(walk: walk, transcriptions: transcriptions)
+    }
+}

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift
@@ -11,7 +11,10 @@ extension WalkSummaryView {
     @ViewBuilder
     var threadsCardSlot: some View {
         if showsThreadsCard, let threadsCardModel {
-            ThreadsCardSection(model: threadsCardModel)
+            ThreadsCardSection(
+                model: threadsCardModel,
+                onThemeTap: { selectedCardTheme = $0 }
+            )
         }
     }
 

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift
@@ -6,6 +6,16 @@ import SwiftUI
 // the main type body under SwiftLint's type_body_length limit. Stored
 // state stays in the struct; everything else lives here.
 
+/// The single `.task(id:)` key for the threads-card load — transcriptions
+/// changing and the reload generation bumping (sheet dismissals) are the
+/// only two reasons to reload, so folding both into one Equatable key lets
+/// SwiftUI's own `.task(id:)` cancellation replace three previously
+/// uncoordinated triggers.
+struct ThreadsCardReloadKey: Equatable {
+    let transcriptions: [UUID: String]
+    let generation: Int
+}
+
 extension WalkSummaryView {
 
     @ViewBuilder
@@ -53,9 +63,22 @@ extension WalkSummaryView {
         .accessibilityHint("Double tap to open the moon's recap")
     }
 
+    /// `.task(id:)` cancels a superseded call before it reaches the guards
+    /// below, closing the race between uncoordinated triggers. The
+    /// changeCount check closes a second race this cancellation can't: a
+    /// release or welcome-back (`releaseTheme`, Settings) landing on
+    /// `ReleasedThreadsStore` while THIS load's own await is in flight,
+    /// which isn't a superseding reload at all — nothing bumped
+    /// `threadsReloadGeneration` — just a decision that made this result
+    /// stale mid-flight. Applying it anyway would resurrect a chip the
+    /// walker just released as a zombie whose tap opens an empty history.
     func loadThreadsCard() async {
         guard showsThreadsCard else { return }
-        threadsCardModel = await ThreadsCardLoader.load(walk: walk, transcriptions: transcriptions)
+        let changeCountBefore = ReleasedThreadsStore.shared.changeCount
+        let result = await ThreadsCardLoader.load(walk: walk, transcriptions: transcriptions)
+        guard !Task.isCancelled else { return }
+        guard ReleasedThreadsStore.shared.changeCount == changeCountBefore else { return }
+        threadsCardModel = result
     }
 
     func releaseTheme(_ theme: ThreadsCardTheme) {

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift
@@ -13,13 +13,24 @@ extension WalkSummaryView {
         if showsThreadsCard, let threadsCardModel {
             ThreadsCardSection(
                 model: threadsCardModel,
-                onThemeTap: { selectedCardTheme = $0 }
+                onThemeTap: { selectedCardTheme = $0 },
+                onRelease: { releaseTheme($0) }
             )
+            .transition(.opacity)
         }
     }
 
     func loadThreadsCard() async {
         guard showsThreadsCard else { return }
         threadsCardModel = await ThreadsCardLoader.load(walk: walk, transcriptions: transcriptions)
+    }
+
+    func releaseTheme(_ theme: ThreadsCardTheme) {
+        ReleasedThreadsStore.shared.release(displayTerm: theme.displayTerm, lemmas: theme.lemmas)
+        withAnimation(.easeOut(duration: 0.4)) {
+            threadsCardModel = ThreadsCardModelBuilder.removing(
+                displayTerm: theme.displayTerm, from: threadsCardModel
+            )
+        }
     }
 }

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
@@ -32,6 +32,13 @@ struct WalkSummaryView: View {
     @State var selectedCardTheme: ThreadsCardTheme?
     @State var recapInvitation: Lunation?
     @State var recapSheet: Lunation?
+    /// Bumped by the sheet-dismissal reload triggers below so the single
+    /// `.task(id:)` key changes and SwiftUI cancels any threads-card load
+    /// still in flight — the three triggers (initial transcriptions,
+    /// theme-history dismiss, recap-sheet dismiss) previously raced as
+    /// independent `Task { }` blocks with no cancellation, so whichever
+    /// finished last won even if it was answering a stale question.
+    @State private var threadsReloadGeneration = 0
     init(walk: WalkInterface, showsThreadsCard: Bool = true) {
         self.walk = walk
         self.showsThreadsCard = showsThreadsCard
@@ -194,7 +201,7 @@ struct WalkSummaryView: View {
             .onReceive(CollectiveRouteCatalogService.shared.$catalog) { catalog in
                 resolveCollectiveContributionLine(from: catalog)
             }
-            .task(id: transcriptions) {
+            .task(id: ThreadsCardReloadKey(transcriptions: transcriptions, generation: threadsReloadGeneration)) {
                 await loadThreadsCard()
             }
             .sheet(isPresented: $showPrompts) {
@@ -208,13 +215,13 @@ struct WalkSummaryView: View {
                 }
             }
             .onChange(of: selectedCardTheme) { _, newValue in
-                if newValue == nil { Task { await loadThreadsCard() } }
+                if newValue == nil { threadsReloadGeneration += 1 }
             }
             .sheet(item: $recapSheet) { lunation in
                 LunationRecapView(lunation: lunation)
             }
             .onChange(of: recapSheet) { _, newValue in
-                if newValue == nil { Task { await loadThreadsCard() } }
+                if newValue == nil { threadsReloadGeneration += 1 }
             }
         }
     }

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
@@ -29,6 +29,7 @@ struct WalkSummaryView: View {
     @State private var selectedFavicon: WalkFavicon?
     @State private var showPrompts = false
     @State var threadsCardModel: ThreadsCardModel?
+    @State var selectedCardTheme: ThreadsCardTheme?
     init(walk: WalkInterface, showsThreadsCard: Bool = true) {
         self.walk = walk
         self.showsThreadsCard = showsThreadsCard
@@ -196,6 +197,11 @@ struct WalkSummaryView: View {
             .sheet(isPresented: $showPrompts) {
                 NavigationStack {
                     PromptListView(walk: walk, transcriptions: transcriptions, recentWalkSnippets: recentWalkSnippets, intention: walk.comment, photoCandidates: photoCandidates)
+                }
+            }
+            .sheet(item: $selectedCardTheme) { theme in
+                NavigationStack {
+                    ThreadHistoryView(displayTerm: theme.displayTerm, cohortLemmas: theme.lemmas)
                 }
             }
         }

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
@@ -204,6 +204,9 @@ struct WalkSummaryView: View {
                     ThreadHistoryView(displayTerm: theme.displayTerm, cohortLemmas: theme.lemmas)
                 }
             }
+            .onChange(of: selectedCardTheme) { _, newValue in
+                if newValue == nil { Task { await loadThreadsCard() } }
+            }
         }
     }
 

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
@@ -6,6 +6,14 @@ import CoreLocation
 struct WalkSummaryView: View {
 
     let walk: WalkInterface
+    /// Recursion-cut flag: a summary presented from `ThreadHistoryView` (tap
+    /// through a card chip to a thread's entries and back into that walk's
+    /// summary) passes `false` here. Without it, summary → card chip →
+    /// thread view → entry row → summary recurses unboundedly, and every
+    /// stacked level is a full Mapbox-bearing `WalkSummaryView` with route
+    /// caches — the compounding-memory pattern the resource-safety doctrine
+    /// forbids. Every existing call site compiles unchanged via the default.
+    let showsThreadsCard: Bool
     /// Computed once per walk identity — `TurningDayService` runs Julian-day
     /// astro math, which must not re-run on every body evaluation.
     let walkTurning: SeasonalMarker?
@@ -15,11 +23,15 @@ struct WalkSummaryView: View {
     @Environment(\.dismiss) private var dismiss
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @ObservedObject private var transcriptionService = TranscriptionService.shared
-    @State private var transcriptions: [UUID: String] = [:]
+    // Drops `private` so the `WalkSummaryView+Threads.swift` extension can read it —
+    // same pattern as the camera state below.
+    @State var transcriptions: [UUID: String] = [:]
     @State private var selectedFavicon: WalkFavicon?
     @State private var showPrompts = false
-    init(walk: WalkInterface) {
+    @State var threadsCardModel: ThreadsCardModel?
+    init(walk: WalkInterface, showsThreadsCard: Bool = true) {
         self.walk = walk
+        self.showsThreadsCard = showsThreadsCard
         self.walkTurning = TurningDayService.turning(for: walk.startDate, hemisphere: .current)
         self.cachedSeekSummary = SeekSummaryModel.summaryData(for: walk)
         _selectedFavicon = State(initialValue: walk.favicon.flatMap { WalkFavicon(rawValue: $0) })
@@ -78,6 +90,7 @@ struct WalkSummaryView: View {
                         activePhotoID: $activePhotoID
                     )
                     intentionCard
+                    threadsCardSlot
                     if let seekSummary = cachedSeekSummary {
                         SeekSummarySection(data: seekSummary)
                     }
@@ -176,6 +189,9 @@ struct WalkSummaryView: View {
             // handing this whole view a second invalidation source.
             .onReceive(CollectiveRouteCatalogService.shared.$catalog) { catalog in
                 resolveCollectiveContributionLine(from: catalog)
+            }
+            .task(id: transcriptions.count) {
+                await loadThreadsCard()
             }
             .sheet(isPresented: $showPrompts) {
                 NavigationStack {

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
@@ -30,6 +30,8 @@ struct WalkSummaryView: View {
     @State private var showPrompts = false
     @State var threadsCardModel: ThreadsCardModel?
     @State var selectedCardTheme: ThreadsCardTheme?
+    @State var recapInvitation: Lunation?
+    @State var recapSheet: Lunation?
     init(walk: WalkInterface, showsThreadsCard: Bool = true) {
         self.walk = walk
         self.showsThreadsCard = showsThreadsCard
@@ -175,6 +177,7 @@ struct WalkSummaryView: View {
                     hasRevealedLightReading = sharingTracker.hasShared(walkUUID: uuid)
                 }
                 loadReliquaryCandidates()
+                recapInvitation = LunationRecapState.shared.invitation(forWalkDated: walk.startDate)
             }
             .onDisappear {
                 pollingTask?.cancel()
@@ -205,6 +208,12 @@ struct WalkSummaryView: View {
                 }
             }
             .onChange(of: selectedCardTheme) { _, newValue in
+                if newValue == nil { Task { await loadThreadsCard() } }
+            }
+            .sheet(item: $recapSheet) { lunation in
+                LunationRecapView(lunation: lunation)
+            }
+            .onChange(of: recapSheet) { _, newValue in
                 if newValue == nil { Task { await loadThreadsCard() } }
             }
         }

--- a/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
+++ b/Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift
@@ -194,7 +194,7 @@ struct WalkSummaryView: View {
             .onReceive(CollectiveRouteCatalogService.shared.$catalog) { catalog in
                 resolveCollectiveContributionLine(from: catalog)
             }
-            .task(id: transcriptions.count) {
+            .task(id: transcriptions) {
                 await loadThreadsCard()
             }
             .sheet(isPresented: $showPrompts) {

--- a/UnitTests/AttentionDirectivesTests.swift
+++ b/UnitTests/AttentionDirectivesTests.swift
@@ -10,10 +10,29 @@ final class AttentionDirectivesTests: XCTestCase {
 
     private let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
 
+    private var savedReleased: Any?
+    private var savedWelcomedBack: Any?
+
     override func setUpWithError() throws {
         try super.setUpWithError()
+        savedReleased = UserDefaults.standard.object(forKey: ReleasedThreadsStore.defaultsKey)
+        savedWelcomedBack = UserDefaults.standard.object(forKey: ReleasedThreadsStore.welcomedBackKey)
         UserDefaults.standard.removeObject(forKey: ReleasedThreadsStore.defaultsKey)
         UserDefaults.standard.removeObject(forKey: ReleasedThreadsStore.welcomedBackKey)
+    }
+
+    override func tearDownWithError() throws {
+        if let savedReleased {
+            UserDefaults.standard.set(savedReleased, forKey: ReleasedThreadsStore.defaultsKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: ReleasedThreadsStore.defaultsKey)
+        }
+        if let savedWelcomedBack {
+            UserDefaults.standard.set(savedWelcomedBack, forKey: ReleasedThreadsStore.welcomedBackKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: ReleasedThreadsStore.welcomedBackKey)
+        }
+        try super.tearDownWithError()
     }
 
     private func recording(_ text: String, offset: TimeInterval = 300) -> RecordingContext {

--- a/UnitTests/AttentionDirectivesTests.swift
+++ b/UnitTests/AttentionDirectivesTests.swift
@@ -10,6 +10,12 @@ final class AttentionDirectivesTests: XCTestCase {
 
     private let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
 
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        UserDefaults.standard.removeObject(forKey: ReleasedThreadsStore.defaultsKey)
+        UserDefaults.standard.removeObject(forKey: ReleasedThreadsStore.welcomedBackKey)
+    }
+
     private func recording(_ text: String, offset: TimeInterval = 300) -> RecordingContext {
         RecordingContext(
             text: text,

--- a/UnitTests/DataManagerThreadsDeletionTests.swift
+++ b/UnitTests/DataManagerThreadsDeletionTests.swift
@@ -11,6 +11,10 @@ final class DataManagerThreadsDeletionTests: XCTestCase {
     private var store: TranscriptContextStore!
     private var directory: URL!
     private var previousDataStack: DataStack!
+    private var recapSuiteName: String!
+    private var recapDefaults: UserDefaults!
+    private var recapState: LunationRecapState!
+    private var savedCaptionShown: Bool!
 
     override func setUpWithError() throws {
         try super.setUpWithError()
@@ -23,9 +27,19 @@ final class DataManagerThreadsDeletionTests: XCTestCase {
             .appendingPathComponent("ThreadsDeletionTests-\(UUID().uuidString)")
         store = TranscriptContextStore(directory: directory)
         DataManager.transcriptContextStore = store
+
+        recapSuiteName = "DataManagerThreadsDeletionTests-\(UUID().uuidString)"
+        recapDefaults = UserDefaults(suiteName: recapSuiteName)
+        recapState = LunationRecapState(defaults: recapDefaults)
+        DataManager.lunationRecapState = recapState
+
+        savedCaptionShown = UserPreferences.threadsReleaseCaptionShown.value
     }
 
     override func tearDownWithError() throws {
+        UserPreferences.threadsReleaseCaptionShown.value = savedCaptionShown
+        DataManager.lunationRecapState = .shared
+        recapDefaults.removePersistentDomain(forName: recapSuiteName)
         DataManager.transcriptContextStore = .shared
         DataManager.dataStack = previousDataStack
         try? FileManager.default.removeItem(at: directory)
@@ -133,12 +147,8 @@ final class DataManagerThreadsDeletionTests: XCTestCase {
     }
 
     func testDeleteAll_clearsRecapStateAndCaptionFlag() {
-        let savedCaptionShown = UserPreferences.threadsReleaseCaptionShown.value
-        defer { UserPreferences.threadsReleaseCaptionShown.value = savedCaptionShown }
-
-        LunationRecapState.shared.clear()
-        LunationRecapState.shared.markFirstCardShown()
-        LunationRecapState.shared.markActedOn(LunationCalendar.lunation(at: 300))
+        recapState.markFirstCardShown()
+        recapState.markActedOn(LunationCalendar.lunation(at: 300))
         UserPreferences.threadsReleaseCaptionShown.value = true
 
         let deleted = expectation(description: "deleted all")
@@ -147,9 +157,9 @@ final class DataManagerThreadsDeletionTests: XCTestCase {
             deleted.fulfill()
         }
         wait(for: [deleted], timeout: 5)
-        XCTAssertNil(LunationRecapState.shared.firstCardShownAt,
+        XCTAssertNil(recapState.firstCardShownAt,
                      "the first-card gate re-arms — a wipe is a fresh start, like a reinstall")
-        XCTAssertNil(LunationRecapState.shared.lastActedLunationIndex)
+        XCTAssertNil(recapState.lastActedLunationIndex)
         XCTAssertFalse(UserPreferences.threadsReleaseCaptionShown.value)
     }
 }

--- a/UnitTests/DataManagerThreadsDeletionTests.swift
+++ b/UnitTests/DataManagerThreadsDeletionTests.swift
@@ -113,4 +113,22 @@ final class DataManagerThreadsDeletionTests: XCTestCase {
         XCTAssertTrue(store.loadAll().isEmpty,
                       "an analysis queued before Delete All must not write after the wipe")
     }
+
+    func testDeleteAll_clearsReleasedThreads() {
+        let suiteName = "ReleasedThreadsDeleteAll-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let released = ReleasedThreadsStore(defaults: defaults)
+        released.release(displayTerm: "the move", lemmas: ["move"])
+        DataManager.releasedThreadsStore = released
+        defer { DataManager.releasedThreadsStore = .shared }
+
+        let deleted = expectation(description: "deleted all")
+        DataManager.deleteAll { success, _ in
+            XCTAssertTrue(success)
+            deleted.fulfill()
+        }
+        wait(for: [deleted], timeout: 5)
+        XCTAssertTrue(released.isEmpty, "Delete All Data clears the released set with everything else")
+    }
 }

--- a/UnitTests/DataManagerThreadsDeletionTests.swift
+++ b/UnitTests/DataManagerThreadsDeletionTests.swift
@@ -131,4 +131,25 @@ final class DataManagerThreadsDeletionTests: XCTestCase {
         wait(for: [deleted], timeout: 5)
         XCTAssertTrue(released.isEmpty, "Delete All Data clears the released set with everything else")
     }
+
+    func testDeleteAll_clearsRecapStateAndCaptionFlag() {
+        let savedCaptionShown = UserPreferences.threadsReleaseCaptionShown.value
+        defer { UserPreferences.threadsReleaseCaptionShown.value = savedCaptionShown }
+
+        LunationRecapState.shared.clear()
+        LunationRecapState.shared.markFirstCardShown()
+        LunationRecapState.shared.markActedOn(LunationCalendar.lunation(at: 300))
+        UserPreferences.threadsReleaseCaptionShown.value = true
+
+        let deleted = expectation(description: "deleted all")
+        DataManager.deleteAll { success, _ in
+            XCTAssertTrue(success)
+            deleted.fulfill()
+        }
+        wait(for: [deleted], timeout: 5)
+        XCTAssertNil(LunationRecapState.shared.firstCardShownAt,
+                     "the first-card gate re-arms — a wipe is a fresh start, like a reinstall")
+        XCTAssertNil(LunationRecapState.shared.lastActedLunationIndex)
+        XCTAssertFalse(UserPreferences.threadsReleaseCaptionShown.value)
+    }
 }

--- a/UnitTests/LunationCalendarTests.swift
+++ b/UnitTests/LunationCalendarTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import Pilgrim
+
+final class LunationCalendarTests: XCTestCase {
+
+    func testLunation_boundariesAreContiguous() {
+        let lunation = LunationCalendar.lunation(at: 300)
+        XCTAssertEqual(LunationCalendar.lunation(containing: lunation.start).index, 300)
+        XCTAssertEqual(LunationCalendar.lunation(containing: lunation.end.addingTimeInterval(-1)).index, 300)
+        XCTAssertEqual(LunationCalendar.lunation(containing: lunation.end).index, 301,
+                       "the close instant belongs to the next lunation")
+        XCTAssertEqual(lunation.end, LunationCalendar.lunation(at: 301).start)
+    }
+
+    func testMostRecentClosed_isThePreviousLunation() {
+        let lunation = LunationCalendar.lunation(at: 300)
+        let closed = LunationCalendar.mostRecentClosed(asOf: lunation.start.addingTimeInterval(86400))
+        XCTAssertEqual(closed.index, 299)
+    }
+
+    func testFullMoon_isTheMidpoint() {
+        let lunation = LunationCalendar.lunation(at: 300)
+        XCTAssertEqual(
+            lunation.fullMoon.timeIntervalSince(lunation.start),
+            lunation.end.timeIntervalSince(lunation.fullMoon),
+            accuracy: 1
+        )
+    }
+
+    func testMoonName_derivesFromFullMoonMonthInTimezone() {
+        let nearMonthEdge = Lunation(
+            index: 0,
+            start: DateFactory.makeDate(2024, 8, 17, 11, 0, 0),
+            end: DateFactory.makeDate(2024, 9, 15, 23, 0, 0),
+            fullMoon: DateFactory.makeDate(2024, 8, 31, 23, 0, 0)
+        )
+        XCTAssertEqual(
+            LunationCalendar.moonName(for: nearMonthEdge, in: TimeZone(identifier: "UTC")!),
+            "Sturgeon Moon"
+        )
+        XCTAssertEqual(
+            LunationCalendar.moonName(for: nearMonthEdge, in: TimeZone(identifier: "Pacific/Auckland")!),
+            "Corn Moon",
+            "the same instant is already September in Auckland — the name follows the device's timezone"
+        )
+    }
+
+    func testMoonName_allTwelveMonthsCovered() {
+        for month in 1...12 {
+            let lunation = Lunation(
+                index: 0,
+                start: DateFactory.makeDate(2024, month, 1),
+                end: DateFactory.makeDate(2024, month, 29),
+                fullMoon: DateFactory.makeDate(2024, month, 15, 12, 0, 0)
+            )
+            let name = LunationCalendar.moonName(for: lunation, in: TimeZone(identifier: "UTC")!)
+            XCTAssertTrue(name.hasSuffix("Moon"))
+        }
+    }
+}

--- a/UnitTests/LunationCalendarTests.swift
+++ b/UnitTests/LunationCalendarTests.swift
@@ -54,7 +54,7 @@ final class LunationCalendarTests: XCTestCase {
                 fullMoon: DateFactory.makeDate(2024, month, 15, 12, 0, 0)
             )
             let name = LunationCalendar.moonName(for: lunation, in: TimeZone(identifier: "UTC")!)
-            XCTAssertTrue(name.hasSuffix("Moon"))
+            XCTAssertEqual(name, LunationCalendar.monthMoonNames[month - 1])
         }
     }
 }

--- a/UnitTests/LunationRecapModelTests.swift
+++ b/UnitTests/LunationRecapModelTests.swift
@@ -1,0 +1,213 @@
+import XCTest
+@testable import Pilgrim
+
+final class LunationRecapModelTests: XCTestCase {
+
+    private let lunation = LunationCalendar.lunation(at: 300)
+
+    private func context(_ uuid: UUID, lemma: String?, displayTerm: String? = nil, insight: Int = 0) -> TranscriptContext {
+        TranscriptContext(
+            schemaVersion: 1, recordingUUID: uuid, transcriptHash: "h",
+            languageCode: "en", wordCount: 200,
+            themes: lemma.map { [Theme(
+                lemma: $0, displayTerm: displayTerm ?? $0, mentionCount: 3, salience: 0.015,
+                mentions: [ThemeMention(start: 0, length: 4)]
+            )] } ?? [],
+            markers: MarkerPack(
+                wordCount: 200, absolutistCount: 0, firstPersonCount: 0,
+                insightCount: insight, causationCount: 0, discrepancyCount: 0,
+                futureCount: 0, pastCount: 0, sentiment: nil
+            )
+        )
+    }
+
+    private func build(
+        contexts: [TranscriptContext],
+        walkIndex: [UUID: (walkUUID: UUID, date: Date)],
+        paces: [UUID: Double] = [:],
+        released: Set<String> = [],
+        backfillComplete: Bool = true
+    ) -> LunationRecapModel {
+        LunationRecapModelBuilder.model(
+            lunation: lunation, moonName: "Sturgeon Moon",
+            contexts: contexts, walkIndex: walkIndex,
+            paceByRecording: paces, released: released,
+            backfillComplete: backfillComplete
+        )
+    }
+
+    /// Three analyzed walks inside the moon; "move" spoken in two of them.
+    private func fixture() -> (contexts: [TranscriptContext], walkIndex: [UUID: (walkUUID: UUID, date: Date)]) {
+        let recs = [UUID(), UUID(), UUID()]
+        let walks = [UUID(), UUID(), UUID()]
+        let contexts = [
+            context(recs[0], lemma: "move"),
+            context(recs[1], lemma: "move"),
+            context(recs[2], lemma: nil)
+        ]
+        var walkIndex: [UUID: (walkUUID: UUID, date: Date)] = [:]
+        for (offset, rec) in recs.enumerated() {
+            walkIndex[rec] = (walks[offset], lunation.start.addingTimeInterval(Double(offset + 1) * 86400))
+        }
+        return (contexts, walkIndex)
+    }
+
+    func testModel_countsWalksAndThemes() {
+        let (contexts, walkIndex) = fixture()
+        let model = build(contexts: contexts, walkIndex: walkIndex)
+        XCTAssertEqual(model.walkCount, 3)
+        XCTAssertEqual(model.themes.map(\.displayTerm), ["move"])
+        XCTAssertEqual(model.themes.first?.walkCount, 2)
+        XCTAssertNil(model.quietLine)
+    }
+
+    func testThemeLine_countCopyPinned() {
+        XCTAssertEqual(
+            LunationRecapCopy.themeLine(term: "the move", walkCount: 6, totalWalks: 9),
+            "'the move' — walked with you in 6 of 9 walks"
+        )
+        XCTAssertEqual(
+            LunationRecapCopy.themeLine(term: "father", walkCount: 1, totalWalks: 1),
+            "'father' — walked with you in 1 of 1 walks",
+            "a single-walk moon still uses count copy — spec sparse state"
+        )
+    }
+
+    func testScopeDivergence_recapAndCardPhrasingsAreStructurallyDistinct() {
+        let recap = LunationRecapCopy.themeLine(term: "move", walkCount: 3, totalWalks: 4)
+        let card = ThreadsCardCopy.statusNote(for: .recurring(walksInWindow: 3))!
+        XCTAssertTrue(recap.contains("walked with you in"))
+        XCTAssertFalse(card.contains("walked with you in"))
+        XCTAssertTrue(card.hasSuffix("walk now"),
+                      "lunation counts vs trailing-window ordinals must never read as the same metric disagreeing")
+    }
+
+    func testNewThisMoon_gatedOnBackfill() {
+        let (contexts, walkIndex) = fixture()
+        XCTAssertEqual(build(contexts: contexts, walkIndex: walkIndex).themes.first?.isNewThisMoon, true)
+        XCTAssertEqual(
+            build(contexts: contexts, walkIndex: walkIndex, backfillComplete: false).themes.first?.isNewThisMoon,
+            false,
+            "firsts are full-history origin claims — suppressed until backfill completes"
+        )
+    }
+
+    func testNewThisMoon_falseWhenThreadPredatesTheMoon() {
+        var (contexts, walkIndex) = fixture()
+        let earlierRec = UUID()
+        contexts.append(context(earlierRec, lemma: "move"))
+        walkIndex[earlierRec] = (UUID(), lunation.start.addingTimeInterval(-10 * 86400))
+        XCTAssertEqual(build(contexts: contexts, walkIndex: walkIndex).themes.first?.isNewThisMoon, false)
+    }
+
+    func testNewThisMoon_falseWhenSiblingLemmaPredatesTheMoon() {
+        var (contexts, walkIndex) = fixture()
+        let earlierRec = UUID()
+        contexts.append(context(earlierRec, lemma: "moving", displayTerm: "move"))
+        walkIndex[earlierRec] = (UUID(), lunation.start.addingTimeInterval(-10 * 86400))
+        XCTAssertEqual(build(contexts: contexts, walkIndex: walkIndex).themes.first?.isNewThisMoon, false,
+                       "a sibling lemma of the same display term predating the moon makes the theme returning, not new — cohorts group over ALL threads")
+    }
+
+    func testReleasedFiltering_leavesTheQuietLine() {
+        let (contexts, walkIndex) = fixture()
+        let model = build(contexts: contexts, walkIndex: walkIndex, released: ["move"])
+        XCTAssertTrue(model.themes.isEmpty)
+        XCTAssertEqual(model.walkCount, 3, "the moon's walk count stands even when nothing is named")
+        XCTAssertEqual(model.quietLine, "nothing held on to name this time")
+    }
+
+    func testRecapPathRelease_rebuildDropsThemeAndLeavesQuietLine() {
+        let (contexts, walkIndex) = fixture()
+        XCTAssertEqual(build(contexts: contexts, walkIndex: walkIndex).themes.map(\.displayTerm), ["move"],
+                       "fixture sanity — the theme is present before the release")
+        let after = build(contexts: contexts, walkIndex: walkIndex, released: ["move"])
+        XCTAssertTrue(after.themes.isEmpty)
+        XCTAssertEqual(after.quietLine, "nothing held on to name this time",
+                       "the released-token re-key rebuilds the recap the moment the thread view pops — a released theme drops out instead of dead-ending")
+    }
+
+    func testZeroAnalyzedWalks_hasItsOwnQuietLine() {
+        let model = build(contexts: [], walkIndex: [:])
+        XCTAssertEqual(model.walkCount, 0)
+        XCTAssertEqual(model.quietLine, "no recorded words walked this moon")
+    }
+
+    func testWalksOutsideTheLunation_doNotCount() {
+        let rec = UUID()
+        let walkIndex = [rec: (walkUUID: UUID(), date: lunation.end.addingTimeInterval(3600))]
+        let model = build(contexts: [context(rec, lemma: "move")], walkIndex: walkIndex)
+        XCTAssertEqual(model.walkCount, 0, "the window is [start, end) — the close belongs to the next moon")
+    }
+
+    func testWalkCount_ignoresWalksWithoutAnalyzedWords() {
+        var (contexts, walkIndex) = fixture()
+        walkIndex[UUID()] = (UUID(), lunation.start.addingTimeInterval(5 * 86400))
+        let model = build(contexts: contexts, walkIndex: walkIndex)
+        XCTAssertEqual(model.walkCount, 3,
+                       "an untranscribed recording's walk doesn't count — the headline copy scopes the claim to walks with recorded words for exactly this reason")
+    }
+
+    func testHeadline_scopedToWalksWithRecordedWords() {
+        XCTAssertEqual(LunationRecapCopy.headline(walkCount: 3), "3 walks with recorded words this moon")
+        XCTAssertEqual(LunationRecapCopy.headline(walkCount: 1), "1 walk with recorded words this moon",
+                       "the qualifier keeps the count honest against a journal showing more walks this moon")
+    }
+
+    func testTexture_paceAndInsightFromTheMoonsRecordings() {
+        let (contexts, walkIndex) = fixture()
+        let insightful = contexts.map { original in
+            TranscriptContext(
+                schemaVersion: 1, recordingUUID: original.recordingUUID, transcriptHash: "h",
+                languageCode: "en", wordCount: 200, themes: original.themes,
+                markers: MarkerPack(
+                    wordCount: 200, absolutistCount: 0, firstPersonCount: 0,
+                    insightCount: 2, causationCount: 0, discrepancyCount: 0,
+                    futureCount: 0, pastCount: 0, sentiment: nil
+                )
+            )
+        }
+        let paces = Dictionary(uniqueKeysWithValues: walkIndex.keys.map { ($0, 80.0) })
+        let model = build(contexts: insightful, walkIndex: walkIndex, paces: paces)
+        XCTAssertEqual(model.textureLine, "Spoken slowly, with words of insight.")
+    }
+
+    func testInvitationCopy_pinned() {
+        XCTAssertEqual(
+            LunationRecapCopy.invitation(moonName: "Sturgeon Moon"),
+            "The Sturgeon Moon has set — see what walked with you."
+        )
+    }
+
+    func testClosedLunations_boundedByFirstCard() {
+        let suiteName = "PastRecapsTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let state = LunationRecapState(defaults: defaults)
+        let now = LunationCalendar.lunation(at: 303).start.addingTimeInterval(86400)
+
+        XCTAssertTrue(PastRecapsListView.closedLunations(now: now, state: state).isEmpty,
+                      "no first card, no reachable moons")
+
+        state.markFirstCardShown(now: LunationCalendar.lunation(at: 300).start.addingTimeInterval(86400))
+        XCTAssertEqual(
+            PastRecapsListView.closedLunations(now: now, state: state).map(\.index),
+            [302, 301, 300],
+            "every moon closed since first contact, newest first — a missed line never costs the month"
+        )
+    }
+
+    func testClosedLunations_boundaryEndEqualsFirstShown_excluded() {
+        let suiteName = "PastRecapsBoundary-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let state = LunationRecapState(defaults: defaults)
+        state.markFirstCardShown(now: LunationCalendar.lunation(at: 300).end)
+        let now = LunationCalendar.lunation(at: 302).start.addingTimeInterval(86400)
+        XCTAssertEqual(
+            PastRecapsListView.closedLunations(now: now, state: state).map(\.index),
+            [301],
+            "a moon closing at the exact first-shown instant belongs to backfilled history — the strict `>` is deliberate and pinned"
+        )
+    }
+}

--- a/UnitTests/LunationRecapStateTests.swift
+++ b/UnitTests/LunationRecapStateTests.swift
@@ -1,0 +1,107 @@
+import XCTest
+@testable import Pilgrim
+
+final class LunationRecapStateTests: XCTestCase {
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var state: LunationRecapState!
+    private var savedToggle = true
+
+    /// A fixed lunation grid: `closed` = lunation 300, `now` one day after
+    /// it closed, `walkAfter` a walk dated after the boundary.
+    private let closed = LunationCalendar.lunation(at: 300)
+    private var now: Date { closed.end.addingTimeInterval(86400) }
+    private var walkAfter: Date { closed.end.addingTimeInterval(3600) }
+
+    override func setUpWithError() throws {
+        suiteName = "LunationRecapStateTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        state = LunationRecapState(defaults: defaults)
+        savedToggle = UserPreferences.threadsAfterWalks.value
+        UserPreferences.threadsAfterWalks.value = true
+    }
+
+    override func tearDownWithError() throws {
+        UserPreferences.threadsAfterWalks.value = savedToggle
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    private func showFirstCard(before boundary: Date) {
+        state.markFirstCardShown(now: boundary.addingTimeInterval(-10 * 86400))
+    }
+
+    func testInvitation_requiresFirstCardShown() {
+        XCTAssertNil(state.invitation(forWalkDated: walkAfter, now: now),
+                     "the recap must never be a walker's first contact with the feature")
+        showFirstCard(before: closed.end)
+        XCTAssertNotNil(state.invitation(forWalkDated: walkAfter, now: now))
+    }
+
+    func testInvitation_boundaryInsideBackfilledHistoryNeverInvites() {
+        state.markFirstCardShown(now: closed.end.addingTimeInterval(3600))
+        XCTAssertNil(state.invitation(forWalkDated: walkAfter, now: now),
+                     "a lunation that closed before the first card belongs to backfilled history")
+    }
+
+    func testInvitation_walkDatedBeforeBoundary_neverInvites() {
+        showFirstCard(before: closed.end)
+        XCTAssertNil(state.invitation(
+            forWalkDated: closed.end.addingTimeInterval(-3600), now: now
+        ), "old summaries read the same whenever opened")
+    }
+
+    func testInvitation_reEvaluatesUntilActedOn() {
+        showFirstCard(before: closed.end)
+        XCTAssertNotNil(state.invitation(forWalkDated: walkAfter, now: now))
+        XCTAssertNotNil(state.invitation(forWalkDated: walkAfter, now: now),
+                        "the flag records acted-on, not first opportunity — pending transcriptions don't cost the month")
+        state.markActedOn(closed)
+        XCTAssertNil(state.invitation(forWalkDated: walkAfter, now: now))
+    }
+
+    func testInvitation_nextLunationSupersedes() {
+        showFirstCard(before: closed.end)
+        state.markActedOn(closed)
+        let next = LunationCalendar.lunation(at: 301)
+        let laterNow = next.end.addingTimeInterval(86400)
+        let laterWalk = next.end.addingTimeInterval(3600)
+        XCTAssertEqual(state.invitation(forWalkDated: laterWalk, now: laterNow)?.index, 301,
+                       "acting on one moon never silences the next")
+    }
+
+    func testInvitation_onlyTheMostRecentClosedLunationInvites() {
+        showFirstCard(before: closed.end)
+        let next = LunationCalendar.lunation(at: 301)
+        let laterNow = next.end.addingTimeInterval(86400)
+        XCTAssertEqual(state.invitation(forWalkDated: walkAfter, now: laterNow), nil,
+                       "once the next lunation closes, a walk dated inside the previous one no longer invites — Past recaps keeps it reachable")
+    }
+
+    func testMarkFirstCardShown_setOnce() {
+        let first = DateFactory.makeDate(2026, 8, 1, 9, 0, 0)
+        state.markFirstCardShown(now: first)
+        state.markFirstCardShown(now: first.addingTimeInterval(86400))
+        XCTAssertEqual(state.firstCardShownAt, first)
+    }
+
+    func testInvitation_toggleOffMeansOff() {
+        showFirstCard(before: closed.end)
+        UserPreferences.threadsAfterWalks.value = false
+        XCTAssertNil(state.invitation(forWalkDated: walkAfter, now: now))
+    }
+
+    func testInvitation_futureActedIndexIsIgnored() {
+        showFirstCard(before: closed.end)
+        state.markActedOn(LunationCalendar.lunation(at: 305))
+        XCTAssertEqual(state.invitation(forWalkDated: walkAfter, now: now)?.index, 300,
+                       "an acted index from a forward-set clock is ignored — it cannot silence months of real invitations")
+    }
+
+    func testMarkActedOn_isMonotonic() {
+        state.markActedOn(closed)
+        state.markActedOn(LunationCalendar.lunation(at: 298))
+        XCTAssertEqual(state.lastActedLunationIndex, 300,
+                       "opening an older moon from Past recaps never regresses the acted index")
+    }
+}

--- a/UnitTests/PilgrimPackageExporterArchivedTests.swift
+++ b/UnitTests/PilgrimPackageExporterArchivedTests.swift
@@ -19,15 +19,30 @@ final class PilgrimPackageExporterArchivedTests: XCTestCase {
     private let endEpoch: Double   = 1_700_001_800
     private let archivedAtEpoch: Double = 1_700_500_000
 
+    private var savedReleased: Any?
+    private var savedWelcomedBack: Any?
+
     override func setUp() {
         super.setUp()
         UserPreferences.archivedWalkRegistry.value = [:]
+        savedReleased = UserDefaults.standard.object(forKey: ReleasedThreadsStore.defaultsKey)
+        savedWelcomedBack = UserDefaults.standard.object(forKey: ReleasedThreadsStore.welcomedBackKey)
         UserDefaults.standard.removeObject(forKey: ReleasedThreadsStore.defaultsKey)
         UserDefaults.standard.removeObject(forKey: ReleasedThreadsStore.welcomedBackKey)
     }
 
     override func tearDown() {
         UserPreferences.archivedWalkRegistry.value = [:]
+        if let savedReleased {
+            UserDefaults.standard.set(savedReleased, forKey: ReleasedThreadsStore.defaultsKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: ReleasedThreadsStore.defaultsKey)
+        }
+        if let savedWelcomedBack {
+            UserDefaults.standard.set(savedWelcomedBack, forKey: ReleasedThreadsStore.welcomedBackKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: ReleasedThreadsStore.welcomedBackKey)
+        }
         super.tearDown()
     }
 

--- a/UnitTests/PilgrimPackageExporterArchivedTests.swift
+++ b/UnitTests/PilgrimPackageExporterArchivedTests.swift
@@ -22,6 +22,8 @@ final class PilgrimPackageExporterArchivedTests: XCTestCase {
     override func setUp() {
         super.setUp()
         UserPreferences.archivedWalkRegistry.value = [:]
+        UserDefaults.standard.removeObject(forKey: ReleasedThreadsStore.defaultsKey)
+        UserDefaults.standard.removeObject(forKey: ReleasedThreadsStore.welcomedBackKey)
     }
 
     override func tearDown() {

--- a/UnitTests/ReleasedThreadsInteractionTests.swift
+++ b/UnitTests/ReleasedThreadsInteractionTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import Pilgrim
+
+final class ReleasedThreadsInteractionTests: XCTestCase {
+
+    func testReleaseConfirmCopy_exactStrings() {
+        XCTAssertEqual(ReleasedThreadsCopy.releaseTitle("my father"), "Let 'my father' go?")
+        XCTAssertEqual(ReleasedThreadsCopy.releaseMessage, "You can welcome it back anytime.")
+        XCTAssertEqual(ReleasedThreadsCopy.releaseConfirm, "Let it go")
+        XCTAssertEqual(ReleasedThreadsCopy.releaseCancel, "Not now")
+    }
+
+    func testWelcomeBackConfirmCopy_exactStrings() {
+        XCTAssertEqual(ReleasedThreadsCopy.welcomeBackTitle("my father"), "Welcome 'my father' back?")
+        XCTAssertEqual(ReleasedThreadsCopy.welcomeBackMessage, "Threads will notice it again.")
+        XCTAssertEqual(ReleasedThreadsCopy.welcomeBackConfirm, "Welcome it back")
+        XCTAssertEqual(ReleasedThreadsCopy.welcomeBackCancel, "Not now")
+    }
+
+    func testCaptionCopy_exactString() {
+        XCTAssertEqual(ReleasedThreadsCopy.caption, "long-press a theme to let it go")
+    }
+
+    func testVoiceOverActionName_exactString() {
+        XCTAssertEqual(ReleasedThreadsCopy.voiceOverActionName, "Let this go")
+    }
+
+    private func model(terms: [String]) -> ThreadsCardModel {
+        ThreadsCardModel(
+            themes: terms.map { ThreadsCardTheme(displayTerm: $0, lemmas: [$0], statusNote: nil) },
+            textureLine: nil,
+            insightWords: [],
+            hasInsight: false
+        )
+    }
+
+    func testRemoving_dropsOnlyTheReleasedCohort() {
+        let after = ThreadsCardModelBuilder.removing(displayTerm: "the move", from: model(terms: ["the move", "father"]))
+        XCTAssertEqual(after?.themes.map(\.displayTerm), ["father"])
+    }
+
+    func testRemoving_lastThemeCollapsesTheCard() {
+        XCTAssertNil(ThreadsCardModelBuilder.removing(displayTerm: "father", from: model(terms: ["father"])),
+                     "an emptied card fades out and the summary reflows to its no-card state")
+    }
+}

--- a/UnitTests/ReleasedThreadsPackageTests.swift
+++ b/UnitTests/ReleasedThreadsPackageTests.swift
@@ -87,4 +87,58 @@ final class ReleasedThreadsPackageTests: XCTestCase {
         )
         XCTAssertEqual(PilgrimPackageConverter.welcomedBackThreads(from: preferences(releasedThreads: nil)), [])
     }
+
+    func testImportMapping_futureDatedDecisions_clampToNow() {
+        let now = released
+        let future = released.addingTimeInterval(365 * 86400)
+
+        let mappedReleased = PilgrimPackageConverter.releasedThreads(
+            from: preferences(releasedThreads: [
+                PilgrimReleasedThread(term: "father", lemmas: ["father"], releasedAt: future)
+            ]),
+            now: now
+        )
+        XCTAssertEqual(mappedReleased, [
+            ReleasedThread(displayTerm: "father", lemmas: ["father"], releasedAt: now)
+        ], "a clock-skewed exporting device must not win every future merge — clamp to import time")
+
+        let mappedWelcomedBack = PilgrimPackageConverter.welcomedBackThreads(
+            from: preferences(
+                releasedThreads: nil,
+                welcomedBack: [PilgrimWelcomedBackThread(term: "father", welcomedBackAt: future)]
+            ),
+            now: now
+        )
+        XCTAssertEqual(mappedWelcomedBack, [
+            WelcomedBackThread(displayTerm: "father", welcomedBackAt: now)
+        ])
+    }
+
+    func testImportMapping_futureDatedRelease_laterLocalDecisionStillWins() throws {
+        let suiteName = "ReleasedThreadsPackageTests-\(UUID().uuidString)"
+        let defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let store = ReleasedThreadsStore(defaults: defaults)
+
+        let now = released
+        let future = released.addingTimeInterval(365 * 86400)
+        let clampedImport = PilgrimPackageConverter.releasedThreads(
+            from: preferences(releasedThreads: [
+                PilgrimReleasedThread(term: "father", lemmas: ["father"], releasedAt: future)
+            ]),
+            now: now
+        )
+        store.merge(released: clampedImport, welcomedBack: [])
+
+        // A genuine later decision must still be able to win. Had the skewed
+        // future date been allowed to stand uncapped, this entirely ordinary
+        // later release would have lost to a date a year away, forever.
+        let later = now.addingTimeInterval(60)
+        store.merge(released: [
+            ReleasedThread(displayTerm: "father", lemmas: ["father"], releasedAt: later)
+        ], welcomedBack: [])
+
+        XCTAssertEqual(store.all.first?.releasedAt, later,
+                       "a later, unskewed decision must be able to win — the clamp keeps the earlier import from parking a permanent future date")
+    }
 }

--- a/UnitTests/ReleasedThreadsPackageTests.swift
+++ b/UnitTests/ReleasedThreadsPackageTests.swift
@@ -1,0 +1,90 @@
+import XCTest
+@testable import Pilgrim
+
+final class ReleasedThreadsPackageTests: XCTestCase {
+
+    private let released = DateFactory.makeDate(2026, 8, 20, 9, 0, 0)
+
+    private func preferences(
+        releasedThreads: [PilgrimReleasedThread]?,
+        welcomedBack: [PilgrimWelcomedBackThread]? = nil
+    ) -> PilgrimPreferences {
+        PilgrimPreferences(
+            distanceUnit: "km", altitudeUnit: "m", speedUnit: "km/h", energyUnit: "kJ",
+            celestialAwareness: false, zodiacSystem: "tropical", beginWithIntention: false,
+            releasedThreads: releasedThreads,
+            welcomedBackThreads: welcomedBack
+        )
+    }
+
+    func testPreferences_roundTripWithReleasedThreads() throws {
+        let original = preferences(
+            releasedThreads: [
+                PilgrimReleasedThread(term: "the move", lemmas: ["move", "moving"], releasedAt: released)
+            ],
+            welcomedBack: [
+                PilgrimWelcomedBackThread(term: "father", welcomedBackAt: released)
+            ]
+        )
+        let data = try PilgrimDateCoding.makeEncoder().encode(original)
+        let decoded = try PilgrimDateCoding.makeDecoder().decode(PilgrimPreferences.self, from: data)
+        XCTAssertEqual(decoded.releasedThreads?.count, 1)
+        XCTAssertEqual(decoded.releasedThreads?[0].term, "the move")
+        XCTAssertEqual(decoded.releasedThreads?[0].lemmas, ["move", "moving"])
+        XCTAssertEqual(decoded.releasedThreads?[0].releasedAt, released)
+        XCTAssertEqual(decoded.welcomedBackThreads?.map(\.term), ["father"])
+        XCTAssertEqual(decoded.welcomedBackThreads?.first?.welcomedBackAt, released)
+    }
+
+    func testPreferences_oldJSONWithoutKey_decodesNil() throws {
+        let old = """
+        {"distanceUnit":"km","altitudeUnit":"m","speedUnit":"km/h","energyUnit":"kJ",
+        "celestialAwareness":false,"zodiacSystem":"tropical","beginWithIntention":false}
+        """
+        let decoded = try PilgrimDateCoding.makeDecoder()
+            .decode(PilgrimPreferences.self, from: Data(old.utf8))
+        XCTAssertNil(decoded.releasedThreads)
+        XCTAssertNil(decoded.welcomedBackThreads)
+    }
+
+    func testBuildManifest_mapsReleasedThreads() {
+        let manifest = PilgrimPackageConverter.buildManifest(
+            walkCount: 0, events: [],
+            releasedThreads: [ReleasedThread(displayTerm: "the move", lemmas: ["move"], releasedAt: released)],
+            welcomedBackThreads: [WelcomedBackThread(displayTerm: "father", welcomedBackAt: released)]
+        )
+        XCTAssertEqual(manifest.preferences.releasedThreads?.map(\.term), ["the move"])
+        XCTAssertEqual(manifest.preferences.releasedThreads?.first?.releasedAt, released)
+        XCTAssertEqual(manifest.preferences.welcomedBackThreads?.map(\.term), ["father"])
+    }
+
+    func testBuildManifest_emptyReleasedSet_omitsKey() throws {
+        let manifest = PilgrimPackageConverter.buildManifest(
+            walkCount: 0, events: [], releasedThreads: [], welcomedBackThreads: []
+        )
+        XCTAssertNil(manifest.preferences.releasedThreads)
+        XCTAssertNil(manifest.preferences.welcomedBackThreads)
+        let json = String(decoding: try PilgrimDateCoding.makeEncoder().encode(manifest), as: UTF8.self)
+        XCTAssertFalse(json.contains("releasedThreads"),
+                       "a walker who released nothing exports a byte-identical preferences block")
+        XCTAssertFalse(json.contains("welcomedBackThreads"))
+    }
+
+    func testImportMapping_fromPreferences() {
+        let mapped = PilgrimPackageConverter.releasedThreads(from: preferences(releasedThreads: [
+            PilgrimReleasedThread(term: "father", lemmas: ["father"], releasedAt: released)
+        ]))
+        XCTAssertEqual(mapped, [
+            ReleasedThread(displayTerm: "father", lemmas: ["father"], releasedAt: released)
+        ])
+        XCTAssertEqual(PilgrimPackageConverter.releasedThreads(from: preferences(releasedThreads: nil)), [])
+        XCTAssertEqual(
+            PilgrimPackageConverter.welcomedBackThreads(from: preferences(
+                releasedThreads: nil,
+                welcomedBack: [PilgrimWelcomedBackThread(term: "father", welcomedBackAt: released)]
+            )),
+            [WelcomedBackThread(displayTerm: "father", welcomedBackAt: released)]
+        )
+        XCTAssertEqual(PilgrimPackageConverter.welcomedBackThreads(from: preferences(releasedThreads: nil)), [])
+    }
+}

--- a/UnitTests/ReleasedThreadsStoreTests.swift
+++ b/UnitTests/ReleasedThreadsStoreTests.swift
@@ -64,17 +64,37 @@ final class ReleasedThreadsStoreTests: XCTestCase {
         XCTAssertEqual(store.all.map(\.displayTerm), ["c", "a", "b"])
     }
 
-    func testMerge_unionsByTermKeepingEarliestDate() {
+    func testMerge_unionsByTermKeepingLatestDate() {
         store.release(displayTerm: "the move", lemmas: ["move"], releasedAt: released)
         store.merge(released: [
             ReleasedThread(displayTerm: "the move", lemmas: ["moving"],
-                           releasedAt: released.addingTimeInterval(-86400)),
+                           releasedAt: released.addingTimeInterval(86400)),
             ReleasedThread(displayTerm: "father", lemmas: ["father"], releasedAt: released)
         ], welcomedBack: [])
         XCTAssertEqual(Set(store.all.map(\.displayTerm)), ["the move", "father"])
         let move = store.all.first { $0.displayTerm == "the move" }
         XCTAssertEqual(move?.lemmas, ["move", "moving"])
-        XCTAssertEqual(move?.releasedAt, released.addingTimeInterval(-86400))
+        XCTAssertEqual(move?.releasedAt, released.addingTimeInterval(86400),
+                       "latest-decision-wins: the union keeps the more recent release date")
+    }
+
+    func testMerge_multiBackupSequence_staleBackupNeverResurrectsAnOlderReleaseDate() {
+        let jan = DateFactory.makeDate(2026, 1, 15, 9, 0, 0)
+        let feb = DateFactory.makeDate(2026, 2, 15, 9, 0, 0)
+        let mar = DateFactory.makeDate(2026, 3, 15, 9, 0, 0)
+
+        store.release(displayTerm: "the move", lemmas: ["move"], releasedAt: jan)
+        store.welcomeBack(displayTerm: "the move", at: feb)
+        store.release(displayTerm: "the move", lemmas: ["move"], releasedAt: mar)
+
+        // A backup taken back in January, imported after all of the above.
+        store.merge(released: [
+            ReleasedThread(displayTerm: "the move", lemmas: ["move"], releasedAt: jan)
+        ], welcomedBack: [])
+
+        XCTAssertEqual(store.all.map(\.displayTerm), ["the move"])
+        XCTAssertEqual(store.all.first?.releasedAt, mar,
+                       "March's re-release is the latest decision — importing the January backup must not resurrect it")
     }
 
     func testMerge_staleImportedRelease_doesNotUndoWelcomeBack() {

--- a/UnitTests/ReleasedThreadsStoreTests.swift
+++ b/UnitTests/ReleasedThreadsStoreTests.swift
@@ -1,0 +1,110 @@
+import XCTest
+@testable import Pilgrim
+
+final class ReleasedThreadsStoreTests: XCTestCase {
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var store: ReleasedThreadsStore!
+    private let released = DateFactory.makeDate(2026, 8, 20, 9, 0, 0)
+
+    override func setUpWithError() throws {
+        suiteName = "ReleasedThreadsTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        store = ReleasedThreadsStore(defaults: defaults)
+    }
+
+    override func tearDownWithError() throws {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    func testRelease_persistsAcrossInstances() {
+        store.release(displayTerm: "the move", lemmas: ["move", "moving"], releasedAt: released)
+        let reopened = ReleasedThreadsStore(defaults: defaults)
+        XCTAssertEqual(reopened.all, [
+            ReleasedThread(displayTerm: "the move", lemmas: ["move", "moving"], releasedAt: released)
+        ])
+    }
+
+    func testRelease_mergesCohortForSameTermKeepingFirstDate() {
+        store.release(displayTerm: "the move", lemmas: ["move"], releasedAt: released)
+        store.release(displayTerm: "the move", lemmas: ["moving"],
+                      releasedAt: released.addingTimeInterval(86400))
+        XCTAssertEqual(store.all, [
+            ReleasedThread(displayTerm: "the move", lemmas: ["move", "moving"], releasedAt: released)
+        ])
+    }
+
+    func testWelcomeBack_removesCohortAtomically() {
+        store.release(displayTerm: "the move", lemmas: ["move", "moving"], releasedAt: released)
+        store.release(displayTerm: "father", lemmas: ["father"], releasedAt: released)
+        store.welcomeBack(displayTerm: "the move")
+        XCTAssertEqual(store.all.map(\.displayTerm), ["father"])
+        XCTAssertEqual(store.releasedLemmas, ["father"])
+    }
+
+    func testReleasedLemmas_unionAcrossEntries() {
+        store.release(displayTerm: "the move", lemmas: ["move", "moving"], releasedAt: released)
+        store.release(displayTerm: "father", lemmas: ["father"], releasedAt: released)
+        XCTAssertEqual(store.releasedLemmas, ["move", "moving", "father"])
+    }
+
+    func testChangeCount_bumpsOnEveryMutation() {
+        let before = store.changeCount
+        store.release(displayTerm: "a", lemmas: ["a"], releasedAt: released)
+        store.welcomeBack(displayTerm: "a")
+        store.clear()
+        XCTAssertEqual(store.changeCount, before + 3)
+    }
+
+    func testAll_sortedNewestFirstThenTerm() {
+        store.release(displayTerm: "b", lemmas: ["b"], releasedAt: released)
+        store.release(displayTerm: "a", lemmas: ["a"], releasedAt: released)
+        store.release(displayTerm: "c", lemmas: ["c"], releasedAt: released.addingTimeInterval(86400))
+        XCTAssertEqual(store.all.map(\.displayTerm), ["c", "a", "b"])
+    }
+
+    func testMerge_unionsByTermKeepingEarliestDate() {
+        store.release(displayTerm: "the move", lemmas: ["move"], releasedAt: released)
+        store.merge(released: [
+            ReleasedThread(displayTerm: "the move", lemmas: ["moving"],
+                           releasedAt: released.addingTimeInterval(-86400)),
+            ReleasedThread(displayTerm: "father", lemmas: ["father"], releasedAt: released)
+        ], welcomedBack: [])
+        XCTAssertEqual(Set(store.all.map(\.displayTerm)), ["the move", "father"])
+        let move = store.all.first { $0.displayTerm == "the move" }
+        XCTAssertEqual(move?.lemmas, ["move", "moving"])
+        XCTAssertEqual(move?.releasedAt, released.addingTimeInterval(-86400))
+    }
+
+    func testMerge_staleImportedRelease_doesNotUndoWelcomeBack() {
+        store.release(displayTerm: "father", lemmas: ["father"], releasedAt: released)
+        store.welcomeBack(displayTerm: "father", at: released.addingTimeInterval(7 * 86400))
+        store.merge(released: [
+            ReleasedThread(displayTerm: "father", lemmas: ["father"], releasedAt: released)
+        ], welcomedBack: [])
+        XCTAssertTrue(store.all.isEmpty,
+                      "the walker's welcome-back is the later decision — importing an old backup never silently re-releases")
+        XCTAssertEqual(store.welcomedBack.map(\.displayTerm), ["father"])
+    }
+
+    func testMerge_staleImportedWelcomeBack_doesNotUndoRelease() {
+        store.release(displayTerm: "father", lemmas: ["father"], releasedAt: released)
+        store.merge(released: [], welcomedBack: [
+            WelcomedBackThread(displayTerm: "father",
+                               welcomedBackAt: released.addingTimeInterval(-86400))
+        ])
+        XCTAssertEqual(store.all.map(\.displayTerm), ["father"],
+                       "released again after that welcome-back — the newer local release stands")
+    }
+
+    func testClear_emptiesEverything() {
+        store.release(displayTerm: "a", lemmas: ["a"], releasedAt: released)
+        store.welcomeBack(displayTerm: "a")
+        store.release(displayTerm: "b", lemmas: ["b"], releasedAt: released)
+        store.clear()
+        XCTAssertTrue(store.isEmpty)
+        XCTAssertTrue(store.welcomedBack.isEmpty)
+        XCTAssertTrue(ReleasedThreadsStore(defaults: defaults).isEmpty)
+    }
+}

--- a/UnitTests/Seek/SeekDemoSeedTests.swift
+++ b/UnitTests/Seek/SeekDemoSeedTests.swift
@@ -46,5 +46,32 @@ final class SeekDemoSeedTests: XCTestCase {
         XCTAssertEqual(wanderSpecs.count, 5)
         XCTAssertTrue(wanderSpecs.allSatisfy { $0.waypoints.isEmpty })
     }
+
+    /// Without a shared, repeated lemma across at least two demo transcripts,
+    /// ThemeExtractor's 25-word and 2-mention floors mean no theme can ever
+    /// form in demo mode — the threads card, thread view, and chips would be
+    /// permanently unreachable for screenshots and QA. Runs the real analysis
+    /// + aggregation pipeline over the seeder's own transcripts, the same way
+    /// ThreadHistoryModelTests and ThreadsCardModelTests exercise it.
+    func testDemoTranscripts_shareThemeAcrossTwoDistinctWalks() {
+        var walksIndex: [UUID: (walkUUID: UUID, date: Date)] = [:]
+        var contexts: [TranscriptContext] = []
+
+        for (index, spec) in ScreenshotDataSeeder.walks.enumerated() {
+            guard let transcript = spec.transcription else { continue }
+            let recordingUUID = UUID()
+            let walkUUID = UUID()
+            let date = startDate.addingTimeInterval(Double(index) * 86400)
+            walksIndex[recordingUUID] = (walkUUID, date)
+            contexts.append(TranscriptContextAnalyzer.analyze(recordingUUID: recordingUUID, transcript: transcript))
+        }
+
+        let threads = ThreadStore.build(contexts: contexts, walks: walksIndex)
+        let spanningTwoWalks = threads.filter { Set($0.appearances.map(\.walkUUID)).count >= 2 }
+
+        XCTAssertFalse(spanningTwoWalks.isEmpty,
+                       "demo transcripts must share a theme across at least two walks so the threads card, " +
+                       "thread view, and chips are reachable in demo mode")
+    }
 }
 #endif

--- a/UnitTests/ThreadHistoryModelTests.swift
+++ b/UnitTests/ThreadHistoryModelTests.swift
@@ -1,0 +1,155 @@
+import XCTest
+import CoreLocation
+@testable import Pilgrim
+
+final class ThreadHistoryModelTests: XCTestCase {
+
+    private let base = DateFactory.makeDate(2024, 6, 1, 9, 0, 0)
+
+    private func appearance(recording: UUID, walk: UUID, date: Date, mentions: Int = 2) -> ThreadAppearance {
+        ThreadAppearance(recordingUUID: recording, walkUUID: walk, date: date,
+                         mentionCount: mentions, salience: 0.01)
+    }
+
+    func testEntries_newestFirstWithOriginOnOldest() {
+        let recs = [UUID(), UUID(), UUID()]
+        let thread = WalkThread(lemma: "move", displayTerm: "the move", appearances: recs.enumerated().map {
+            appearance(recording: $1, walk: UUID(), date: base.addingTimeInterval(Double($0) * 86400))
+        })
+        let entries = ThreadHistoryModelBuilder.entries(
+            cohort: [thread], contextsByRecording: [:], transcriptsByRecording: [:],
+            backfillComplete: true
+        )
+        XCTAssertEqual(entries.map(\.recordingUUID), [recs[2], recs[1], recs[0]])
+        XCTAssertEqual(entries.map(\.isOrigin), [false, false, true],
+                       "the oldest entry carries 'where it began'")
+    }
+
+    func testEntries_backfillIncomplete_suppressesOrigin() {
+        let recs = [UUID(), UUID()]
+        let thread = WalkThread(lemma: "move", displayTerm: "the move", appearances: recs.enumerated().map {
+            appearance(recording: $1, walk: UUID(), date: base.addingTimeInterval(Double($0) * 86400))
+        })
+        let entries = ThreadHistoryModelBuilder.entries(
+            cohort: [thread], contextsByRecording: [:], transcriptsByRecording: [:],
+            backfillComplete: false
+        )
+        XCTAssertEqual(entries.count, 2)
+        XCTAssertTrue(entries.allSatisfy { !$0.isOrigin },
+                      "origin claims stay suppressed pre-backfill — no 'where it began' footer, no origin-map action")
+    }
+
+    func testEntries_onePerRecordingAcrossCohort() {
+        let rec = UUID(), walk = UUID()
+        let cohort = [
+            WalkThread(lemma: "move", displayTerm: "the move",
+                       appearances: [appearance(recording: rec, walk: walk, date: base, mentions: 3)]),
+            WalkThread(lemma: "moving", displayTerm: "the move",
+                       appearances: [appearance(recording: rec, walk: walk, date: base, mentions: 2)])
+        ]
+        let entries = ThreadHistoryModelBuilder.entries(
+            cohort: cohort, contextsByRecording: [:], transcriptsByRecording: [:],
+            backfillComplete: true
+        )
+        XCTAssertEqual(entries.count, 1, "two cohort lemmas in one recording is still one moment")
+    }
+
+    func testExcerpt_realOffsetsFromAnalyzer() {
+        let transcript = "A long quiet morning on the water. The river kept speaking to me about " +
+            "patience and the river answered its own question before I could. Nothing else needed saying today."
+        let uuid = UUID()
+        let context = TranscriptContextAnalyzer.analyze(recordingUUID: uuid, transcript: transcript)
+        XCTAssertTrue(context.themes.contains { $0.lemma == "river" }, "fixture sanity")
+        let excerpt = ThreadHistoryModelBuilder.excerpt(
+            for: ["river"], context: context, transcript: transcript
+        )
+        XCTAssertNotNil(excerpt)
+        XCTAssertTrue(excerpt!.contains("river"))
+    }
+
+    func testExcerpt_hashMismatchReturnsNil() {
+        let transcript = "The river again today, and the river once more — twenty five words of it, " +
+            "give or take, spoken slowly into the morning air."
+        let context = TranscriptContextAnalyzer.analyze(recordingUUID: UUID(), transcript: transcript)
+        XCTAssertNil(ThreadHistoryModelBuilder.excerpt(
+            for: ["river"], context: context, transcript: transcript + " edited"
+        ), "stored offsets are only trusted against the exact transcript they were computed from")
+    }
+
+    func testSlice_graphemeSafeAroundEmoji() {
+        let transcript = "🚶‍♂️🌫️🌊 the river again"
+        let mentionStart = transcript.distance(
+            from: transcript.startIndex,
+            to: transcript.range(of: "river")!.lowerBound
+        )
+        let excerpt = ThreadHistoryModelBuilder.slice(
+            transcript, around: ThemeMention(start: mentionStart, length: 5), radius: 60
+        )
+        XCTAssertNotNil(excerpt)
+        XCTAssertTrue(excerpt!.contains("river"),
+                      "multi-scalar emoji before the mention must not shift the slice")
+    }
+
+    func testSlice_outOfBoundsMentionReturnsNil() {
+        XCTAssertNil(ThreadHistoryModelBuilder.slice(
+            "short", around: ThemeMention(start: 40, length: 5), radius: 60
+        ))
+        XCTAssertNil(ThreadHistoryModelBuilder.slice(
+            "short", around: ThemeMention(start: 2, length: 40), radius: 60
+        ))
+    }
+
+    func testSlice_ellipsesOnlyWhereTruncated() {
+        let transcript = String(repeating: "before ", count: 30) + "river" + String(repeating: " after", count: 30)
+        let mentionStart = transcript.distance(
+            from: transcript.startIndex,
+            to: transcript.range(of: "river")!.lowerBound
+        )
+        let middle = ThreadHistoryModelBuilder.slice(
+            transcript, around: ThemeMention(start: mentionStart, length: 5), radius: 30
+        )
+        XCTAssertTrue(middle!.hasPrefix("…") && middle!.hasSuffix("…"))
+
+        let atStart = ThreadHistoryModelBuilder.slice(
+            "river first then much more text follows on and on and on and on and on and on and on",
+            around: ThemeMention(start: 0, length: 5), radius: 30
+        )
+        XCTAssertFalse(atStart!.hasPrefix("…"), "no leading ellipsis when the slice reaches the start")
+    }
+
+    func testSlice_noWhitespaceWindow_degeneratesToBareEllipsis() {
+        let transcript = String(repeating: "a", count: 200)
+        let excerpt = ThreadHistoryModelBuilder.slice(
+            transcript, around: ThemeMention(start: 100, length: 5), radius: 30
+        )
+        XCTAssertEqual(excerpt, "…",
+                       "a truncated window with no whitespace trims to a bare ellipsis — pinned so any future formatting change is deliberate, not accidental")
+    }
+
+    func testOriginResolver_toleranceBoundary() {
+        let start = base
+        let sample: (Date) -> (timestamp: Date, latitude: Double, longitude: Double) = {
+            ($0, 43.0, -8.5)
+        }
+        XCTAssertNotNil(ThreadOriginResolver.coordinate(
+            recordingStart: start, samples: [sample(start.addingTimeInterval(120))]
+        ), "a fix exactly at the tolerance edge still counts")
+        XCTAssertNil(ThreadOriginResolver.coordinate(
+            recordingStart: start, samples: [sample(start.addingTimeInterval(121))]
+        ), "beyond tolerance the coordinate is a guess — the action hides instead")
+        XCTAssertNil(ThreadOriginResolver.coordinate(recordingStart: start, samples: []))
+    }
+
+    func testOriginResolver_picksNearestSample() {
+        let start = base
+        let coordinate = ThreadOriginResolver.coordinate(
+            recordingStart: start,
+            samples: [
+                (start.addingTimeInterval(-90), 1.0, 1.0),
+                (start.addingTimeInterval(10), 2.0, 2.0),
+                (start.addingTimeInterval(60), 3.0, 3.0)
+            ]
+        )
+        XCTAssertEqual(coordinate?.latitude, 2.0)
+    }
+}

--- a/UnitTests/ThreadIntentionSuggestionsTests.swift
+++ b/UnitTests/ThreadIntentionSuggestionsTests.swift
@@ -115,18 +115,56 @@ final class ThreadIntentionSuggestionsTests: XCTestCase {
                       "one second beyond the window leaves a single distinct walk — below the floor")
     }
 
+    func testFieldGate_passed_chipsAreLive() {
+        XCTAssertFalse(ThreadIntentionSuggestions.pendingFieldGate,
+                       "field gate passed 2026-08-24 (spec addendum) — chips ship live in 1.12.0")
+    }
+
     @MainActor
-    func testCurrent_pendingFieldGate_shipsDark() async {
+    func testCurrent_releaseVisibleOnNextCall() async {
         let saved = UserPreferences.threadsAfterWalks.value
         defer { UserPreferences.threadsAfterWalks.value = saved }
         UserPreferences.threadsAfterWalks.value = true
 
-        XCTAssertTrue(ThreadIntentionSuggestions.pendingFieldGate,
-                      "chips wait for the human field gate — flip only after it passes")
-        let suggestions = await ThreadIntentionSuggestions.current()
-        XCTAssertTrue(suggestions.isEmpty,
-                      "while the gate is pending, current() returns nothing even with the toggle on — "
-                      + "the chips section never renders in production")
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SuggestionsWiring-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = TranscriptContextStore(directory: directory)
+
+        let suiteName = "SuggestionsWiring-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let releasedStore = ReleasedThreadsStore(defaults: defaults)
+
+        let base = DateFactory.makeDate(2024, 6, 1, 9, 0, 0)
+        let recA = UUID(), recB = UUID()
+        let walkIndex: [UUID: (walkUUID: UUID, date: Date)] = [
+            recA: (UUID(), base),
+            recB: (UUID(), base.addingTimeInterval(5 * 86400))
+        ]
+        for rec in [recA, recB] {
+            _ = store.save(TranscriptContext(
+                schemaVersion: 1, recordingUUID: rec, transcriptHash: "h",
+                languageCode: "en", wordCount: 200,
+                themes: [Theme(lemma: "move", displayTerm: "the move", mentionCount: 3,
+                               salience: 0.015, mentions: [ThemeMention(start: 0, length: 4)])],
+                markers: nil
+            ))
+        }
+
+        let asOf = base.addingTimeInterval(6 * 86400)
+        let before = await ThreadIntentionSuggestions.current(
+            asOf: asOf, store: store, releasedStore: releasedStore, walkIndex: walkIndex
+        )
+        XCTAssertEqual(before, ["walk with 'the move'"],
+                       "fixture sanity — the suggestion is live before the release")
+
+        releasedStore.release(displayTerm: "the move", lemmas: ["move"])
+        let after = await ThreadIntentionSuggestions.current(
+            asOf: asOf, store: store, releasedStore: releasedStore, walkIndex: walkIndex
+        )
+        XCTAssertTrue(after.isEmpty,
+                      "current()'s own build path filters released lemmas and its memo re-keys on the released token — visible on the very next call")
     }
 
     @MainActor

--- a/UnitTests/ThreadsBackfillTests.swift
+++ b/UnitTests/ThreadsBackfillTests.swift
@@ -9,14 +9,22 @@ import XCTest
 @MainActor
 final class ThreadsBackfillTests: XCTestCase {
 
+    /// The pre-rename key (see ThreadsBackfill.legacyCompletedKey, which is
+    /// private) — hardcoded here deliberately, the same way the production
+    /// hygiene removal hardcodes it: this string is frozen, not a symbol
+    /// that can drift with a rename.
+    private static let legacyCompletedKey = "threadsBackfillCompleted"
+
     private var store: TranscriptContextStore!
     private var directory: URL!
     private var savedCompleted: Any?
+    private var savedLegacyCompleted: Any?
     private var savedToggle = true
 
     override func setUpWithError() throws {
         try super.setUpWithError()
         savedCompleted = UserDefaults.standard.object(forKey: ThreadsBackfill.completedKey)
+        savedLegacyCompleted = UserDefaults.standard.object(forKey: Self.legacyCompletedKey)
         savedToggle = UserPreferences.threadsAfterWalks.value
         UserDefaults.standard.set(false, forKey: ThreadsBackfill.completedKey)
         UserPreferences.threadsAfterWalks.value = true
@@ -31,6 +39,11 @@ final class ThreadsBackfillTests: XCTestCase {
         } else {
             UserDefaults.standard.removeObject(forKey: ThreadsBackfill.completedKey)
         }
+        if let savedLegacyCompleted {
+            UserDefaults.standard.set(savedLegacyCompleted, forKey: Self.legacyCompletedKey)
+        } else {
+            UserDefaults.standard.removeObject(forKey: Self.legacyCompletedKey)
+        }
         UserPreferences.threadsAfterWalks.value = savedToggle
         try? FileManager.default.removeItem(at: directory)
         try super.tearDownWithError()
@@ -38,6 +51,18 @@ final class ThreadsBackfillTests: XCTestCase {
 
     private func makeItems(_ count: Int) -> [(uuid: UUID, transcript: String)] {
         (0..<count).map { _ in (uuid: UUID(), transcript: "walking with the river again this morning") }
+    }
+
+    /// v1.11.0 TestFlight devices swept zero recordings under a snapshot bug
+    /// (fixed in 9529fff) yet still set the old flag true — `runIfNeeded`'s
+    /// `!isComplete` guard then never re-evaluates them. `completedKey` was
+    /// renamed to re-arm those devices: the new key is absent regardless of
+    /// what the old key holds, so `isComplete` must read false.
+    func testIsComplete_legacyKeyTrue_reArmsUnderNewKey() {
+        UserDefaults.standard.set(true, forKey: Self.legacyCompletedKey)
+
+        XCTAssertFalse(ThreadsBackfill.isComplete,
+                       "a device that swept nothing under the old key must re-evaluate under the new key")
     }
 
     func testRunIfNeeded_processesEveryItemAcrossBatches() async {

--- a/UnitTests/ThreadsCardModelTests.swift
+++ b/UnitTests/ThreadsCardModelTests.swift
@@ -1,6 +1,8 @@
 import XCTest
+import CoreStore
 @testable import Pilgrim
 
+@MainActor
 final class ThreadsCardModelTests: XCTestCase {
 
     private let base = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
@@ -220,5 +222,85 @@ final class ThreadsCardModelTests: XCTestCase {
             XCTAssertNil(note.rangeOfCharacter(from: .decimalDigits),
                          "principle 1: ordinal words, never metric digits (failed at \(walks))")
         }
+    }
+
+    private func seedWalkWithVoiceRecording(
+        in stack: DataStack, walkUUID: UUID, recordingUUID: UUID
+    ) throws -> Walk {
+        try stack.perform(synchronous: { transaction in
+            let walk = transaction.create(Into<Walk>())
+            walk._uuid .= walkUUID
+            walk._workoutType .= .walking
+            walk._startDate .= Date(timeIntervalSince1970: 1_700_000_000)
+            walk._endDate .= Date(timeIntervalSince1970: 1_700_001_800)
+            walk._distance .= 1000
+            walk._activeDuration .= 1800
+            walk._pauseDuration .= 0
+            walk._talkDuration .= 0
+            walk._meditateDuration .= 0
+            walk._ascend .= 0
+            walk._descend .= 0
+            walk._isRace .= false
+            walk._isUserModified .= false
+            walk._finishedRecording .= true
+            walk._dayIdentifier .= "20231115"
+
+            let recording = transaction.create(Into<VoiceRecording>())
+            recording._uuid .= recordingUUID
+            recording._fileRelativePath .= "Recordings/X/a.m4a"
+            recording._workout .= walk
+        })
+        return try XCTUnwrap(stack.fetchOne(From<Walk>().where(\._uuid == walkUUID)))
+    }
+
+    /// I1 residual: `onTranscriptionSave`/`onRetranscribe` mutate the summary's
+    /// `transcriptions` dict synchronously, but `DataManager
+    /// .updateVoiceRecordingTranscription` only re-analyzes inside its async
+    /// CoreStore write completion — a reload triggered by the mutation can
+    /// win the race and read the pre-edit context. The loader must hash-check
+    /// and re-analyze inline, the ThreadsDossierBuilder discipline, so the
+    /// card never survives on a stale analysis.
+    func testLoader_staleStoredContext_reAnalyzesInlineAndDropsEditedAwayTheme() async throws {
+        let savedToggle = UserPreferences.threadsAfterWalks.value
+        defer { UserPreferences.threadsAfterWalks.value = savedToggle }
+        UserPreferences.threadsAfterWalks.value = true
+
+        let previousDataStack = DataManager.dataStack
+        let stack = DataStack(PilgrimV7.schema)
+        try stack.addStorageAndWait(InMemoryStore())
+        DataManager.dataStack = stack
+        defer { DataManager.dataStack = previousDataStack }
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ThreadsCardLoaderTests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = TranscriptContextStore(directory: directory)
+
+        let releasedSuite = "ThreadsCardLoaderTests-\(UUID().uuidString)"
+        let releasedDefaults = try XCTUnwrap(UserDefaults(suiteName: releasedSuite))
+        defer { releasedDefaults.removePersistentDomain(forName: releasedSuite) }
+        let releasedStore = ReleasedThreadsStore(defaults: releasedDefaults)
+
+        let walkUUID = UUID(), recordingUUID = UUID()
+        let walk = try seedWalkWithVoiceRecording(in: stack, walkUUID: walkUUID, recordingUUID: recordingUUID)
+
+        // Analyzed and stored BEFORE the edit landed — "move" is baked into
+        // the stale context still sitting on disk.
+        let staleTranscript = String(repeating: "the move keeps returning to me today ", count: 6)
+        store.save(TranscriptContextAnalyzer.analyze(recordingUUID: recordingUUID, transcript: staleTranscript))
+
+        // The edit removed every mention of "move", and is too short to
+        // surface any theme of its own — the recomputed context should carry
+        // no themes at all.
+        let editedTranscript = "Just a quiet morning with nothing much on my mind."
+
+        let model = await ThreadsCardLoader.load(
+            walk: walk,
+            transcriptions: [recordingUUID: editedTranscript],
+            store: store,
+            releasedStore: releasedStore
+        )
+
+        XCTAssertNil(model, "the edit removed the only theme — a stale reload must not still name 'the move'")
     }
 }

--- a/UnitTests/ThreadsCardModelTests.swift
+++ b/UnitTests/ThreadsCardModelTests.swift
@@ -1,0 +1,208 @@
+import XCTest
+@testable import Pilgrim
+
+final class ThreadsCardModelTests: XCTestCase {
+
+    private let base = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+
+    private func appearance(recording: UUID, walk: UUID, date: Date, mentions: Int, salience: Double) -> ThreadAppearance {
+        ThreadAppearance(recordingUUID: recording, walkUUID: walk, date: date,
+                         mentionCount: mentions, salience: salience)
+    }
+
+    private func context(_ uuid: UUID, words: Int = 200, language: String? = "en") -> TranscriptContext {
+        TranscriptContext(
+            schemaVersion: 1, recordingUUID: uuid, transcriptHash: "h",
+            languageCode: language, wordCount: words, themes: [], markers: nil
+        )
+    }
+
+    private func singleThemeFixture(
+        earlierDates: [Date] = [],
+        backfillComplete: Bool = true
+    ) -> ThreadsCardModel? {
+        let rec = UUID(), walk = UUID()
+        var appearances = earlierDates.map {
+            appearance(recording: UUID(), walk: UUID(), date: $0, mentions: 2, salience: 0.01)
+        }
+        appearances.append(appearance(recording: rec, walk: walk, date: base, mentions: 3, salience: 0.015))
+        let thread = WalkThread(lemma: "move", displayTerm: "the move", appearances: appearances)
+        return ThreadsCardModelBuilder.model(
+            walkUUID: walk,
+            threads: [thread],
+            recordings: [(uuid: rec, transcript: "words", wordsPerMinute: nil)],
+            contextsByRecording: [rec: context(rec)],
+            backfillComplete: backfillComplete
+        )
+    }
+
+    func testModel_firstTimeStatusRequiresBackfill() {
+        XCTAssertEqual(singleThemeFixture()?.themes.first?.statusNote, "first time")
+        XCTAssertNil(singleThemeFixture(backfillComplete: false)?.themes.first?.statusNote,
+                     "origin claims stay suppressed pre-backfill — the chip shows without a note")
+    }
+
+    func testModel_ordinalStatusThroughHistory() {
+        let model = singleThemeFixture(earlierDates: [
+            base.addingTimeInterval(-10 * 86400),
+            base.addingTimeInterval(-5 * 86400)
+        ])
+        XCTAssertEqual(model?.themes.first?.statusNote, "third walk now")
+    }
+
+    func testStatusCopy_returningAndCap() {
+        XCTAssertEqual(ThreadsCardCopy.statusNote(for: .recurring(walksInWindow: 1)), "returning")
+        XCTAssertEqual(ThreadsCardCopy.statusNote(for: .recurring(walksInWindow: 2)), "second walk now")
+        XCTAssertEqual(ThreadsCardCopy.statusNote(for: .recurring(walksInWindow: 12)), "twelfth walk now")
+        XCTAssertEqual(ThreadsCardCopy.statusNote(for: .recurring(walksInWindow: 13)), "with you again")
+        XCTAssertNil(ThreadsCardCopy.statusNote(for: nil))
+    }
+
+    func testModel_topFourBySalienceDeterministicTies() {
+        let walk = UUID()
+        let recordings = (0..<5).map { _ in UUID() }
+        // "elm" is built BEFORE "dawn" and the two tie exactly on mentions
+        // and salience — the top-4 cut is decided by the alphabetical
+        // tie-break, not insertion order.
+        let lemmas = ["alder", "birch", "cedar", "elm", "dawn"]
+        let mentionCounts = [5, 4, 3, 2, 2]
+        let threads = lemmas.enumerated().map { index, lemma in
+            WalkThread(lemma: lemma, displayTerm: lemma, appearances: [
+                appearance(recording: recordings[index], walk: walk, date: base,
+                           mentions: mentionCounts[index], salience: Double(mentionCounts[index]) / 200)
+            ])
+        }
+        let contexts = Dictionary(uniqueKeysWithValues: recordings.map { ($0, context($0)) })
+        let model = ThreadsCardModelBuilder.model(
+            walkUUID: walk, threads: threads,
+            recordings: recordings.map { (uuid: $0, transcript: "words", wordsPerMinute: nil) },
+            contextsByRecording: contexts, backfillComplete: true
+        )
+        XCTAssertEqual(model?.themes.map(\.displayTerm), ["alder", "birch", "cedar", "dawn"],
+                       "top four by salience; 'dawn' and 'elm' tie exactly and the alphabetical tie-break keeps 'dawn'")
+    }
+
+    func testModel_cohortMergesSharedDisplayTerm() {
+        let walk = UUID()
+        let recA = UUID(), recB = UUID()
+        let threads = [
+            WalkThread(lemma: "move", displayTerm: "the move", appearances: [
+                appearance(recording: recA, walk: walk, date: base, mentions: 3, salience: 0.015)
+            ]),
+            WalkThread(lemma: "moving", displayTerm: "the move", appearances: [
+                appearance(recording: recB, walk: walk, date: base, mentions: 2, salience: 0.01)
+            ])
+        ]
+        let contexts = [recA: context(recA), recB: context(recB)]
+        let model = ThreadsCardModelBuilder.model(
+            walkUUID: walk, threads: threads,
+            recordings: [(uuid: recA, transcript: "w", wordsPerMinute: nil),
+                         (uuid: recB, transcript: "w", wordsPerMinute: nil)],
+            contextsByRecording: contexts, backfillComplete: true
+        )
+        XCTAssertEqual(model?.themes.count, 1, "two lemmas, one chip")
+        XCTAssertEqual(model?.themes.first?.lemmas, ["move", "moving"])
+    }
+
+    func testCohortStatus_firstTimeOnlyIfNoLemmaAppearedEarlier() {
+        let walk = UUID()
+        let recNow = UUID()
+        let threads = [
+            WalkThread(lemma: "move", displayTerm: "the move", appearances: [
+                appearance(recording: recNow, walk: walk, date: base, mentions: 3, salience: 0.015)
+            ]),
+            WalkThread(lemma: "moving", displayTerm: "the move", appearances: [
+                appearance(recording: UUID(), walk: UUID(),
+                           date: base.addingTimeInterval(-10 * 86400), mentions: 2, salience: 0.01)
+            ])
+        ]
+        let model = ThreadsCardModelBuilder.model(
+            walkUUID: walk, threads: threads,
+            recordings: [(uuid: recNow, transcript: "w", wordsPerMinute: nil)],
+            contextsByRecording: [recNow: context(recNow)], backfillComplete: true
+        )
+        XCTAssertEqual(model?.themes.first?.statusNote, "second walk now",
+                       "a first-time claim is only true if NO lemma in the cohort appeared earlier")
+    }
+
+    func testCohortLemmas_includeSiblingsAbsentFromThisWalk() {
+        let walk = UUID()
+        let recNow = UUID()
+        let threads = [
+            WalkThread(lemma: "move", displayTerm: "the move", appearances: [
+                appearance(recording: recNow, walk: walk, date: base, mentions: 3, salience: 0.015)
+            ]),
+            WalkThread(lemma: "moving", displayTerm: "the move", appearances: [
+                appearance(recording: UUID(), walk: UUID(),
+                           date: base.addingTimeInterval(-10 * 86400), mentions: 2, salience: 0.01)
+            ])
+        ]
+        let model = ThreadsCardModelBuilder.model(
+            walkUUID: walk, threads: threads,
+            recordings: [(uuid: recNow, transcript: "w", wordsPerMinute: nil)],
+            contextsByRecording: [recNow: context(recNow)], backfillComplete: true
+        )
+        XCTAssertEqual(model?.themes.first?.lemmas, ["move", "moving"],
+                       "release acts on every lemma sharing the display term — including a sibling with no appearance in this walk")
+    }
+
+    func testModel_noActiveThreads_returnsNil() {
+        let rec = UUID()
+        XCTAssertNil(ThreadsCardModelBuilder.model(
+            walkUUID: UUID(), threads: [],
+            recordings: [(uuid: rec, transcript: "w", wordsPerMinute: nil)],
+            contextsByRecording: [rec: context(rec)], backfillComplete: true
+        ), "no theme, no card — the summary stays pixel-identical")
+    }
+
+    func testTexture_slowPaceAndInsight() {
+        XCTAssertEqual(
+            ThreadsTexture.line(meanWordsPerMinute: 80, hasInsight: true),
+            "Spoken slowly, with words of insight."
+        )
+        XCTAssertEqual(
+            ThreadsTexture.line(meanWordsPerMinute: 180, hasInsight: false),
+            "Spoken quickly."
+        )
+        XCTAssertEqual(
+            ThreadsTexture.line(meanWordsPerMinute: nil, hasInsight: true),
+            "With words of insight."
+        )
+    }
+
+    func testTexture_weakSignalsOmitEverything() {
+        XCTAssertNil(ThreadsTexture.line(meanWordsPerMinute: 120, hasInsight: false),
+                     "a conversational pace and no insight words is not a texture — the line is omitted")
+    }
+
+    func testInsightWords_exactTraceableSurfacesDeduped() {
+        let words = ThreadsTexture.insightWords(in: [
+            "I realize now what I noticed before.",
+            "I realize it again with new awareness."
+        ])
+        XCTAssertEqual(words, ["realize", "noticed", "awareness"],
+                       "spoken order, deduplicated — the exact words the clause traces to")
+    }
+
+    func testModel_nonEnglishRecordings_noInsightClause() {
+        let rec = UUID(), walk = UUID()
+        let thread = WalkThread(lemma: "mudanza", displayTerm: "mudanza", appearances: [
+            appearance(recording: rec, walk: walk, date: base, mentions: 3, salience: 0.015)
+        ])
+        let model = ThreadsCardModelBuilder.model(
+            walkUUID: walk, threads: [thread],
+            recordings: [(uuid: rec, transcript: "I realize I notice awareness", wordsPerMinute: nil)],
+            contextsByRecording: [rec: context(rec, language: "es")], backfillComplete: true
+        )
+        XCTAssertTrue(model?.insightWords.isEmpty == true,
+                      "the insight lexicon is English-validated — other languages degrade to themes-only")
+    }
+
+    func testCopy_neverEmitsDigits() {
+        for walks in 1...40 {
+            let note = ThreadsCardCopy.statusNote(for: .recurring(walksInWindow: walks)) ?? ""
+            XCTAssertNil(note.rangeOfCharacter(from: .decimalDigits),
+                         "principle 1: ordinal words, never metric digits (failed at \(walks))")
+        }
+    }
+}

--- a/UnitTests/ThreadsCardModelTests.swift
+++ b/UnitTests/ThreadsCardModelTests.swift
@@ -302,5 +302,12 @@ final class ThreadsCardModelTests: XCTestCase {
         )
 
         XCTAssertNil(model, "the edit removed the only theme — a stale reload must not still name 'the move'")
+
+        // The loader's inline re-analysis must stay in-memory: the transcription
+        // choke point is the sole persistent writer, because it alone carries the
+        // ASR flaggedFragments needed to filter hallucinated themes. The store on
+        // disk should still hold the pre-edit (stale) context, not the loader's.
+        let persisted = store.context(for: recordingUUID, matching: TranscriptContextStore.hash(of: staleTranscript))
+        XCTAssertNotNil(persisted, "a loader-triggered re-analysis must never persist — the stored context stays the stale one until the choke point writes fresh")
     }
 }

--- a/UnitTests/ThreadsCardModelTests.swift
+++ b/UnitTests/ThreadsCardModelTests.swift
@@ -184,6 +184,22 @@ final class ThreadsCardModelTests: XCTestCase {
                        "spoken order, deduplicated — the exact words the clause traces to")
     }
 
+    func testModel_belowFloorInsight_noClaimNoTap() {
+        let rec = UUID(), walk = UUID()
+        let thread = WalkThread(lemma: "move", displayTerm: "the move", appearances: [
+            appearance(recording: rec, walk: walk, date: base, mentions: 3, salience: 0.015)
+        ])
+        let model = ThreadsCardModelBuilder.model(
+            walkUUID: walk, threads: [thread],
+            recordings: [(uuid: rec, transcript: "I realize the move", wordsPerMinute: 80)],
+            contextsByRecording: [rec: context(rec)], backfillComplete: true
+        )
+        XCTAssertEqual(model?.textureLine, "Spoken slowly.",
+                       "a single insight word sits below the floor — the claim never appears in the line")
+        XCTAssertEqual(model?.hasInsight, false,
+                       "the model exposes the same floor decision the view must gate on")
+    }
+
     func testModel_nonEnglishRecordings_noInsightClause() {
         let rec = UUID(), walk = UUID()
         let thread = WalkThread(lemma: "mudanza", displayTerm: "mudanza", appearances: [

--- a/UnitTests/ThreadsReleaseFilteringTests.swift
+++ b/UnitTests/ThreadsReleaseFilteringTests.swift
@@ -1,0 +1,130 @@
+import XCTest
+@testable import Pilgrim
+
+final class ThreadsReleaseFilteringTests: XCTestCase {
+
+    private let base = DateFactory.makeDate(2024, 6, 1, 9, 0, 0)
+
+    private func context(_ uuid: UUID, lemma: String, mentions: Int) -> TranscriptContext {
+        TranscriptContext(
+            schemaVersion: 1, recordingUUID: uuid, transcriptHash: "h",
+            languageCode: "en", wordCount: 200,
+            themes: [Theme(
+                lemma: lemma, displayTerm: lemma, mentionCount: mentions,
+                salience: Double(mentions) / 200,
+                mentions: Array(repeating: ThemeMention(start: 0, length: 4), count: mentions)
+            )],
+            markers: nil
+        )
+    }
+
+    func testBuild_dropsReleasedLemmas() {
+        let rec = UUID(), walk = UUID()
+        let contexts = [context(rec, lemma: "move", mentions: 3)]
+        let walks = [rec: (walkUUID: walk, date: base)]
+        XCTAssertEqual(ThreadStore.build(contexts: contexts, walks: walks).count, 1)
+        XCTAssertTrue(ThreadStore.build(contexts: contexts, walks: walks, released: ["move"]).isEmpty)
+    }
+
+    func testBuild_cohortLemmasBothDrop() {
+        let recA = UUID(), recB = UUID(), walk = UUID()
+        let contexts = [
+            context(recA, lemma: "move", mentions: 3),
+            context(recB, lemma: "moving", mentions: 2)
+        ]
+        let walks = [recA: (walkUUID: walk, date: base), recB: (walkUUID: walk, date: base)]
+        let threads = ThreadStore.build(contexts: contexts, walks: walks, released: ["move", "moving"])
+        XCTAssertTrue(threads.isEmpty, "release acts on the display term's full lemma cohort")
+    }
+
+    private var recurringText: String {
+        "The move is here. The move is near. The move is real. The move returns. " +
+        "The garden waits. The garden grows. The garden helps."
+    }
+
+    func testRecurringWord_skipsReleasedAndPromotesNext() {
+        let context = ActivityContext.make(
+            recordings: [RecordingContext(
+                text: recurringText, timestamp: base,
+                startCoordinate: nil, endCoordinate: nil, wordsPerMinute: nil
+            )],
+            startDate: base
+        )
+        let unfiltered = AttentionDirectives.detect(context: context, releasedLemmas: []).joined()
+        XCTAssertTrue(unfiltered.contains("'move'"))
+        let filtered = AttentionDirectives.detect(context: context, releasedLemmas: ["move"]).joined()
+        XCTAssertFalse(filtered.contains("'move'"))
+        XCTAssertTrue(filtered.contains("'garden'"), "the next-ranked candidate is promoted")
+    }
+
+    func testIntentionEcho_exemptFromRelease() {
+        let context = ActivityContext.make(
+            recordings: [RecordingContext(
+                text: recurringText, timestamp: base,
+                startCoordinate: nil, endCoordinate: nil, wordsPerMinute: nil
+            )],
+            startDate: base,
+            intention: "sit with the move"
+        )
+        let joined = AttentionDirectives.detect(context: context, releasedLemmas: ["move"]).joined()
+        XCTAssertTrue(joined.contains("intention spoke of"),
+                      "the echo quotes the walker's own stated intention — walker-authored, not app-noticed")
+    }
+
+    func testDossierBuilder_releaseVisibleOnNextOpen() {
+        let saved = UserPreferences.threadsAfterWalks.value
+        defer { UserPreferences.threadsAfterWalks.value = saved }
+        UserPreferences.threadsAfterWalks.value = true
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ReleaseFilteringTests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = TranscriptContextStore(directory: directory)
+
+        let suiteName = "ReleaseFilteringTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let releasedStore = ReleasedThreadsStore(defaults: defaults)
+
+        let transcript = "The move is on my mind today. The move would change everything for us. " +
+            "The move keeps returning whenever the morning turns quiet enough to hear it speak plainly."
+        let recUUID = UUID(), walkUUID = UUID()
+        let recording = RecordingContext(
+            text: transcript, timestamp: base,
+            startCoordinate: nil, endCoordinate: nil, wordsPerMinute: nil,
+            recordingUUID: recUUID
+        )
+        let walkIndex = [recUUID: (walkUUID: walkUUID, date: base)]
+
+        let before = ThreadsDossierBuilder.build(
+            walkUUID: walkUUID, recordings: [recording], walkIndex: walkIndex,
+            store: store, releasedStore: releasedStore
+        )
+        XCTAssertTrue(before?.contains("'move'") == true)
+
+        releasedStore.release(displayTerm: "move", lemmas: ["move"])
+        let after = ThreadsDossierBuilder.build(
+            walkUUID: walkUUID, recordings: [recording], walkIndex: walkIndex,
+            store: store, releasedStore: releasedStore
+        )
+        XCTAssertNotNil(after, "marker profiles still render — release removes noticing, not analysis")
+        XCTAssertFalse(after!.contains("'move'"),
+                       "the released token invalidates the memo — visible on the very next open")
+    }
+
+    func testSuggestions_selectOverFilteredThreadsExcludesReleased() {
+        let recA = UUID(), recB = UUID()
+        let contexts = [
+            context(recA, lemma: "move", mentions: 3),
+            context(recB, lemma: "move", mentions: 3)
+        ]
+        let walks = [
+            recA: (walkUUID: UUID(), date: base),
+            recB: (walkUUID: UUID(), date: base.addingTimeInterval(5 * 86400))
+        ]
+        let filtered = ThreadStore.build(contexts: contexts, walks: walks, released: ["move"])
+        XCTAssertTrue(ThreadIntentionSuggestions.select(
+            threads: filtered, asOf: base.addingTimeInterval(6 * 86400)
+        ).isEmpty, "select over release-filtered threads yields nothing — ranking only; the async current() wiring is pinned by Task 8's testCurrent_releaseVisibleOnNextCall")
+    }
+}

--- a/UnitTests/VoiceRecordingPersistenceTests.swift
+++ b/UnitTests/VoiceRecordingPersistenceTests.swift
@@ -21,7 +21,7 @@ final class VoiceRecordingPersistenceTests: XCTestCase {
         try super.tearDownWithError()
     }
 
-    private func seedRecording(uuid: UUID) throws {
+    private func seedRecording(uuid: UUID, transcription: String? = nil, wordsPerMinute: Double? = nil) throws {
         try stack.perform(synchronous: { transaction in
             let walk = transaction.create(Into<Walk>())
             walk._uuid .= UUID()
@@ -44,6 +44,8 @@ final class VoiceRecordingPersistenceTests: XCTestCase {
             recording._uuid .= uuid
             recording._fileRelativePath .= "Recordings/X/a.m4a"
             recording._workout .= walk
+            if let transcription { recording._transcription .= transcription }
+            if let wordsPerMinute { recording._wordsPerMinute .= wordsPerMinute }
         })
     }
 
@@ -248,5 +250,41 @@ final class VoiceRecordingPersistenceTests: XCTestCase {
             done.fulfill()
         }
         wait(for: [done], timeout: 5)
+    }
+
+    // MARK: - Snapshot queries (Threads/Lunation) — dataStack is a static
+    // default on these, not an injectable parameter, so swap-and-restore
+    // DataManager.dataStack the way ThreadsCardModelTests/
+    // DataManagerThreadsDeletionTests do.
+
+    @MainActor
+    func test_transcribedRecordingsSnapshot_returnsTranscribedRecordings() throws {
+        let previousDataStack = DataManager.dataStack
+        DataManager.dataStack = stack
+        defer { DataManager.dataStack = previousDataStack }
+
+        let uuid = UUID()
+        try seedRecording(uuid: uuid, transcription: "walked beneath the cedars")
+
+        let snapshot = DataManager.transcribedRecordingsSnapshot()
+
+        XCTAssertEqual(snapshot.count, 1, "queryAttributes stores \"id\" as a string — a raw `as? UUID` cast must not silently drop every row")
+        XCTAssertEqual(snapshot.first?.uuid, uuid)
+        XCTAssertEqual(snapshot.first?.transcript, "walked beneath the cedars")
+    }
+
+    @MainActor
+    func test_voiceRecordingPaceIndex_returnsWordsPerMinuteByRecording() throws {
+        let previousDataStack = DataManager.dataStack
+        DataManager.dataStack = stack
+        defer { DataManager.dataStack = previousDataStack }
+
+        let uuid = UUID()
+        try seedRecording(uuid: uuid, wordsPerMinute: 132.5)
+
+        let index = DataManager.voiceRecordingPaceIndex()
+
+        XCTAssertEqual(index.count, 1, "queryAttributes stores \"id\" as a string — a raw `as? UUID` cast must not silently drop every row")
+        XCTAssertEqual(index[uuid] ?? -1, 132.5, accuracy: 0.001)
     }
 }

--- a/UnitTests/VoiceRecordingPersistenceTests.swift
+++ b/UnitTests/VoiceRecordingPersistenceTests.swift
@@ -287,4 +287,21 @@ final class VoiceRecordingPersistenceTests: XCTestCase {
         XCTAssertEqual(index.count, 1, "queryAttributes stores \"id\" as a string — a raw `as? UUID` cast must not silently drop every row")
         XCTAssertEqual(index[uuid] ?? -1, 132.5, accuracy: 0.001)
     }
+
+    @MainActor
+    func test_voiceRecordingWalkIndex_returnsOwningWalkByRecording() throws {
+        let previousDataStack = DataManager.dataStack
+        DataManager.dataStack = stack
+        defer { DataManager.dataStack = previousDataStack }
+
+        let uuid = UUID()
+        try seedRecording(uuid: uuid)
+        let walk = try XCTUnwrap(try stack.fetchOne(From<VoiceRecording>().where(\._uuid == uuid))?._workout.value)
+
+        let index = DataManager.voiceRecordingWalkIndex()
+
+        XCTAssertEqual(index.count, 1, "queryAttributes stores \"id\" as a string — a raw `as? UUID` cast must not silently drop every row")
+        XCTAssertEqual(index[uuid]?.walkUUID, walk._uuid.value)
+        XCTAssertEqual(index[uuid]?.date, walk._startDate.value)
+    }
 }

--- a/docs/superpowers/plans/2026-08-24-thought-threads-stage3-4.md
+++ b/docs/superpowers/plans/2026-08-24-thought-threads-stage3-4.md
@@ -1,0 +1,3492 @@
+# Thought Threads — Stage 3+4 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** The engine earns its surfaces. Stage 3+4 ships the "What walked with you" card, the thread history view with excerpts and the origin map, "Let this one go" releases with a `.pilgrim` carve-out, the lunation recap with its walk-dated invitation, and flips the intention chips live — everything specified in `docs/superpowers/specs/2026-08-22-thought-threads-design.md` "### Stage 3 — card + thread view" and the whole "## Stage 3+4 addendum (2026-08-24)".
+
+**Architecture:** All new logic lives as pure model builders in `Pilgrim/Models/Threads/` (testable without UI), with thin SwiftUI files in `Pilgrim/Scenes/WalkSummary/` and `Pilgrim/Scenes/Settings/`. `ThreadStore.build` gains a released-lemma filter parameter — the single choke point covering card, thread view, dossier trajectories, quiet-this-walk lines, intention chips, and the recap; `AttentionDirectives.recurringWord` gets the one bypass-path skip. The released set is a new UserDefaults-backed store with its own change token, cleared by Delete All Data, and round-tripped through the `.pilgrim` preferences block (the sanctioned carve-out). Lunation machinery extends `LunarPhase`'s existing constants. Nothing touches the CoreStore schema, `SharePayload`, or the network.
+
+**Tech Stack:** Swift, SwiftUI, CoreStore (reads only, existing helpers), CoreLocation (route-sample lookup + reverse geocoding), Mapbox via the existing `PilgrimMapView`, XCTest.
+
+## Global Constraints
+
+- iOS 18 minimum; no new dependencies; no CoreStore schema changes (`PilgrimV7` stays current). Frozen identifiers stay frozen: `_workout`, `"workout"`, `"Workout"` etc. are SQL names — never "fix" them.
+- Nothing leaves the device. The released set's ONLY egress is the `.pilgrim` preferences block (spec: scoped carve-out, `zodiacSystem` precedent — the lemmas already appear verbatim in exported transcripts). `TranscriptContext`, `MarkerPack`, and `WalkThread` never appear in `Pilgrim/Models/Share/` or `Pilgrim/Models/Data/PilgrimPackage/`; `ReleasedThread` appears in `PilgrimPackage` only in the three sanctioned carve-out sites (models field, converter mapping, importer merge). Task 9's grep gates enforce exactly this.
+- The journal is untouched — no file under any Journal scene changes in this plan.
+- **No directional words in UI** ("rising", "fading", trend talk) and no metric digits in card/status copy. Ordinal words ("third walk now") and dates are fine. Digits are allowed ONLY where the spec sanctions them: the recap's "in N of M walks" counts and thread-view dates.
+- `threadsAfterWalks` off means off everywhere: card, thread navigation, chips, recap invitation, and both settings rows all gate on it.
+- Deterministic output everywhere: same inputs, same UI. Ties break by the existing `recurringWord` convention (highest count, then alphabetical).
+- **pbxproj, the 4-entries lesson:** every new Swift file needs FOUR entries in `Pilgrim.xcodeproj/project.pbxproj` — a `PBXBuildFile`, a `PBXFileReference`, a children entry in the right `PBXGroup`, and a `PBXSourcesBuildPhase` entry in the right target (app files → `Pilgrim` target, test files → `UnitTests` target). Copy the entry pattern of a sibling file in the same group. A file missing any one of the four compiles on your machine and breaks the build for everyone else.
+- Test command (per class): `xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/<ClassName> 2>&1 | tail -20`
+- **Suite reconciliation:** the pre-plan full-suite baseline is **1269** "Test Case '...' started" lines. After each task, the delta must equal the tests you added (count via `grep -c "Test Case '" <log>` or `xcrun xcresulttool`). A test file that silently never joined the target is exactly the failure mode this reconciliation catches.
+- Comment policy: self-documenting code; comments only for constraints code can't show. SwiftLint errors at 750 lines/type and 60 lines/function — keep new SwiftUI in focused files; WalkSummary additions go in a `WalkSummaryView+Threads.swift` extension (the `+Map.swift` pattern), with only `@State` declarations added to the main struct.
+- The custom `ProgressView` shadows SwiftUI's — qualify as `SwiftUI.ProgressView` if ever needed.
+- Typography: `Constants.Typography.*` only. Spacing: `Constants.UI.Padding.*`. Colors: the wabi-sabi palette (ink, fog, moss, stone, parchment, dawn).
+- CoreStore fetches assert main-thread: every `DataManager.*Index()`/`*Snapshot()` call happens on the main actor; detached tasks receive plain values.
+
+---
+
+### Task 1: ReleasedThreadsStore — the persisted released set
+
+**Files:**
+- Create: `Pilgrim/Models/Threads/ReleasedThreadsStore.swift`
+- Modify: `Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageModels.swift` (`PilgrimPreferences` gains an optional field + new `PilgrimReleasedThread` struct)
+- Modify: `Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageConverter.swift` (`buildManifest` export + `releasedThreads(from:)` import mapping)
+- Modify: `Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageImporter.swift` (`DecodedPackage` field + merge on import success)
+- Modify: `Pilgrim/Models/Data/DataManager.swift` (seam + `deleteAll` clearing hook)
+- Test: `UnitTests/ReleasedThreadsStoreTests.swift`, `UnitTests/ReleasedThreadsPackageTests.swift`, extend `UnitTests/DataManagerThreadsDeletionTests.swift`
+
+**Interfaces:**
+- Consumes: `UserDefaults`, `PilgrimDateCoding` (existing `.secondsSince1970` manifest coding), `DataManager.deleteAll` success path (DataManager.swift:842-859), `PilgrimPackageImporter.importPackage` success hook (PilgrimPackageImporter.swift:84-92).
+- Produces (used by Tasks 2, 3, 5, 7):
+  - `struct ReleasedThread: Codable, Equatable` — `{ displayTerm: String, lemmas: [String], releasedAt: Date }`
+  - `final class ReleasedThreadsStore` — `static let shared`; `init(defaults: UserDefaults)`; `var changeCount: Int` (session memo token, bumps on every mutation); `var all: [ReleasedThread]` (releasedAt-descending, term-ascending); `var releasedLemmas: Set<String>`; `var isEmpty: Bool`; `func release(displayTerm:lemmas:releasedAt:)` (merges cohorts for an already-released term); `func welcomeBack(displayTerm:)` (removes the cohort atomically); `func merge(_:)` (import union, earliest date wins); `func clear()` (Delete All hook)
+  - `struct PilgrimReleasedThread: Codable` — `{ term: String, lemmas: [String], releasedAt: Date }`
+  - `PilgrimPreferences.releasedThreads: [PilgrimReleasedThread]?` (nil-defaulted init parameter — every existing construction site compiles unchanged; old `.pilgrim` files decode nil; old importers ignore the unknown key)
+  - `PilgrimPackageConverter.releasedThreads(from: PilgrimPreferences) -> [ReleasedThread]`
+  - `DecodedPackage.releasedThreads: [ReleasedThread]`
+  - `DataManager.releasedThreadsStore: ReleasedThreadsStore` (test seam, defaults `.shared`)
+
+- [ ] **Step 1: Write the failing tests**
+
+`UnitTests/ReleasedThreadsStoreTests.swift`:
+
+```swift
+import XCTest
+@testable import Pilgrim
+
+final class ReleasedThreadsStoreTests: XCTestCase {
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var store: ReleasedThreadsStore!
+    private let released = DateFactory.makeDate(2026, 8, 20, 9, 0, 0)
+
+    override func setUpWithError() throws {
+        suiteName = "ReleasedThreadsTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        store = ReleasedThreadsStore(defaults: defaults)
+    }
+
+    override func tearDownWithError() throws {
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    func testRelease_persistsAcrossInstances() {
+        store.release(displayTerm: "the move", lemmas: ["move", "moving"], releasedAt: released)
+        let reopened = ReleasedThreadsStore(defaults: defaults)
+        XCTAssertEqual(reopened.all, [
+            ReleasedThread(displayTerm: "the move", lemmas: ["move", "moving"], releasedAt: released)
+        ])
+    }
+
+    func testRelease_mergesCohortForSameTermKeepingFirstDate() {
+        store.release(displayTerm: "the move", lemmas: ["move"], releasedAt: released)
+        store.release(displayTerm: "the move", lemmas: ["moving"],
+                      releasedAt: released.addingTimeInterval(86400))
+        XCTAssertEqual(store.all, [
+            ReleasedThread(displayTerm: "the move", lemmas: ["move", "moving"], releasedAt: released)
+        ])
+    }
+
+    func testWelcomeBack_removesCohortAtomically() {
+        store.release(displayTerm: "the move", lemmas: ["move", "moving"], releasedAt: released)
+        store.release(displayTerm: "father", lemmas: ["father"], releasedAt: released)
+        store.welcomeBack(displayTerm: "the move")
+        XCTAssertEqual(store.all.map(\.displayTerm), ["father"])
+        XCTAssertEqual(store.releasedLemmas, ["father"])
+    }
+
+    func testReleasedLemmas_unionAcrossEntries() {
+        store.release(displayTerm: "the move", lemmas: ["move", "moving"], releasedAt: released)
+        store.release(displayTerm: "father", lemmas: ["father"], releasedAt: released)
+        XCTAssertEqual(store.releasedLemmas, ["move", "moving", "father"])
+    }
+
+    func testChangeCount_bumpsOnEveryMutation() {
+        let before = store.changeCount
+        store.release(displayTerm: "a", lemmas: ["a"], releasedAt: released)
+        store.welcomeBack(displayTerm: "a")
+        store.clear()
+        XCTAssertEqual(store.changeCount, before + 3)
+    }
+
+    func testAll_sortedNewestFirstThenTerm() {
+        store.release(displayTerm: "b", lemmas: ["b"], releasedAt: released)
+        store.release(displayTerm: "a", lemmas: ["a"], releasedAt: released)
+        store.release(displayTerm: "c", lemmas: ["c"], releasedAt: released.addingTimeInterval(86400))
+        XCTAssertEqual(store.all.map(\.displayTerm), ["c", "a", "b"])
+    }
+
+    func testMerge_unionsByTermKeepingEarliestDate() {
+        store.release(displayTerm: "the move", lemmas: ["move"], releasedAt: released)
+        store.merge([
+            ReleasedThread(displayTerm: "the move", lemmas: ["moving"],
+                           releasedAt: released.addingTimeInterval(-86400)),
+            ReleasedThread(displayTerm: "father", lemmas: ["father"], releasedAt: released)
+        ])
+        XCTAssertEqual(Set(store.all.map(\.displayTerm)), ["the move", "father"])
+        let move = store.all.first { $0.displayTerm == "the move" }
+        XCTAssertEqual(move?.lemmas, ["move", "moving"])
+        XCTAssertEqual(move?.releasedAt, released.addingTimeInterval(-86400))
+    }
+
+    func testClear_emptiesEverything() {
+        store.release(displayTerm: "a", lemmas: ["a"], releasedAt: released)
+        store.clear()
+        XCTAssertTrue(store.isEmpty)
+        XCTAssertTrue(ReleasedThreadsStore(defaults: defaults).isEmpty)
+    }
+}
+```
+
+`UnitTests/ReleasedThreadsPackageTests.swift`:
+
+```swift
+import XCTest
+@testable import Pilgrim
+
+final class ReleasedThreadsPackageTests: XCTestCase {
+
+    private let released = DateFactory.makeDate(2026, 8, 20, 9, 0, 0)
+
+    private func preferences(releasedThreads: [PilgrimReleasedThread]?) -> PilgrimPreferences {
+        PilgrimPreferences(
+            distanceUnit: "km", altitudeUnit: "m", speedUnit: "km/h", energyUnit: "kJ",
+            celestialAwareness: false, zodiacSystem: "tropical", beginWithIntention: false,
+            releasedThreads: releasedThreads
+        )
+    }
+
+    func testPreferences_roundTripWithReleasedThreads() throws {
+        let original = preferences(releasedThreads: [
+            PilgrimReleasedThread(term: "the move", lemmas: ["move", "moving"], releasedAt: released)
+        ])
+        let data = try PilgrimDateCoding.makeEncoder().encode(original)
+        let decoded = try PilgrimDateCoding.makeDecoder().decode(PilgrimPreferences.self, from: data)
+        XCTAssertEqual(decoded.releasedThreads?.count, 1)
+        XCTAssertEqual(decoded.releasedThreads?[0].term, "the move")
+        XCTAssertEqual(decoded.releasedThreads?[0].lemmas, ["move", "moving"])
+        XCTAssertEqual(decoded.releasedThreads?[0].releasedAt, released)
+    }
+
+    func testPreferences_oldJSONWithoutKey_decodesNil() throws {
+        let old = """
+        {"distanceUnit":"km","altitudeUnit":"m","speedUnit":"km/h","energyUnit":"kJ",
+        "celestialAwareness":false,"zodiacSystem":"tropical","beginWithIntention":false}
+        """
+        let decoded = try PilgrimDateCoding.makeDecoder()
+            .decode(PilgrimPreferences.self, from: Data(old.utf8))
+        XCTAssertNil(decoded.releasedThreads)
+    }
+
+    func testBuildManifest_mapsReleasedThreads() {
+        let manifest = PilgrimPackageConverter.buildManifest(
+            walkCount: 0, events: [],
+            releasedThreads: [ReleasedThread(displayTerm: "the move", lemmas: ["move"], releasedAt: released)]
+        )
+        XCTAssertEqual(manifest.preferences.releasedThreads?.map(\.term), ["the move"])
+        XCTAssertEqual(manifest.preferences.releasedThreads?.first?.releasedAt, released)
+    }
+
+    func testBuildManifest_emptyReleasedSet_omitsKey() throws {
+        let manifest = PilgrimPackageConverter.buildManifest(
+            walkCount: 0, events: [], releasedThreads: []
+        )
+        XCTAssertNil(manifest.preferences.releasedThreads)
+        let json = String(decoding: try PilgrimDateCoding.makeEncoder().encode(manifest), as: UTF8.self)
+        XCTAssertFalse(json.contains("releasedThreads"),
+                       "a walker who released nothing exports a byte-identical preferences block")
+    }
+
+    func testImportMapping_fromPreferences() {
+        let mapped = PilgrimPackageConverter.releasedThreads(from: preferences(releasedThreads: [
+            PilgrimReleasedThread(term: "father", lemmas: ["father"], releasedAt: released)
+        ]))
+        XCTAssertEqual(mapped, [
+            ReleasedThread(displayTerm: "father", lemmas: ["father"], releasedAt: released)
+        ])
+        XCTAssertEqual(PilgrimPackageConverter.releasedThreads(from: preferences(releasedThreads: nil)), [])
+    }
+}
+```
+
+Append to `UnitTests/DataManagerThreadsDeletionTests.swift` (inside the existing class, mirroring its `testDeleteAll` expectation pattern):
+
+```swift
+    func testDeleteAll_clearsReleasedThreads() {
+        let suiteName = "ReleasedThreadsDeleteAll-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let released = ReleasedThreadsStore(defaults: defaults)
+        released.release(displayTerm: "the move", lemmas: ["move"])
+        DataManager.releasedThreadsStore = released
+        defer { DataManager.releasedThreadsStore = .shared }
+
+        let deleted = expectation(description: "deleted all")
+        DataManager.deleteAll { success, _ in
+            XCTAssertTrue(success)
+            deleted.fulfill()
+        }
+        wait(for: [deleted], timeout: 5)
+        XCTAssertTrue(released.isEmpty, "Delete All Data clears the released set with everything else")
+    }
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/ReleasedThreadsStoreTests 2>&1 | tail -20`
+Expected: FAIL — `cannot find 'ReleasedThreadsStore' in scope` (build error counts as red).
+
+- [ ] **Step 3: Implement the store**
+
+`Pilgrim/Models/Threads/ReleasedThreadsStore.swift`:
+
+```swift
+import Foundation
+
+/// A walker's decision to stop noticing a thread. Cohort-scoped: releasing a
+/// display term releases every lemma that shared it at release time, and
+/// welcome-back restores the cohort atomically. Releasing is wabi-sabi, not
+/// deletion — the words remain in their transcripts; the app simply stops
+/// noticing.
+struct ReleasedThread: Codable, Equatable {
+    let displayTerm: String
+    let lemmas: [String]
+    let releasedAt: Date
+}
+
+/// UserDefaults-persisted released set. Releases are walker decisions, not
+/// derived analysis — they survive relaunch, ride in the `.pilgrim`
+/// preferences block (the sanctioned carve-out), and Delete All Data clears
+/// them with everything else. Analysis and stored contexts are untouched by
+/// release, so it is fully reversible.
+final class ReleasedThreadsStore {
+
+    static let shared = ReleasedThreadsStore(defaults: .standard)
+
+    static let defaultsKey = "releasedThreads"
+
+    private let defaults: UserDefaults
+    private let lock = NSLock()
+    private var _changeCount = 0
+
+    init(defaults: UserDefaults) {
+        self.defaults = defaults
+    }
+
+    /// Session-scoped memo token, bumped on every mutation — folded into the
+    /// dossier-builder and suggestions memo keys so a release is visible on
+    /// the very next prompt or sheet open.
+    var changeCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _changeCount
+    }
+
+    /// Newest release first, ties broken by term — the settings list order.
+    var all: [ReleasedThread] {
+        lock.lock()
+        defer { lock.unlock() }
+        return load()
+    }
+
+    var releasedLemmas: Set<String> {
+        Set(all.flatMap(\.lemmas))
+    }
+
+    var isEmpty: Bool { all.isEmpty }
+
+    func release(displayTerm: String, lemmas: [String], releasedAt: Date = Date()) {
+        mutate { entries in
+            if let index = entries.firstIndex(where: { $0.displayTerm == displayTerm }) {
+                entries[index] = ReleasedThread(
+                    displayTerm: displayTerm,
+                    lemmas: Set(entries[index].lemmas).union(lemmas).sorted(),
+                    releasedAt: entries[index].releasedAt
+                )
+            } else {
+                entries.append(ReleasedThread(
+                    displayTerm: displayTerm, lemmas: lemmas.sorted(), releasedAt: releasedAt
+                ))
+            }
+        }
+    }
+
+    func welcomeBack(displayTerm: String) {
+        mutate { entries in
+            entries.removeAll { $0.displayTerm == displayTerm }
+        }
+    }
+
+    /// Import merge: a union of decisions, never an overwrite — releases made
+    /// on this device and releases carried in the package both stand. The
+    /// earlier release date wins so repeated imports stay stable.
+    func merge(_ imported: [ReleasedThread]) {
+        guard !imported.isEmpty else { return }
+        mutate { entries in
+            for thread in imported {
+                if let index = entries.firstIndex(where: { $0.displayTerm == thread.displayTerm }) {
+                    entries[index] = ReleasedThread(
+                        displayTerm: thread.displayTerm,
+                        lemmas: Set(entries[index].lemmas).union(thread.lemmas).sorted(),
+                        releasedAt: min(entries[index].releasedAt, thread.releasedAt)
+                    )
+                } else {
+                    entries.append(thread)
+                }
+            }
+        }
+    }
+
+    /// Delete All Data hook — walker decisions clear with everything else.
+    func clear() {
+        mutate { entries in
+            entries.removeAll()
+        }
+    }
+
+    private func mutate(_ body: (inout [ReleasedThread]) -> Void) {
+        lock.lock()
+        defer { lock.unlock() }
+        var entries = load()
+        body(&entries)
+        entries.sort { ($0.releasedAt, $1.displayTerm) > ($1.releasedAt, $0.displayTerm) }
+        if let data = try? JSONEncoder().encode(entries) {
+            defaults.set(data, forKey: Self.defaultsKey)
+        }
+        _changeCount += 1
+    }
+
+    private func load() -> [ReleasedThread] {
+        guard let data = defaults.data(forKey: Self.defaultsKey),
+              let entries = try? JSONDecoder().decode([ReleasedThread].self, from: data) else { return [] }
+        return entries
+    }
+}
+```
+
+- [ ] **Step 4: Wire the `.pilgrim` carve-out and the Delete All hook**
+
+1. `PilgrimPackageModels.swift` — replace the `PilgrimPreferences` struct (line 60) and add the new struct directly below it. The explicit init keeps the new field nil-defaulted so the converter and every test fixture compile unchanged:
+
+```swift
+struct PilgrimPreferences: Codable {
+    let distanceUnit: String
+    let altitudeUnit: String
+    let speedUnit: String
+    let energyUnit: String
+    let celestialAwareness: Bool
+    let zodiacSystem: String
+    let beginWithIntention: Bool
+    /// Released thought threads — the one sanctioned derived-data carve-out
+    /// (walker decisions, like zodiacSystem; the lemmas already appear
+    /// verbatim in the exported transcripts). Optional so pre-1.12 files
+    /// decode and pre-1.12 importers ignore the unknown key.
+    let releasedThreads: [PilgrimReleasedThread]?
+
+    init(
+        distanceUnit: String,
+        altitudeUnit: String,
+        speedUnit: String,
+        energyUnit: String,
+        celestialAwareness: Bool,
+        zodiacSystem: String,
+        beginWithIntention: Bool,
+        releasedThreads: [PilgrimReleasedThread]? = nil
+    ) {
+        self.distanceUnit = distanceUnit
+        self.altitudeUnit = altitudeUnit
+        self.speedUnit = speedUnit
+        self.energyUnit = energyUnit
+        self.celestialAwareness = celestialAwareness
+        self.zodiacSystem = zodiacSystem
+        self.beginWithIntention = beginWithIntention
+        self.releasedThreads = releasedThreads
+    }
+}
+
+struct PilgrimReleasedThread: Codable {
+    let term: String
+    let lemmas: [String]
+    let releasedAt: Date
+}
+```
+
+2. `PilgrimPackageConverter.swift` — in `buildManifest` (line 241), add a defaulted parameter and pass the mapped field into the `PilgrimPreferences(...)` construction (line 252):
+
+```swift
+    static func buildManifest(
+        walkCount: Int,
+        events: [PilgrimEvent],
+        archivedEntries: [PilgrimArchivedWalk] = [],
+        releasedThreads: [ReleasedThread] = ReleasedThreadsStore.shared.all
+    ) -> PilgrimManifest {
+```
+
+and inside, extend the existing `PilgrimPreferences(` construction with:
+
+```swift
+            beginWithIntention: UserPreferences.beginWithIntention.value,
+            releasedThreads: releasedThreads.isEmpty ? nil : releasedThreads.map {
+                PilgrimReleasedThread(term: $0.displayTerm, lemmas: $0.lemmas, releasedAt: $0.releasedAt)
+            }
+```
+
+Add the import mapping helper next to `convertEvents(_:)`:
+
+```swift
+    /// Import-side mapping for the released-threads carve-out. Pure, so the
+    /// importer's merge stays a one-liner and this stays testable.
+    static func releasedThreads(from preferences: PilgrimPreferences) -> [ReleasedThread] {
+        (preferences.releasedThreads ?? []).map {
+            ReleasedThread(displayTerm: $0.term, lemmas: $0.lemmas, releasedAt: $0.releasedAt)
+        }
+    }
+```
+
+3. `PilgrimPackageImporter.swift` — add `let releasedThreads: [ReleasedThread]` to `DecodedPackage` (line 54), populate it in `unpackAndDecode`'s final `DecodedPackage(...)` construction with `releasedThreads: PilgrimPackageConverter.releasedThreads(from: manifest.preferences)`, and in the `importPackage` success hook (line 86) add the merge between the tombstone clear and the backfill reset:
+
+```swift
+                        if case .success = result {
+                            TranscriptContextStore.shared.clearTombstones(for: importedRecordingUUIDs)
+                            ReleasedThreadsStore.shared.merge(package.releasedThreads)
+                            ThreadsBackfill.reset()
+                        }
+```
+
+Any test fixture constructing `DecodedPackage` directly gains `releasedThreads: []`.
+
+4. `DataManager.swift` — add the seam next to the existing `transcriptContextStore` seam:
+
+```swift
+    /// Injection seam for tests; production always uses the shared store.
+    static var releasedThreadsStore: ReleasedThreadsStore = .shared
+```
+
+and in `deleteAll`'s `.success` branch (line 844-855), after `UserPreferences.clearArchivedRegistry()`:
+
+```swift
+                releasedThreadsStore.clear()
+```
+
+The call sits in the transaction-success completion, preserving the Data Safety rule: walker decisions are only cleared once the database wipe committed.
+
+- [ ] **Step 5: Run all three test classes — PASS**
+
+Run: `xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/ReleasedThreadsStoreTests -only-testing:UnitTests/ReleasedThreadsPackageTests -only-testing:UnitTests/DataManagerThreadsDeletionTests 2>&1 | tail -20`
+Expected: PASS — 8 + 5 new tests, plus the existing DataManagerThreadsDeletionTests still green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Pilgrim/Models/Threads/ReleasedThreadsStore.swift Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageModels.swift Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageConverter.swift Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageImporter.swift Pilgrim/Models/Data/DataManager.swift UnitTests/ReleasedThreadsStoreTests.swift UnitTests/ReleasedThreadsPackageTests.swift UnitTests/DataManagerThreadsDeletionTests.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat(threads): released set — cohort releases, Delete All clearing, .pilgrim carve-out"
+```
+
+---
+
+### Task 2: Filtering integration — released cohorts vanish everywhere
+
+**Files:**
+- Modify: `Pilgrim/Models/Threads/ThreadStore.swift` (`build` gains `released` parameter)
+- Modify: `Pilgrim/Models/Prompt/AttentionDirectives.swift` (`detect` + `recurringWord` gain the released skip)
+- Modify: `Pilgrim/Models/Threads/ThreadsDossierBuilder.swift` (released filter + memo token)
+- Modify: `Pilgrim/Models/Threads/ThreadIntentionSuggestions.swift` (released filter + memo token)
+- Test: `UnitTests/ThreadsReleaseFilteringTests.swift`
+
+**Interfaces:**
+- Consumes: `ReleasedThreadsStore` (Task 1); existing `ThreadStore` / `AttentionDirectives` / builder / suggestions surfaces.
+- Produces (used by Tasks 3, 4, 7):
+  - `ThreadStore.build(contexts:walks:released:)` — `released: Set<String> = []`; a released lemma founds no thread, covering card, thread view, dossier trajectories, quiet-this-walk lines, chips, and the recap in one place.
+  - `AttentionDirectives.detect(context:detectedLanguageCode:releasedLemmas:)` — `releasedLemmas: Set<String> = ReleasedThreadsStore.shared.releasedLemmas`; only `recurringWord` consumes it (the one surfacing path that bypasses ThreadStore); the next-ranked candidate is promoted. `intentionEcho` is deliberately exempt — it only quotes words from the walker's own stated intention.
+  - `ThreadsDossierBuilder.build(walkUUID:recordings:walkIndex:store:releasedStore:)` — memo key now includes the released store's change token.
+  - `ThreadIntentionSuggestions.current(asOf:store:releasedStore:)` — same token in its memo key.
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+import XCTest
+@testable import Pilgrim
+
+final class ThreadsReleaseFilteringTests: XCTestCase {
+
+    private let base = DateFactory.makeDate(2024, 6, 1, 9, 0, 0)
+
+    private func context(_ uuid: UUID, lemma: String, mentions: Int) -> TranscriptContext {
+        TranscriptContext(
+            schemaVersion: 1, recordingUUID: uuid, transcriptHash: "h",
+            languageCode: "en", wordCount: 200,
+            themes: [Theme(
+                lemma: lemma, displayTerm: lemma, mentionCount: mentions,
+                salience: Double(mentions) / 200,
+                mentions: Array(repeating: ThemeMention(start: 0, length: 4), count: mentions)
+            )],
+            markers: nil
+        )
+    }
+
+    func testBuild_dropsReleasedLemmas() {
+        let rec = UUID(), walk = UUID()
+        let contexts = [context(rec, lemma: "move", mentions: 3)]
+        let walks = [rec: (walkUUID: walk, date: base)]
+        XCTAssertEqual(ThreadStore.build(contexts: contexts, walks: walks).count, 1)
+        XCTAssertTrue(ThreadStore.build(contexts: contexts, walks: walks, released: ["move"]).isEmpty)
+    }
+
+    func testBuild_cohortLemmasBothDrop() {
+        let recA = UUID(), recB = UUID(), walk = UUID()
+        let contexts = [
+            context(recA, lemma: "move", mentions: 3),
+            context(recB, lemma: "moving", mentions: 2)
+        ]
+        let walks = [recA: (walkUUID: walk, date: base), recB: (walkUUID: walk, date: base)]
+        let threads = ThreadStore.build(contexts: contexts, walks: walks, released: ["move", "moving"])
+        XCTAssertTrue(threads.isEmpty, "release acts on the display term's full lemma cohort")
+    }
+
+    private var recurringText: String {
+        "The move is here. The move is near. The move is real. The move returns. " +
+        "The garden waits. The garden grows. The garden helps."
+    }
+
+    func testRecurringWord_skipsReleasedAndPromotesNext() {
+        let context = ActivityContext.make(
+            recordings: [RecordingContext(
+                text: recurringText, timestamp: base,
+                startCoordinate: nil, endCoordinate: nil, wordsPerMinute: nil
+            )],
+            startDate: base
+        )
+        let unfiltered = AttentionDirectives.detect(context: context, releasedLemmas: []).joined()
+        XCTAssertTrue(unfiltered.contains("'move'"))
+        let filtered = AttentionDirectives.detect(context: context, releasedLemmas: ["move"]).joined()
+        XCTAssertFalse(filtered.contains("'move'"))
+        XCTAssertTrue(filtered.contains("'garden'"), "the next-ranked candidate is promoted")
+    }
+
+    func testIntentionEcho_exemptFromRelease() {
+        let context = ActivityContext.make(
+            recordings: [RecordingContext(
+                text: recurringText, timestamp: base,
+                startCoordinate: nil, endCoordinate: nil, wordsPerMinute: nil
+            )],
+            startDate: base,
+            intention: "sit with the move"
+        )
+        let joined = AttentionDirectives.detect(context: context, releasedLemmas: ["move"]).joined()
+        XCTAssertTrue(joined.contains("intention spoke of"),
+                      "the echo quotes the walker's own stated intention — walker-authored, not app-noticed")
+    }
+
+    func testDossierBuilder_releaseVisibleOnNextOpen() {
+        let saved = UserPreferences.threadsAfterWalks.value
+        defer { UserPreferences.threadsAfterWalks.value = saved }
+        UserPreferences.threadsAfterWalks.value = true
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ReleaseFilteringTests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = TranscriptContextStore(directory: directory)
+
+        let suiteName = "ReleaseFilteringTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let releasedStore = ReleasedThreadsStore(defaults: defaults)
+
+        let transcript = "The move is on my mind today. The move would change everything for us. " +
+            "The move keeps returning whenever the morning turns quiet enough to hear it speak plainly."
+        let recUUID = UUID(), walkUUID = UUID()
+        let recording = RecordingContext(
+            text: transcript, timestamp: base,
+            startCoordinate: nil, endCoordinate: nil, wordsPerMinute: nil,
+            recordingUUID: recUUID
+        )
+        let walkIndex = [recUUID: (walkUUID: walkUUID, date: base)]
+
+        let before = ThreadsDossierBuilder.build(
+            walkUUID: walkUUID, recordings: [recording], walkIndex: walkIndex,
+            store: store, releasedStore: releasedStore
+        )
+        XCTAssertTrue(before?.contains("'move'") == true)
+
+        releasedStore.release(displayTerm: "move", lemmas: ["move"])
+        let after = ThreadsDossierBuilder.build(
+            walkUUID: walkUUID, recordings: [recording], walkIndex: walkIndex,
+            store: store, releasedStore: releasedStore
+        )
+        XCTAssertNotNil(after, "marker profiles still render — release removes noticing, not analysis")
+        XCTAssertFalse(after!.contains("'move'"),
+                       "the released token invalidates the memo — visible on the very next open")
+    }
+
+    func testSuggestions_selectOverFilteredThreadsExcludesReleased() {
+        let recA = UUID(), recB = UUID()
+        let contexts = [
+            context(recA, lemma: "move", mentions: 3),
+            context(recB, lemma: "move", mentions: 3)
+        ]
+        let walks = [
+            recA: (walkUUID: UUID(), date: base),
+            recB: (walkUUID: UUID(), date: base.addingTimeInterval(5 * 86400))
+        ]
+        let filtered = ThreadStore.build(contexts: contexts, walks: walks, released: ["move"])
+        XCTAssertTrue(ThreadIntentionSuggestions.select(
+            threads: filtered, asOf: base.addingTimeInterval(6 * 86400)
+        ).isEmpty, "chips read the same filtered aggregation as everything else")
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure** (`-only-testing:UnitTests/ThreadsReleaseFilteringTests`). Expected: FAIL — `build(contexts:walks:released:)` and `detect(context:releasedLemmas:)` don't exist yet (build error is red).
+
+- [ ] **Step 3: Implement the ThreadStore filter**
+
+In `ThreadStore.swift`, replace the `build` signature and its inner loop (only the two marked lines change):
+
+```swift
+    static func build(
+        contexts: [TranscriptContext],
+        walks: [UUID: (walkUUID: UUID, date: Date)],
+        released: Set<String> = []
+    ) -> [WalkThread] {
+        var appearancesByLemma: [String: [ThreadAppearance]] = [:]
+        var displayCounts: [String: [String: Int]] = [:]
+
+        for context in contexts {
+            guard let walk = walks[context.recordingUUID] else { continue }
+            for theme in context.themes where !released.contains(theme.lemma) {
+                appearancesByLemma[theme.lemma, default: []].append(ThreadAppearance(
+                    recordingUUID: context.recordingUUID,
+                    walkUUID: walk.walkUUID,
+                    date: walk.date,
+                    mentionCount: theme.mentionCount,
+                    salience: theme.salience
+                ))
+                displayCounts[theme.lemma, default: [:]][theme.displayTerm, default: 0] += theme.mentionCount
+            }
+        }
+        // ...remainder of build unchanged...
+```
+
+- [ ] **Step 4: Implement the recurringWord skip**
+
+In `AttentionDirectives.swift`, replace the `detect` signature and body head plus `recurringWord`:
+
+```swift
+    /// `detectedLanguageCode` defaults to nil ("detect here") so direct
+    /// callers stay unchanged; PromptGenerator.resolvedDerivations passes
+    /// its precomputed code so the echo skips its own detection pass.
+    /// `releasedLemmas` feeds only recurringWord — the one surfacing path
+    /// that bypasses ThreadStore; intentionEcho is deliberately exempt
+    /// because it quotes the walker's own stated intention.
+    static func detect(
+        context: ActivityContext,
+        detectedLanguageCode: String? = nil,
+        releasedLemmas: Set<String> = ReleasedThreadsStore.shared.releasedLemmas
+    ) -> [String] {
+        // Lemmatizing the full transcript is the expensive step; do it once
+        // here and share it between the two detectors that need it.
+        let spokenMentions = context.hasSpeech
+            ? TranscriptNLP.contentLemmaMentions(in: context.recordings.map(\.text).joined(separator: " "))
+            : []
+        let directives = [
+            stillness(context),
+            paceShift(context),
+            intentionEcho(context, spokenMentions: spokenMentions, detectedLanguageCode: detectedLanguageCode),
+            recurringWord(context, spokenMentions: spokenMentions, releasedLemmas: releasedLemmas),
+            firstVersusLast(context)
+        ].compactMap { $0 }
+        return Array(directives.prefix(maxDirectives))
+    }
+```
+
+```swift
+    /// The most-repeated content lemma across all recordings, excluding any
+    /// lemma the intention already claimed and any released lemma — the
+    /// next-ranked candidate is promoted, so a release never silences the
+    /// directive, only redirects it. Shown as its most frequent surface form
+    /// so the walker's own inflection is echoed back.
+    private static func recurringWord(
+        _ context: ActivityContext,
+        spokenMentions mentions: [TranscriptNLP.LemmaMention],
+        releasedLemmas: Set<String>
+    ) -> String? {
+        guard context.hasSpeech else { return nil }
+        let intentionLemmas = context.intention
+            .map { Set(TranscriptNLP.contentLemmas(in: $0)) } ?? []
+
+        var counts: [String: Int] = [:]
+        var surfaces: [String: [String: Int]] = [:]
+        for mention in mentions
+        where !intentionLemmas.contains(mention.lemma) && !releasedLemmas.contains(mention.lemma) {
+            counts[mention.lemma, default: 0] += 1
+            surfaces[mention.lemma, default: [:]][mention.surface, default: 0] += 1
+        }
+
+        guard let (lemma, count) = counts.filter({ $0.value >= 3 })
+            .min(by: { ($0.value, $1.key) > ($1.value, $0.key) }) else { return nil }
+        let display = surfaces[lemma]?
+            .min(by: { ($0.value, $1.key) > ($1.value, $0.key) })?.key ?? lemma
+
+        return "The word '\(display)' returns \(count) times across the recordings — it may be doing quiet work."
+    }
+```
+
+(`PromptAssembler.walkRecord` and `PromptGenerator.resolvedDerivations` call sites compile unchanged via the default — verify with a build.)
+
+- [ ] **Step 5: Fold the released token into both memo keys**
+
+Replace `ThreadsDossierBuilder.swift`'s memo declaration and the head of `build` (everything from the guard through the memo check; the body below is unchanged except the two marked lines):
+
+```swift
+    private static var memo: (
+        changeCount: Int, releasedToken: Int, walkUUID: UUID,
+        backfillComplete: Bool, dossier: String?
+    )?
+    private static let memoLock = NSLock()
+
+    static func build(
+        walkUUID: UUID,
+        recordings: [RecordingContext],
+        walkIndex: [UUID: (walkUUID: UUID, date: Date)],
+        store: TranscriptContextStore = .shared,
+        releasedStore: ReleasedThreadsStore = .shared
+    ) -> String? {
+        guard UserPreferences.threadsAfterWalks.value, !recordings.isEmpty else { return nil }
+        // One consistent read each, captured before any store mutation: a
+        // mid-build mutation leaves the memoized tokens stale, so the next
+        // call rebuilds instead of absorbing the mutation unseen.
+        let backfillComplete = ThreadsBackfill.isComplete
+        let preBuildChangeCount = store.changeCount
+        let releasedToken = releasedStore.changeCount
+        let released = releasedStore.releasedLemmas
+        memoLock.lock()
+        let cached = memo
+        memoLock.unlock()
+        if let cached, cached.changeCount == preBuildChangeCount,
+           cached.releasedToken == releasedToken,
+           cached.walkUUID == walkUUID, cached.backfillComplete == backfillComplete {
+            return cached.dossier
+        }
+```
+
+then, further down, the two changed lines:
+
+```swift
+        let threads = ThreadStore.build(contexts: allContexts, walks: walkIndex, released: released)
+```
+
+and the memo write:
+
+```swift
+        memoLock.lock()
+        memo = (preBuildChangeCount, releasedToken, walkUUID, backfillComplete, dossier)
+        memoLock.unlock()
+        return dossier
+```
+
+In `ThreadIntentionSuggestions.swift`, replace the memo declaration and `current`:
+
+```swift
+    private static var memo: (changeCount: Int, releasedToken: Int, day: Date, suggestions: [String])?
+    private static let memoLock = NSLock()
+```
+
+```swift
+    @MainActor
+    static func current(
+        asOf: Date = Date(),
+        store: TranscriptContextStore = .shared,
+        releasedStore: ReleasedThreadsStore = .shared
+    ) async -> [String] {
+        guard !pendingFieldGate else { return [] }
+        guard UserPreferences.threadsAfterWalks.value else { return [] }
+        let walkIndex = DataManager.voiceRecordingWalkIndex()
+        guard !walkIndex.isEmpty else { return [] }
+
+        let day = Calendar.current.startOfDay(for: asOf)
+        let preLoadChangeCount = store.changeCount
+        let releasedToken = releasedStore.changeCount
+        let released = releasedStore.releasedLemmas
+        memoLock.lock()
+        let cached = memo
+        memoLock.unlock()
+        if let cached, cached.changeCount == preLoadChangeCount,
+           cached.releasedToken == releasedToken, cached.day == day {
+            return cached.suggestions
+        }
+
+        return await Task.detached(priority: .userInitiated) {
+            let threads = ThreadStore.build(contexts: store.loadAll(), walks: walkIndex, released: released)
+            let suggestions = select(threads: threads, asOf: asOf)
+            memoLock.lock()
+            memo = (preLoadChangeCount, releasedToken, day, suggestions)
+            memoLock.unlock()
+            return suggestions
+        }.value
+    }
+```
+
+- [ ] **Step 6: Run the new class, then the neighbors it touched**
+
+Run: `xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/ThreadsReleaseFilteringTests -only-testing:UnitTests/ThreadStoreTests -only-testing:UnitTests/ThreadsDossierTests -only-testing:UnitTests/ThreadIntentionSuggestionsTests -only-testing:UnitTests/AttentionDirectivesTests 2>&1 | tail -20`
+Expected: PASS — 6 new tests; every pre-existing test in the four neighbor classes untouched by the defaulted parameters.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Pilgrim/Models/Threads/ThreadStore.swift Pilgrim/Models/Prompt/AttentionDirectives.swift Pilgrim/Models/Threads/ThreadsDossierBuilder.swift Pilgrim/Models/Threads/ThreadIntentionSuggestions.swift UnitTests/ThreadsReleaseFilteringTests.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat(threads): released cohorts vanish everywhere — one ThreadStore filter, one recurringWord skip, tokened memos"
+```
+
+---
+
+### Task 3: The card — "What walked with you"
+
+**Files:**
+- Create: `Pilgrim/Models/Threads/ThreadsTexture.swift`
+- Create: `Pilgrim/Models/Threads/ThreadsCardModel.swift`
+- Create: `Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift`
+- Create: `Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift`
+- Modify: `Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift` (one `@State`, one slot in the VStack, one `.task`, `transcriptions` drops `private`)
+- Test: `UnitTests/ThreadsCardModelTests.swift`
+
+**Interfaces:**
+- Consumes: `ThreadStore.build(contexts:walks:released:)` + `ThreadStore.status` (Task 2), `TranscriptContextStore.shared.loadAll()`, `DataManager.voiceRecordingWalkIndex()`, `ThreadsBackfill.isComplete`, `MarkerLexicons.insight`, `TranscriptNLP.wordTokens`, `ContextFormatter.speakingPaceLabel` thresholds (<100 slow, ≥170 rapid — mirrored as constants here), `FlowLayout` (defined in `IntentionSettingView.swift`, internal — reusable).
+- Produces (used by Tasks 4, 5, 6, 7):
+  - `struct ThreadsCardTheme: Equatable, Identifiable` — `{ displayTerm: String, lemmas: [String], statusNote: String? }`, `id == displayTerm`
+  - `struct ThreadsCardModel: Equatable` — `{ themes: [ThreadsCardTheme], textureLine: String?, insightWords: [String] }`
+  - `ThreadsCardCopy.statusNote(for: ThreadStatus?) -> String?` — ordinal words, never digits
+  - `ThreadsCardModelBuilder.model(walkUUID:threads:recordings:contextsByRecording:backfillComplete:) -> ThreadsCardModel?` (pure) and `ThreadsCardModelBuilder.mergedThread(displayTerm:cohort:)`
+  - `ThreadsTexture.insightWords(in:) / .paceClause(meanWordsPerMinute:) / .line(meanWordsPerMinute:hasInsight:)`
+  - `ThreadsCardLoader.load(walk:transcriptions:store:releasedStore:) async -> ThreadsCardModel?` (`@MainActor`; nil when toggle off, nothing transcribed, or no theme survives)
+  - `ThreadsCardSection(model:)` view; `WalkSummaryView.threadsCardSlot` + `loadThreadsCard()` in the new extension
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+import XCTest
+@testable import Pilgrim
+
+final class ThreadsCardModelTests: XCTestCase {
+
+    private let base = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+
+    private func appearance(recording: UUID, walk: UUID, date: Date, mentions: Int, salience: Double) -> ThreadAppearance {
+        ThreadAppearance(recordingUUID: recording, walkUUID: walk, date: date,
+                         mentionCount: mentions, salience: salience)
+    }
+
+    private func context(_ uuid: UUID, words: Int = 200, language: String? = "en") -> TranscriptContext {
+        TranscriptContext(
+            schemaVersion: 1, recordingUUID: uuid, transcriptHash: "h",
+            languageCode: language, wordCount: words, themes: [], markers: nil
+        )
+    }
+
+    private func singleThemeFixture(
+        earlierDates: [Date] = [],
+        backfillComplete: Bool = true
+    ) -> ThreadsCardModel? {
+        let rec = UUID(), walk = UUID()
+        var appearances = earlierDates.map {
+            appearance(recording: UUID(), walk: UUID(), date: $0, mentions: 2, salience: 0.01)
+        }
+        appearances.append(appearance(recording: rec, walk: walk, date: base, mentions: 3, salience: 0.015))
+        let thread = WalkThread(lemma: "move", displayTerm: "the move", appearances: appearances)
+        return ThreadsCardModelBuilder.model(
+            walkUUID: walk,
+            threads: [thread],
+            recordings: [(uuid: rec, transcript: "words", wordsPerMinute: nil)],
+            contextsByRecording: [rec: context(rec)],
+            backfillComplete: backfillComplete
+        )
+    }
+
+    func testModel_firstTimeStatusRequiresBackfill() {
+        XCTAssertEqual(singleThemeFixture()?.themes.first?.statusNote, "first time")
+        XCTAssertNil(singleThemeFixture(backfillComplete: false)?.themes.first?.statusNote,
+                     "origin claims stay suppressed pre-backfill — the chip shows without a note")
+    }
+
+    func testModel_ordinalStatusThroughHistory() {
+        let model = singleThemeFixture(earlierDates: [
+            base.addingTimeInterval(-10 * 86400),
+            base.addingTimeInterval(-5 * 86400)
+        ])
+        XCTAssertEqual(model?.themes.first?.statusNote, "third walk now")
+    }
+
+    func testStatusCopy_returningAndCap() {
+        XCTAssertEqual(ThreadsCardCopy.statusNote(for: .recurring(walksInWindow: 1)), "returning")
+        XCTAssertEqual(ThreadsCardCopy.statusNote(for: .recurring(walksInWindow: 2)), "second walk now")
+        XCTAssertEqual(ThreadsCardCopy.statusNote(for: .recurring(walksInWindow: 12)), "twelfth walk now")
+        XCTAssertEqual(ThreadsCardCopy.statusNote(for: .recurring(walksInWindow: 13)), "with you again")
+        XCTAssertNil(ThreadsCardCopy.statusNote(for: nil))
+    }
+
+    func testModel_topFourBySalienceDeterministicTies() {
+        let walk = UUID()
+        let recordings = (0..<5).map { _ in UUID() }
+        let lemmas = ["alder", "birch", "cedar", "dawn", "elm"]
+        let threads = lemmas.enumerated().map { index, lemma in
+            WalkThread(lemma: lemma, displayTerm: lemma, appearances: [
+                appearance(recording: recordings[index], walk: walk, date: base,
+                           mentions: 5 - index, salience: Double(5 - index) / 200)
+            ])
+        }
+        let contexts = Dictionary(uniqueKeysWithValues: recordings.map { ($0, context($0)) })
+        let model = ThreadsCardModelBuilder.model(
+            walkUUID: walk, threads: threads,
+            recordings: recordings.map { (uuid: $0, transcript: "words", wordsPerMinute: nil) },
+            contextsByRecording: contexts, backfillComplete: true
+        )
+        XCTAssertEqual(model?.themes.map(\.displayTerm), ["alder", "birch", "cedar", "dawn"],
+                       "top four by salience; the fifth theme waits in the thread view")
+    }
+
+    func testModel_cohortMergesSharedDisplayTerm() {
+        let walk = UUID()
+        let recA = UUID(), recB = UUID()
+        let threads = [
+            WalkThread(lemma: "move", displayTerm: "the move", appearances: [
+                appearance(recording: recA, walk: walk, date: base, mentions: 3, salience: 0.015)
+            ]),
+            WalkThread(lemma: "moving", displayTerm: "the move", appearances: [
+                appearance(recording: recB, walk: walk, date: base, mentions: 2, salience: 0.01)
+            ])
+        ]
+        let contexts = [recA: context(recA), recB: context(recB)]
+        let model = ThreadsCardModelBuilder.model(
+            walkUUID: walk, threads: threads,
+            recordings: [(uuid: recA, transcript: "w", wordsPerMinute: nil),
+                         (uuid: recB, transcript: "w", wordsPerMinute: nil)],
+            contextsByRecording: contexts, backfillComplete: true
+        )
+        XCTAssertEqual(model?.themes.count, 1, "two lemmas, one chip")
+        XCTAssertEqual(model?.themes.first?.lemmas, ["move", "moving"])
+    }
+
+    func testCohortStatus_firstTimeOnlyIfNoLemmaAppearedEarlier() {
+        let walk = UUID()
+        let recNow = UUID()
+        let threads = [
+            WalkThread(lemma: "move", displayTerm: "the move", appearances: [
+                appearance(recording: recNow, walk: walk, date: base, mentions: 3, salience: 0.015)
+            ]),
+            WalkThread(lemma: "moving", displayTerm: "the move", appearances: [
+                appearance(recording: UUID(), walk: UUID(),
+                           date: base.addingTimeInterval(-10 * 86400), mentions: 2, salience: 0.01)
+            ])
+        ]
+        let model = ThreadsCardModelBuilder.model(
+            walkUUID: walk, threads: threads,
+            recordings: [(uuid: recNow, transcript: "w", wordsPerMinute: nil)],
+            contextsByRecording: [recNow: context(recNow)], backfillComplete: true
+        )
+        XCTAssertEqual(model?.themes.first?.statusNote, "second walk now",
+                       "a first-time claim is only true if NO lemma in the cohort appeared earlier")
+    }
+
+    func testModel_noActiveThreads_returnsNil() {
+        let rec = UUID()
+        XCTAssertNil(ThreadsCardModelBuilder.model(
+            walkUUID: UUID(), threads: [],
+            recordings: [(uuid: rec, transcript: "w", wordsPerMinute: nil)],
+            contextsByRecording: [rec: context(rec)], backfillComplete: true
+        ), "no theme, no card — the summary stays pixel-identical")
+    }
+
+    func testTexture_slowPaceAndInsight() {
+        XCTAssertEqual(
+            ThreadsTexture.line(meanWordsPerMinute: 80, hasInsight: true),
+            "Spoken slowly, with words of insight."
+        )
+        XCTAssertEqual(
+            ThreadsTexture.line(meanWordsPerMinute: 180, hasInsight: false),
+            "Spoken quickly."
+        )
+        XCTAssertEqual(
+            ThreadsTexture.line(meanWordsPerMinute: nil, hasInsight: true),
+            "With words of insight."
+        )
+    }
+
+    func testTexture_weakSignalsOmitEverything() {
+        XCTAssertNil(ThreadsTexture.line(meanWordsPerMinute: 120, hasInsight: false),
+                     "a conversational pace and no insight words is not a texture — the line is omitted")
+    }
+
+    func testInsightWords_exactTraceableSurfacesDeduped() {
+        let words = ThreadsTexture.insightWords(in: [
+            "I realize now what I noticed before.",
+            "I realize it again with new awareness."
+        ])
+        XCTAssertEqual(words, ["realize", "noticed", "awareness"],
+                       "spoken order, deduplicated — the exact words the clause traces to")
+    }
+
+    func testModel_nonEnglishRecordings_noInsightClause() {
+        let rec = UUID(), walk = UUID()
+        let thread = WalkThread(lemma: "mudanza", displayTerm: "mudanza", appearances: [
+            appearance(recording: rec, walk: walk, date: base, mentions: 3, salience: 0.015)
+        ])
+        let model = ThreadsCardModelBuilder.model(
+            walkUUID: walk, threads: [thread],
+            recordings: [(uuid: rec, transcript: "I realize I notice awareness", wordsPerMinute: nil)],
+            contextsByRecording: [rec: context(rec, language: "es")], backfillComplete: true
+        )
+        XCTAssertTrue(model?.insightWords.isEmpty == true,
+                      "the insight lexicon is English-validated — other languages degrade to themes-only")
+    }
+
+    func testCopy_neverEmitsDigits() {
+        for walks in 1...40 {
+            let note = ThreadsCardCopy.statusNote(for: .recurring(walksInWindow: walks)) ?? ""
+            XCTAssertNil(note.rangeOfCharacter(from: .decimalDigits),
+                         "principle 1: ordinal words, never metric digits (failed at \(walks))")
+        }
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure** (`-only-testing:UnitTests/ThreadsCardModelTests`). Expected: FAIL — types don't exist.
+
+- [ ] **Step 3: Implement the texture**
+
+`Pilgrim/Models/Threads/ThreadsTexture.swift`:
+
+```swift
+import Foundation
+
+/// State-only texture: pace derived mechanically from words-per-minute,
+/// insight from exact lexicon words the walker can be shown. No directional
+/// language, no numbers — weak signals are omitted, and the whole line is
+/// omitted when nothing clears threshold (spec: Stage 3 card).
+enum ThreadsTexture {
+
+    /// Mirrors ContextFormatter.speakingPaceLabel's outer buckets: only the
+    /// extremes are remarkable enough to name.
+    static let slowCeiling: Double = 100
+    static let quickFloor: Double = 170
+    static let insightFloor = 2
+
+    /// Insight-word surfaces in spoken order, deduplicated — the exact words
+    /// that earn "with words of insight", revealed on tap (traceability:
+    /// if we can't show the words, we don't show the claim).
+    static func insightWords(in transcripts: [String]) -> [String] {
+        var seen: Set<String> = []
+        return transcripts
+            .flatMap { TranscriptNLP.wordTokens(in: $0) }
+            .filter { MarkerLexicons.insight.contains($0) }
+            .filter { seen.insert($0).inserted }
+    }
+
+    static func paceClause(meanWordsPerMinute: Double?) -> String? {
+        guard let wpm = meanWordsPerMinute else { return nil }
+        if wpm < slowCeiling { return "spoken slowly" }
+        if wpm >= quickFloor { return "spoken quickly" }
+        return nil
+    }
+
+    static func line(meanWordsPerMinute: Double?, hasInsight: Bool) -> String? {
+        var clauses: [String] = []
+        if let pace = paceClause(meanWordsPerMinute: meanWordsPerMinute) {
+            clauses.append(pace)
+        }
+        if hasInsight {
+            clauses.append("with words of insight")
+        }
+        guard let first = clauses.first else { return nil }
+        let capitalized = first.prefix(1).capitalized + String(first.dropFirst())
+        return ([capitalized] + clauses.dropFirst()).joined(separator: ", ") + "."
+    }
+}
+```
+
+- [ ] **Step 4: Implement the card model**
+
+`Pilgrim/Models/Threads/ThreadsCardModel.swift`:
+
+```swift
+import Foundation
+
+struct ThreadsCardTheme: Equatable, Identifiable {
+    let displayTerm: String
+    let lemmas: [String]
+    let statusNote: String?
+
+    var id: String { displayTerm }
+}
+
+struct ThreadsCardModel: Equatable {
+    let themes: [ThreadsCardTheme]
+    let textureLine: String?
+    let insightWords: [String]
+}
+
+enum ThreadsCardCopy {
+
+    private static let ordinalWords: [Int: String] = [
+        2: "second", 3: "third", 4: "fourth", 5: "fifth", 6: "sixth",
+        7: "seventh", 8: "eighth", 9: "ninth", 10: "tenth",
+        11: "eleventh", 12: "twelfth"
+    ]
+
+    /// Ordinal words, never digits (spec principle 1). Beyond the table the
+    /// copy stays soft instead of inventing "twenty-third"; a bare
+    /// walksInWindow of 1 means the thread recurred outside the 30-day
+    /// window — "returning", not a false ordinal.
+    static func statusNote(for status: ThreadStatus?) -> String? {
+        switch status {
+        case .firstTime:
+            return "first time"
+        case .recurring(let walks):
+            if walks <= 1 { return "returning" }
+            guard let word = ordinalWords[walks] else { return "with you again" }
+            return "\(word) walk now"
+        case nil:
+            return nil
+        }
+    }
+}
+
+enum ThreadsCardModelBuilder {
+
+    static let maxThemes = 4
+
+    /// Pure: threads in, card model out. Nil means no card — the summary
+    /// must stay pixel-identical when nothing was found.
+    static func model(
+        walkUUID: UUID,
+        threads: [WalkThread],
+        recordings: [(uuid: UUID, transcript: String, wordsPerMinute: Double?)],
+        contextsByRecording: [UUID: TranscriptContext],
+        backfillComplete: Bool
+    ) -> ThreadsCardModel? {
+        let active = threads.filter { thread in
+            thread.appearances.contains { $0.walkUUID == walkUUID }
+        }
+        guard !active.isEmpty else { return nil }
+
+        // Two lemmas can share a display term (move/moving → "the move"):
+        // one chip per term, and release later acts on the whole cohort,
+        // so the cohort is assembled here.
+        let cohorts = Dictionary(grouping: active, by: \.displayTerm)
+
+        let totalWords = recordings
+            .compactMap { contextsByRecording[$0.uuid]?.wordCount }
+            .reduce(0, +)
+
+        let ranked = cohorts
+            .map { term, cohort -> (theme: ThreadsCardTheme, salience: Double, mentions: Int) in
+                let merged = mergedThread(displayTerm: term, cohort: cohort)
+                let mentions = merged.appearances
+                    .filter { $0.walkUUID == walkUUID }
+                    .reduce(0) { $0 + $1.mentionCount }
+                let salience = totalWords > 0 ? Double(mentions) / Double(totalWords) : 0
+                let status = ThreadStore.status(
+                    of: merged, atWalk: walkUUID, backfillComplete: backfillComplete
+                )
+                return (
+                    ThreadsCardTheme(
+                        displayTerm: term,
+                        lemmas: cohort.map(\.lemma).sorted(),
+                        statusNote: ThreadsCardCopy.statusNote(for: status)
+                    ),
+                    salience,
+                    mentions
+                )
+            }
+            .sorted {
+                ($0.salience, $0.mentions, $1.theme.displayTerm)
+                    > ($1.salience, $1.mentions, $0.theme.displayTerm)
+            }
+            .prefix(maxThemes)
+            .map(\.theme)
+
+        let englishTranscripts = recordings
+            .filter { contextsByRecording[$0.uuid]?.languageCode == "en" }
+            .map(\.transcript)
+        let insightWords = ThreadsTexture.insightWords(in: englishTranscripts)
+
+        let wpms = recordings.compactMap(\.wordsPerMinute)
+        let meanWPM = wpms.isEmpty ? nil : wpms.reduce(0, +) / Double(wpms.count)
+
+        return ThreadsCardModel(
+            themes: Array(ranked),
+            textureLine: ThreadsTexture.line(
+                meanWordsPerMinute: meanWPM,
+                hasInsight: insightWords.count >= ThreadsTexture.insightFloor
+            ),
+            insightWords: insightWords
+        )
+    }
+
+    /// One pseudo-thread per cohort so ThreadStore.status sees the cohort's
+    /// full history — a first-time claim is only true if NO lemma in the
+    /// cohort appeared earlier.
+    static func mergedThread(displayTerm: String, cohort: [WalkThread]) -> WalkThread {
+        WalkThread(
+            lemma: cohort.map(\.lemma).sorted().first ?? displayTerm,
+            displayTerm: displayTerm,
+            appearances: cohort.flatMap(\.appearances)
+                .sorted { ($0.date, $0.recordingUUID.uuidString) < ($1.date, $1.recordingUUID.uuidString) }
+        )
+    }
+}
+```
+
+- [ ] **Step 5: Run the model tests — PASS** (`-only-testing:UnitTests/ThreadsCardModelTests`, expected 12 tests).
+
+- [ ] **Step 6: Implement the card view and loader**
+
+`Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift`:
+
+```swift
+import SwiftUI
+
+/// Loads the card model off the summary's hot path: CoreStore reads on the
+/// main actor, store I/O and thread aggregation detached, plain values
+/// across the boundary (the ThreadsDossierBuilder discipline).
+enum ThreadsCardLoader {
+
+    @MainActor
+    static func load(
+        walk: WalkInterface,
+        transcriptions: [UUID: String],
+        store: TranscriptContextStore = .shared,
+        releasedStore: ReleasedThreadsStore = .shared
+    ) async -> ThreadsCardModel? {
+        guard UserPreferences.threadsAfterWalks.value,
+              let walkUUID = walk.uuid,
+              !transcriptions.isEmpty else { return nil }
+
+        let recordings = walk.voiceRecordings.compactMap { recording -> (uuid: UUID, transcript: String, wordsPerMinute: Double?)? in
+            guard let uuid = recording.uuid, let text = transcriptions[uuid] else { return nil }
+            return (uuid, text, recording.wordsPerMinute)
+        }
+        guard !recordings.isEmpty else { return nil }
+
+        let walkIndex = DataManager.voiceRecordingWalkIndex()
+        let released = releasedStore.releasedLemmas
+        let backfillComplete = ThreadsBackfill.isComplete
+
+        return await Task.detached(priority: .userInitiated) {
+            let contexts = store.loadAll()
+            let contextsByRecording = Dictionary(
+                uniqueKeysWithValues: contexts.map { ($0.recordingUUID, $0) }
+            )
+            let threads = ThreadStore.build(contexts: contexts, walks: walkIndex, released: released)
+            return ThreadsCardModelBuilder.model(
+                walkUUID: walkUUID,
+                threads: threads,
+                recordings: recordings,
+                contextsByRecording: contextsByRecording,
+                backfillComplete: backfillComplete
+            )
+        }.value
+    }
+}
+
+/// "What walked with you" — the quiet card naming the themes of this walk.
+/// Rendered only when a model exists: at least one transcribed recording,
+/// at least one surviving theme, toggle on.
+struct ThreadsCardSection: View {
+
+    let model: ThreadsCardModel
+
+    @State private var showInsightWords = false
+
+    var body: some View {
+        VStack(spacing: Constants.UI.Padding.small) {
+            Text("What walked with you")
+                .font(Constants.Typography.caption)
+                .foregroundColor(.fog)
+            FlowLayout(spacing: Constants.UI.Padding.small) {
+                ForEach(model.themes) { theme in
+                    chip(theme)
+                }
+            }
+            if let texture = model.textureLine {
+                textureLine(texture)
+            }
+        }
+        .padding(Constants.UI.Padding.normal)
+        .frame(maxWidth: .infinity)
+        .background(Color.parchmentSecondary)
+        .cornerRadius(Constants.UI.CornerRadius.normal)
+    }
+
+    private func chip(_ theme: ThreadsCardTheme) -> some View {
+        VStack(spacing: 2) {
+            Text(theme.displayTerm)
+                .font(Constants.Typography.body)
+                .foregroundColor(.ink)
+            if let note = theme.statusNote {
+                Text(note)
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .frame(minHeight: 44)
+        .background(Capsule().fill(Color.moss.opacity(0.1)))
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            theme.statusNote.map { "\(theme.displayTerm), \($0)" } ?? theme.displayTerm
+        )
+    }
+
+    private func textureLine(_ texture: String) -> some View {
+        Button {
+            guard !model.insightWords.isEmpty else { return }
+            showInsightWords.toggle()
+        } label: {
+            VStack(spacing: Constants.UI.Padding.xs) {
+                Text(texture)
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog)
+                    .multilineTextAlignment(.center)
+                if showInsightWords, !model.insightWords.isEmpty {
+                    Text(model.insightWords.map { "'\($0)'" }.joined(separator: ", "))
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.moss)
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .frame(maxWidth: .infinity, minHeight: 44)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityHint(
+            model.insightWords.isEmpty ? "" : "Double tap to see the words of insight"
+        )
+    }
+}
+```
+
+`Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift`:
+
+```swift
+import SwiftUI
+
+// MARK: - Thought Threads card glue
+//
+// Extracted from `WalkSummaryView.swift` like the +Map extension, to keep
+// the main type body under SwiftLint's type_body_length limit. Stored
+// state stays in the struct; everything else lives here.
+
+extension WalkSummaryView {
+
+    @ViewBuilder
+    var threadsCardSlot: some View {
+        if let threadsCardModel {
+            ThreadsCardSection(model: threadsCardModel)
+        }
+    }
+
+    func loadThreadsCard() async {
+        threadsCardModel = await ThreadsCardLoader.load(walk: walk, transcriptions: transcriptions)
+    }
+}
+```
+
+In `WalkSummaryView.swift`:
+1. The `@State private var transcriptions` declaration (line 18) drops `private` (the extension file needs it — same pattern as the camera state, see the comment at lines 36-38): `@State var transcriptions: [UUID: String] = [:]`
+2. Add below the other `@State` declarations: `@State var threadsCardModel: ThreadsCardModel?`
+3. In the body's `VStack`, directly below `intentionCard` (line 80): `threadsCardSlot`
+4. On the `ScrollView` modifier chain, after the `.onReceive(CollectiveRouteCatalogService.shared.$catalog)` block:
+
+```swift
+            .task(id: transcriptions.count) {
+                await loadThreadsCard()
+            }
+```
+
+(`id: transcriptions.count` re-runs the load when auto-transcription lands while the summary is open — the card appears the moment analysis exists.)
+
+- [ ] **Step 7: Build the app target, run the full UnitTests suite**
+
+Run: `xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests 2>&1 | tail -5`
+Expected: PASS; "Test Case '" count = 1269 + 32 (Tasks 1-3 tests: 14 + 6 + 12).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add Pilgrim/Models/Threads/ThreadsTexture.swift Pilgrim/Models/Threads/ThreadsCardModel.swift Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift UnitTests/ThreadsCardModelTests.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat(threads): the card — what walked with you, in ordinal words and traceable texture"
+```
+
+---
+
+### Task 4: The thread view — full history, excerpts, where it began
+
+**Files:**
+- Create: `Pilgrim/Models/Threads/ThreadHistoryModel.swift`
+- Create: `Pilgrim/Scenes/WalkSummary/ThreadHistoryView.swift`
+- Modify: `Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift` (chips become buttons)
+- Modify: `Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift` (pass the tap handler)
+- Modify: `Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift` (one `@State`, one `.sheet`)
+- Test: `UnitTests/ThreadHistoryModelTests.swift`
+
+**Interfaces:**
+- Consumes: `ThreadStore.build(contexts:walks:released:)` (Task 2), `ThemeMention` character offsets (Character/grapheme counts, produced via `text.distance` in `TranscriptNLP`), `TranscriptContextStore.hash(of:)`, `DataManager.transcribedRecordingsSnapshot()` / `.voiceRecordingWalkIndex()` (both `@MainActor`), `DataManager.dataStack.fetchOne(From<Walk>().where(\._uuid == uuid))` (the WalkSummaryView idiom, line 325), `WalkSummaryView.computeSegments(for:)`, `PilgrimMapView` (all-defaults init, `initialCamera: MapCameraSeed.Seed`), `PilgrimAnnotation.Kind.voiceRecording(label:)`, `WalkSummaryView(walk:)` presented via `.sheet(item:)` (Walk is Identifiable — the RecordingsListView idiom, line 55).
+- Produces (used by Tasks 5, 7):
+  - `struct ThreadHistoryEntry: Equatable` — `{ recordingUUID: UUID, walkUUID: UUID, date: Date, excerpt: String?, isOrigin: Bool }`
+  - `ThreadHistoryModelBuilder.entries(cohort:contextsByRecording:transcriptsByRecording:) -> [ThreadHistoryEntry]` (newest first, oldest flagged origin)
+  - `ThreadHistoryModelBuilder.excerpt(for:context:transcript:)` / `.slice(_:around:radius:)` (grapheme-safe)
+  - `ThreadOriginResolver.coordinate(recordingStart:samples:) -> CLLocationCoordinate2D?` (nearest route sample within `tolerance` = 120 s)
+  - `ThreadHistoryView(displayTerm:cohortLemmas:)` (pushed inside a NavigationStack)
+  - `ThreadsCardSection(model:onThemeTap:)`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+import XCTest
+import CoreLocation
+@testable import Pilgrim
+
+final class ThreadHistoryModelTests: XCTestCase {
+
+    private let base = DateFactory.makeDate(2024, 6, 1, 9, 0, 0)
+
+    private func appearance(recording: UUID, walk: UUID, date: Date, mentions: Int = 2) -> ThreadAppearance {
+        ThreadAppearance(recordingUUID: recording, walkUUID: walk, date: date,
+                         mentionCount: mentions, salience: 0.01)
+    }
+
+    func testEntries_newestFirstWithOriginOnOldest() {
+        let recs = [UUID(), UUID(), UUID()]
+        let thread = WalkThread(lemma: "move", displayTerm: "the move", appearances: recs.enumerated().map {
+            appearance(recording: $1, walk: UUID(), date: base.addingTimeInterval(Double($0) * 86400))
+        })
+        let entries = ThreadHistoryModelBuilder.entries(
+            cohort: [thread], contextsByRecording: [:], transcriptsByRecording: [:]
+        )
+        XCTAssertEqual(entries.map(\.recordingUUID), [recs[2], recs[1], recs[0]])
+        XCTAssertEqual(entries.map(\.isOrigin), [false, false, true],
+                       "the oldest entry carries 'where it began'")
+    }
+
+    func testEntries_onePerRecordingAcrossCohort() {
+        let rec = UUID(), walk = UUID()
+        let cohort = [
+            WalkThread(lemma: "move", displayTerm: "the move",
+                       appearances: [appearance(recording: rec, walk: walk, date: base, mentions: 3)]),
+            WalkThread(lemma: "moving", displayTerm: "the move",
+                       appearances: [appearance(recording: rec, walk: walk, date: base, mentions: 2)])
+        ]
+        let entries = ThreadHistoryModelBuilder.entries(
+            cohort: cohort, contextsByRecording: [:], transcriptsByRecording: [:]
+        )
+        XCTAssertEqual(entries.count, 1, "two cohort lemmas in one recording is still one moment")
+    }
+
+    func testExcerpt_realOffsetsFromAnalyzer() {
+        let transcript = "A long quiet morning on the water. The river kept speaking to me about " +
+            "patience and the river answered its own question before I could. Nothing else needed saying today."
+        let uuid = UUID()
+        let context = TranscriptContextAnalyzer.analyze(recordingUUID: uuid, transcript: transcript)
+        XCTAssertTrue(context.themes.contains { $0.lemma == "river" }, "fixture sanity")
+        let excerpt = ThreadHistoryModelBuilder.excerpt(
+            for: ["river"], context: context, transcript: transcript
+        )
+        XCTAssertNotNil(excerpt)
+        XCTAssertTrue(excerpt!.contains("river"))
+    }
+
+    func testExcerpt_hashMismatchReturnsNil() {
+        let transcript = "The river again today, and the river once more — twenty five words of it, " +
+            "give or take, spoken slowly into the morning air."
+        let context = TranscriptContextAnalyzer.analyze(recordingUUID: UUID(), transcript: transcript)
+        XCTAssertNil(ThreadHistoryModelBuilder.excerpt(
+            for: ["river"], context: context, transcript: transcript + " edited"
+        ), "stored offsets are only trusted against the exact transcript they were computed from")
+    }
+
+    func testSlice_graphemeSafeAroundEmoji() {
+        let transcript = "🚶‍♂️🌫️🌊 the river again"
+        let mentionStart = transcript.distance(
+            from: transcript.startIndex,
+            to: transcript.range(of: "river")!.lowerBound
+        )
+        let excerpt = ThreadHistoryModelBuilder.slice(
+            transcript, around: ThemeMention(start: mentionStart, length: 5), radius: 60
+        )
+        XCTAssertNotNil(excerpt)
+        XCTAssertTrue(excerpt!.contains("river"),
+                      "multi-scalar emoji before the mention must not shift the slice")
+    }
+
+    func testSlice_outOfBoundsMentionReturnsNil() {
+        XCTAssertNil(ThreadHistoryModelBuilder.slice(
+            "short", around: ThemeMention(start: 40, length: 5), radius: 60
+        ))
+        XCTAssertNil(ThreadHistoryModelBuilder.slice(
+            "short", around: ThemeMention(start: 2, length: 40), radius: 60
+        ))
+    }
+
+    func testSlice_ellipsesOnlyWhereTruncated() {
+        let transcript = String(repeating: "before ", count: 30) + "river" + String(repeating: " after", count: 30)
+        let mentionStart = transcript.distance(
+            from: transcript.startIndex,
+            to: transcript.range(of: "river")!.lowerBound
+        )
+        let middle = ThreadHistoryModelBuilder.slice(
+            transcript, around: ThemeMention(start: mentionStart, length: 5), radius: 30
+        )
+        XCTAssertTrue(middle!.hasPrefix("…") && middle!.hasSuffix("…"))
+
+        let atStart = ThreadHistoryModelBuilder.slice(
+            "river first then much more text follows on and on and on and on and on and on and on",
+            around: ThemeMention(start: 0, length: 5), radius: 30
+        )
+        XCTAssertFalse(atStart!.hasPrefix("…"), "no leading ellipsis when the slice reaches the start")
+    }
+
+    func testOriginResolver_toleranceBoundary() {
+        let start = base
+        let sample: (Date) -> (timestamp: Date, latitude: Double, longitude: Double) = {
+            ($0, 43.0, -8.5)
+        }
+        XCTAssertNotNil(ThreadOriginResolver.coordinate(
+            recordingStart: start, samples: [sample(start.addingTimeInterval(120))]
+        ), "a fix exactly at the tolerance edge still counts")
+        XCTAssertNil(ThreadOriginResolver.coordinate(
+            recordingStart: start, samples: [sample(start.addingTimeInterval(121))]
+        ), "beyond tolerance the coordinate is a guess — the action hides instead")
+        XCTAssertNil(ThreadOriginResolver.coordinate(recordingStart: start, samples: []))
+    }
+
+    func testOriginResolver_picksNearestSample() {
+        let start = base
+        let coordinate = ThreadOriginResolver.coordinate(
+            recordingStart: start,
+            samples: [
+                (start.addingTimeInterval(-90), 1.0, 1.0),
+                (start.addingTimeInterval(10), 2.0, 2.0),
+                (start.addingTimeInterval(60), 3.0, 3.0)
+            ]
+        )
+        XCTAssertEqual(coordinate?.latitude, 2.0)
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure** (`-only-testing:UnitTests/ThreadHistoryModelTests`). Expected: FAIL — types don't exist.
+
+- [ ] **Step 3: Implement the model**
+
+`Pilgrim/Models/Threads/ThreadHistoryModel.swift`:
+
+```swift
+import Foundation
+import CoreLocation
+
+struct ThreadHistoryEntry: Equatable {
+    let recordingUUID: UUID
+    let walkUUID: UUID
+    let date: Date
+    let excerpt: String?
+    let isOrigin: Bool
+}
+
+enum ThreadHistoryModelBuilder {
+
+    static let excerptRadius = 60
+
+    /// Newest first; the oldest entry carries the origin label. One entry
+    /// per recording — when two cohort lemmas appear in the same recording,
+    /// the strongest theme (mention count, then lemma) provides the excerpt.
+    static func entries(
+        cohort: [WalkThread],
+        contextsByRecording: [UUID: TranscriptContext],
+        transcriptsByRecording: [UUID: String]
+    ) -> [ThreadHistoryEntry] {
+        let lemmas = Set(cohort.map(\.lemma))
+        let appearancesByRecording = Dictionary(
+            grouping: cohort.flatMap(\.appearances), by: \.recordingUUID
+        )
+
+        let sorted: [ThreadHistoryEntry] = appearancesByRecording
+            .map { recordingUUID, appearances in
+                // Same recording ⇒ same walk and date; the excerpt picks the
+                // strongest cohort theme itself, so any element serves.
+                let appearance = appearances[0]
+                return ThreadHistoryEntry(
+                    recordingUUID: recordingUUID,
+                    walkUUID: appearance.walkUUID,
+                    date: appearance.date,
+                    excerpt: excerpt(
+                        for: lemmas,
+                        context: contextsByRecording[recordingUUID],
+                        transcript: transcriptsByRecording[recordingUUID]
+                    ),
+                    isOrigin: false
+                )
+            }
+            .sorted { ($0.date, $0.recordingUUID.uuidString) > ($1.date, $1.recordingUUID.uuidString) }
+
+        guard let oldest = sorted.last else { return [] }
+        return Array(sorted.dropLast()) + [ThreadHistoryEntry(
+            recordingUUID: oldest.recordingUUID,
+            walkUUID: oldest.walkUUID,
+            date: oldest.date,
+            excerpt: oldest.excerpt,
+            isOrigin: true
+        )]
+    }
+
+    static func excerpt(
+        for lemmas: Set<String>,
+        context: TranscriptContext?,
+        transcript: String?
+    ) -> String? {
+        guard let context, let transcript,
+              context.transcriptHash == TranscriptContextStore.hash(of: transcript),
+              let theme = context.themes
+                .filter({ lemmas.contains($0.lemma) })
+                .sorted(by: { ($0.mentionCount, $1.lemma) > ($1.mentionCount, $0.lemma) })
+                .first,
+              let mention = theme.mentions.first else { return nil }
+        return slice(transcript, around: mention, radius: excerptRadius)
+    }
+
+    /// Mention offsets are Character (grapheme) counts, produced by
+    /// `text.distance` at analysis time — sliced back with `limitedBy:` so
+    /// emoji and combining marks can never push an index past either end.
+    static func slice(_ transcript: String, around mention: ThemeMention, radius: Int) -> String? {
+        guard mention.start >= 0, mention.length > 0,
+              let mentionStart = transcript.index(
+                transcript.startIndex, offsetBy: mention.start, limitedBy: transcript.endIndex
+              ),
+              let mentionEnd = transcript.index(
+                mentionStart, offsetBy: mention.length, limitedBy: transcript.endIndex
+              ) else { return nil }
+
+        let start = transcript.index(mentionStart, offsetBy: -radius, limitedBy: transcript.startIndex)
+            ?? transcript.startIndex
+        let end = transcript.index(mentionEnd, offsetBy: radius, limitedBy: transcript.endIndex)
+            ?? transcript.endIndex
+
+        var excerpt = String(transcript[start..<end])
+        if start > transcript.startIndex {
+            excerpt = "…" + String(excerpt.drop(while: { !$0.isWhitespace }))
+                .trimmingCharacters(in: .whitespaces)
+        }
+        if end < transcript.endIndex {
+            excerpt = String(String(excerpt.reversed()).drop(while: { !$0.isWhitespace }).reversed())
+                .trimmingCharacters(in: .whitespaces) + "…"
+        }
+        return excerpt
+    }
+}
+
+enum ThreadOriginResolver {
+
+    static let tolerance: TimeInterval = 120
+
+    /// The route sample nearest the recording's start, within tolerance —
+    /// beyond it the fix is a guess, and the origin-map action hides
+    /// instead of guessing (spec: Return to where it began).
+    static func coordinate(
+        recordingStart: Date,
+        samples: [(timestamp: Date, latitude: Double, longitude: Double)]
+    ) -> CLLocationCoordinate2D? {
+        guard let nearest = samples.min(by: {
+            abs($0.timestamp.timeIntervalSince(recordingStart))
+                < abs($1.timestamp.timeIntervalSince(recordingStart))
+        }), abs(nearest.timestamp.timeIntervalSince(recordingStart)) <= tolerance else { return nil }
+        return CLLocationCoordinate2D(latitude: nearest.latitude, longitude: nearest.longitude)
+    }
+}
+```
+
+- [ ] **Step 4: Run the model tests — PASS** (`-only-testing:UnitTests/ThreadHistoryModelTests`, expected 9 tests).
+
+- [ ] **Step 5: Implement the view**
+
+`Pilgrim/Scenes/WalkSummary/ThreadHistoryView.swift`:
+
+```swift
+import SwiftUI
+import CoreStore
+import CoreLocation
+
+/// Best-effort reverse geocoding of each walk's starting point — resolved
+/// once per walk, capped per screen so a long history cannot hammer the
+/// geocoder; a missing place simply doesn't render.
+@MainActor
+final class ThreadPlaceResolver: ObservableObject {
+
+    @Published private(set) var places: [UUID: String] = [:]
+    private var requested: Set<UUID> = []
+    private let geocoder = CLGeocoder()
+    private static let maxResolutions = 12
+
+    func resolve(walkUUID: UUID) {
+        guard !requested.contains(walkUUID), requested.count < Self.maxResolutions else { return }
+        requested.insert(walkUUID)
+        guard let walk = try? DataManager.dataStack.fetchOne(
+            From<Walk>().where(\._uuid == walkUUID)
+        ), let first = walk.routeData.first else { return }
+        let location = CLLocation(latitude: first.latitude, longitude: first.longitude)
+        Task {
+            guard let placemark = try? await geocoder.reverseGeocodeLocation(location).first,
+                  let name = placemark.locality ?? placemark.name else { return }
+            places[walkUUID] = name
+        }
+    }
+}
+
+/// A thread's full history, newest first — date, place, and the walker's
+/// own words around each mention. The oldest entry is labeled "where it
+/// began" and offers the origin walk's map when a route fix exists.
+struct ThreadHistoryView: View {
+
+    let displayTerm: String
+    let cohortLemmas: [String]
+
+    @State private var entries: [ThreadHistoryEntry] = []
+    @State private var origin: OriginMapData?
+    @State private var selectedWalk: Walk?
+    @State private var presentedOriginMap: OriginMapData?
+    @StateObject private var placeResolver = ThreadPlaceResolver()
+
+    struct OriginMapData: Identifiable {
+        let id = UUID()
+        let walk: Walk
+        let coordinate: CLLocationCoordinate2D
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter
+    }()
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Constants.UI.Padding.normal) {
+                ForEach(entries, id: \.recordingUUID) { entry in
+                    entryRow(entry)
+                }
+            }
+            .padding(Constants.UI.Padding.normal)
+        }
+        .canvasBackground()
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                Text(displayTerm)
+                    .font(Constants.Typography.heading)
+                    .foregroundColor(.ink)
+            }
+        }
+        .sheet(item: $selectedWalk) { walk in
+            WalkSummaryView(walk: walk)
+        }
+        .sheet(item: $presentedOriginMap) { data in
+            ThreadOriginMapView(displayTerm: displayTerm, data: data)
+        }
+        .task { await load() }
+    }
+
+    private func entryRow(_ entry: ThreadHistoryEntry) -> some View {
+        VStack(alignment: .leading, spacing: Constants.UI.Padding.xs) {
+            Button {
+                selectedWalk = try? DataManager.dataStack.fetchOne(
+                    From<Walk>().where(\._uuid == entry.walkUUID)
+                )
+            } label: {
+                VStack(alignment: .leading, spacing: Constants.UI.Padding.xs) {
+                    HStack(spacing: Constants.UI.Padding.xs) {
+                        Text(Self.dateFormatter.string(from: entry.date))
+                            .font(Constants.Typography.caption)
+                            .foregroundColor(.fog)
+                        if let place = placeResolver.places[entry.walkUUID] {
+                            Text("· \(place)")
+                                .font(Constants.Typography.caption)
+                                .foregroundColor(.fog)
+                        }
+                    }
+                    if let excerpt = entry.excerpt {
+                        Text(excerpt)
+                            .font(Constants.Typography.body)
+                            .foregroundColor(.ink)
+                            .multilineTextAlignment(.leading)
+                    }
+                }
+                .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityElement(children: .combine)
+            .accessibilityHint("Double tap to open this walk's summary")
+
+            if entry.isOrigin {
+                originFooter
+            }
+        }
+        .padding(Constants.UI.Padding.normal)
+        .background(Color.parchmentSecondary)
+        .cornerRadius(Constants.UI.CornerRadius.normal)
+        .task { placeResolver.resolve(walkUUID: entry.walkUUID) }
+    }
+
+    private var originFooter: some View {
+        HStack(spacing: Constants.UI.Padding.xs) {
+            Image(systemName: "leaf")
+                .font(.caption)
+                .foregroundColor(.moss)
+            Text("where it began")
+                .font(Constants.Typography.caption)
+                .foregroundColor(.moss)
+            Spacer()
+            if let origin {
+                Button {
+                    presentedOriginMap = origin
+                } label: {
+                    Text("open the map")
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.stone)
+                        .frame(minHeight: 44)
+                }
+            }
+        }
+    }
+
+    @MainActor
+    private func load() async {
+        guard UserPreferences.threadsAfterWalks.value else { return }
+        let walkIndex = DataManager.voiceRecordingWalkIndex()
+        let transcripts = Dictionary(
+            uniqueKeysWithValues: DataManager.transcribedRecordingsSnapshot()
+                .map { ($0.uuid, $0.transcript) }
+        )
+        let released = ReleasedThreadsStore.shared.releasedLemmas
+        let lemmas = Set(cohortLemmas)
+
+        entries = await Task.detached(priority: .userInitiated) { () -> [ThreadHistoryEntry] in
+            let contexts = TranscriptContextStore.shared.loadAll()
+            let contextsByRecording = Dictionary(
+                uniqueKeysWithValues: contexts.map { ($0.recordingUUID, $0) }
+            )
+            let threads = ThreadStore.build(contexts: contexts, walks: walkIndex, released: released)
+            return ThreadHistoryModelBuilder.entries(
+                cohort: threads.filter { lemmas.contains($0.lemma) },
+                contextsByRecording: contextsByRecording,
+                transcriptsByRecording: transcripts
+            )
+        }.value
+        origin = resolveOrigin()
+    }
+
+    /// Resolution happens when the view opens — never persisted, so a
+    /// deleted origin walk or a fix gap simply hides the action on the next
+    /// open, and the record's earliest surviving appearance becomes "where
+    /// it began" (spec: deletion is deliberate record-editing).
+    @MainActor
+    private func resolveOrigin() -> OriginMapData? {
+        guard let oldest = entries.last, oldest.isOrigin,
+              let walk = try? DataManager.dataStack.fetchOne(
+                From<Walk>().where(\._uuid == oldest.walkUUID)
+              ),
+              let recording = walk.voiceRecordings.first(where: { $0.uuid == oldest.recordingUUID }),
+              let coordinate = ThreadOriginResolver.coordinate(
+                recordingStart: recording.startDate,
+                samples: walk.routeData.map { ($0.timestamp, $0.latitude, $0.longitude) }
+              ) else { return nil }
+        return OriginMapData(walk: walk, coordinate: coordinate)
+    }
+}
+
+/// The origin walk's map — the existing historical summary map, static and
+/// read-only, no live-walk controls — centered on where the thread first
+/// found words.
+struct ThreadOriginMapView: View {
+
+    let displayTerm: String
+    let data: ThreadHistoryView.OriginMapData
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            PilgrimMapView(
+                isInteractive: false,
+                showsUserLocation: false,
+                routeSegments: WalkSummaryView.computeSegments(for: data.walk),
+                pinAnnotations: [PilgrimAnnotation(
+                    coordinate: data.coordinate,
+                    kind: .voiceRecording(label: "where it began")
+                )],
+                initialCamera: MapCameraSeed.Seed(center: data.coordinate, zoom: 15)
+            )
+            .ignoresSafeArea(edges: .bottom)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Text("Where '\(displayTerm)' began")
+                        .font(Constants.Typography.heading)
+                        .foregroundColor(.ink)
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") { dismiss() }
+                        .foregroundColor(.stone)
+                }
+            }
+        }
+    }
+}
+```
+
+- [ ] **Step 6: Wire the card taps**
+
+1. `ThreadsCardSection.swift` — add the handler property and replace `chip(_:)`:
+
+```swift
+    let model: ThreadsCardModel
+    var onThemeTap: ((ThreadsCardTheme) -> Void)?
+```
+
+```swift
+    private func chip(_ theme: ThreadsCardTheme) -> some View {
+        Button {
+            onThemeTap?(theme)
+        } label: {
+            VStack(spacing: 2) {
+                Text(theme.displayTerm)
+                    .font(Constants.Typography.body)
+                    .foregroundColor(.ink)
+                if let note = theme.statusNote {
+                    Text(note)
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.fog)
+                }
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .frame(minHeight: 44)
+            .background(Capsule().fill(Color.moss.opacity(0.1)))
+        }
+        .buttonStyle(.plain)
+        .disabled(onThemeTap == nil)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(
+            theme.statusNote.map { "\(theme.displayTerm), \($0)" } ?? theme.displayTerm
+        )
+        .accessibilityHint(onThemeTap == nil ? "" : "Double tap to view history")
+    }
+```
+
+2. `WalkSummaryView.swift` — add `@State var selectedCardTheme: ThreadsCardTheme?` and, after the existing `.sheet(isPresented: $showPrompts)` block:
+
+```swift
+            .sheet(item: $selectedCardTheme) { theme in
+                NavigationStack {
+                    ThreadHistoryView(displayTerm: theme.displayTerm, cohortLemmas: theme.lemmas)
+                }
+            }
+```
+
+3. `WalkSummaryView+Threads.swift` — the slot passes the handler:
+
+```swift
+    @ViewBuilder
+    var threadsCardSlot: some View {
+        if let threadsCardModel {
+            ThreadsCardSection(
+                model: threadsCardModel,
+                onThemeTap: { selectedCardTheme = $0 }
+            )
+        }
+    }
+```
+
+- [ ] **Step 7: Build + full UnitTests suite — PASS** (baseline 1269 + 41). Commit.
+
+```bash
+git add Pilgrim/Models/Threads/ThreadHistoryModel.swift Pilgrim/Scenes/WalkSummary/ThreadHistoryView.swift Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift UnitTests/ThreadHistoryModelTests.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat(threads): thread view — the walker's own words, newest first, back to where it began"
+```
+
+---
+
+### Task 5: Let this one go
+
+**Files:**
+- Create: `Pilgrim/Models/Threads/ReleasedThreadsCopy.swift`
+- Create: `Pilgrim/Scenes/Settings/ReleasedThreadsListView.swift`
+- Modify: `Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift` (long-press, VoiceOver action, confirm, caption)
+- Modify: `Pilgrim/Scenes/WalkSummary/ThreadHistoryView.swift` (term header with long-press + confirm, pops on release)
+- Modify: `Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift` (release handler, card fade-out)
+- Modify: `Pilgrim/Models/Preferences/UserPreferences.swift` (caption-shown flag)
+- Modify: `Pilgrim/Models/Threads/ThreadsCardModel.swift` (`removing(displayTerm:from:)`)
+- Modify: `Pilgrim/Scenes/Settings/SettingsCards/VoiceCard.swift` (hidden-when-empty settings row)
+- Test: `UnitTests/ReleasedThreadsInteractionTests.swift`
+
+**Interfaces:**
+- Consumes: `ReleasedThreadsStore` (Task 1), `ThreadsCardTheme.lemmas` cohort (Task 3), `settingNavRow(label:)` (SettingsCardStyle.swift:74).
+- Produces:
+  - `ReleasedThreadsCopy` — every confirm string, centralized so card and thread view can never drift, and so Task 9's gentleness pass edits one file
+  - `ThreadsCardModelBuilder.removing(displayTerm:from:) -> ThreadsCardModel?` (nil when the last theme leaves — drives the card fade-out/reflow)
+  - `UserPreferences.threadsReleaseCaptionShown` — `UserPreference.Required<Bool>(key: "threadsReleaseCaptionShown", defaultValue: false)`
+  - `ThreadsCardSection(model:onThemeTap:onRelease:)` with per-chip long-press + "Let this go" VoiceOver custom action + one-time caption
+  - `ReleasedThreadsListView` (welcome-back confirms), surfaced from VoiceCard only when non-empty and the toggle is on
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+import XCTest
+@testable import Pilgrim
+
+final class ReleasedThreadsInteractionTests: XCTestCase {
+
+    func testReleaseConfirmCopy_exactStrings() {
+        XCTAssertEqual(ReleasedThreadsCopy.releaseTitle("my father"), "Let 'my father' go?")
+        XCTAssertEqual(ReleasedThreadsCopy.releaseMessage, "You can welcome it back anytime.")
+        XCTAssertEqual(ReleasedThreadsCopy.releaseConfirm, "Let it go")
+        XCTAssertEqual(ReleasedThreadsCopy.releaseCancel, "Not now")
+    }
+
+    func testWelcomeBackConfirmCopy_exactStrings() {
+        XCTAssertEqual(ReleasedThreadsCopy.welcomeBackTitle("my father"), "Welcome 'my father' back?")
+        XCTAssertEqual(ReleasedThreadsCopy.welcomeBackMessage, "Threads will notice it again.")
+        XCTAssertEqual(ReleasedThreadsCopy.welcomeBackConfirm, "Welcome it back")
+        XCTAssertEqual(ReleasedThreadsCopy.welcomeBackCancel, "Not now")
+    }
+
+    func testCaptionCopy_exactString() {
+        XCTAssertEqual(ReleasedThreadsCopy.caption, "long-press a theme to let it go")
+    }
+
+    func testVoiceOverActionName_exactString() {
+        XCTAssertEqual(ReleasedThreadsCopy.voiceOverActionName, "Let this go")
+    }
+
+    private func model(terms: [String]) -> ThreadsCardModel {
+        ThreadsCardModel(
+            themes: terms.map { ThreadsCardTheme(displayTerm: $0, lemmas: [$0], statusNote: nil) },
+            textureLine: nil,
+            insightWords: []
+        )
+    }
+
+    func testRemoving_dropsOnlyTheReleasedCohort() {
+        let after = ThreadsCardModelBuilder.removing(displayTerm: "the move", from: model(terms: ["the move", "father"]))
+        XCTAssertEqual(after?.themes.map(\.displayTerm), ["father"])
+    }
+
+    func testRemoving_lastThemeCollapsesTheCard() {
+        XCTAssertNil(ThreadsCardModelBuilder.removing(displayTerm: "father", from: model(terms: ["father"])),
+                     "an emptied card fades out and the summary reflows to its no-card state")
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure** (`-only-testing:UnitTests/ReleasedThreadsInteractionTests`). Expected: FAIL — `ReleasedThreadsCopy` doesn't exist.
+
+- [ ] **Step 3: Implement the copy and the model removal**
+
+`Pilgrim/Models/Threads/ReleasedThreadsCopy.swift`:
+
+```swift
+import Foundation
+
+/// Every release/welcome-back string in one place: the card and the thread
+/// view can never drift apart, and the pre-release gentleness pass (Task 9)
+/// edits one file. The confirm leads with reversibility by design.
+enum ReleasedThreadsCopy {
+
+    static func releaseTitle(_ term: String) -> String { "Let '\(term)' go?" }
+    static let releaseMessage = "You can welcome it back anytime."
+    static let releaseConfirm = "Let it go"
+    static let releaseCancel = "Not now"
+
+    static func welcomeBackTitle(_ term: String) -> String { "Welcome '\(term)' back?" }
+    static let welcomeBackMessage = "Threads will notice it again."
+    static let welcomeBackConfirm = "Welcome it back"
+    static let welcomeBackCancel = "Not now"
+
+    static let caption = "long-press a theme to let it go"
+    static let voiceOverActionName = "Let this go"
+}
+```
+
+Append to `ThreadsCardModelBuilder` in `ThreadsCardModel.swift`:
+
+```swift
+    /// Local, animatable card update after a release — the stores were
+    /// already told; this keeps the on-screen card honest without a reload.
+    static func removing(displayTerm: String, from model: ThreadsCardModel?) -> ThreadsCardModel? {
+        guard let model else { return nil }
+        let remaining = model.themes.filter { $0.displayTerm != displayTerm }
+        guard !remaining.isEmpty else { return nil }
+        return ThreadsCardModel(
+            themes: remaining,
+            textureLine: model.textureLine,
+            insightWords: model.insightWords
+        )
+    }
+```
+
+In `UserPreferences.swift`, below `threadsAfterWalks` (line 95):
+
+```swift
+    static let threadsReleaseCaptionShown = UserPreference.Required<Bool>(key: "threadsReleaseCaptionShown", defaultValue: false)
+```
+
+- [ ] **Step 4: Run the tests — PASS** (`-only-testing:UnitTests/ReleasedThreadsInteractionTests`, expected 6 tests).
+
+- [ ] **Step 5: Wire the card**
+
+`ThreadsCardSection.swift` — add the release handler, confirm state, caption, and gesture/action parity. The struct's stored properties and body become:
+
+```swift
+struct ThreadsCardSection: View {
+
+    let model: ThreadsCardModel
+    var onThemeTap: ((ThreadsCardTheme) -> Void)?
+    var onRelease: ((ThreadsCardTheme) -> Void)?
+
+    @State private var showInsightWords = false
+    @State private var themeToRelease: ThreadsCardTheme?
+    @State private var captionDismissed = UserPreferences.threadsReleaseCaptionShown.value
+
+    var body: some View {
+        VStack(spacing: Constants.UI.Padding.small) {
+            Text("What walked with you")
+                .font(Constants.Typography.caption)
+                .foregroundColor(.fog)
+            FlowLayout(spacing: Constants.UI.Padding.small) {
+                ForEach(model.themes) { theme in
+                    chip(theme)
+                }
+            }
+            if let texture = model.textureLine {
+                textureLine(texture)
+            }
+            if onRelease != nil, !captionDismissed {
+                captionRow
+            }
+        }
+        .padding(Constants.UI.Padding.normal)
+        .frame(maxWidth: .infinity)
+        .background(Color.parchmentSecondary)
+        .cornerRadius(Constants.UI.CornerRadius.normal)
+        .alert(
+            themeToRelease.map { ReleasedThreadsCopy.releaseTitle($0.displayTerm) } ?? "",
+            isPresented: Binding(
+                get: { themeToRelease != nil },
+                set: { if !$0 { themeToRelease = nil } }
+            ),
+            presenting: themeToRelease
+        ) { theme in
+            Button(ReleasedThreadsCopy.releaseConfirm) {
+                onRelease?(theme)
+                themeToRelease = nil
+            }
+            Button(ReleasedThreadsCopy.releaseCancel, role: .cancel) {
+                themeToRelease = nil
+            }
+        } message: { _ in
+            Text(ReleasedThreadsCopy.releaseMessage)
+        }
+    }
+
+    private var captionRow: some View {
+        HStack(spacing: Constants.UI.Padding.xs) {
+            Text(ReleasedThreadsCopy.caption)
+                .font(Constants.Typography.caption)
+                .foregroundColor(.fog.opacity(0.7))
+            Button {
+                UserPreferences.threadsReleaseCaptionShown.value = true
+                captionDismissed = true
+            } label: {
+                Image(systemName: "xmark")
+                    .font(.caption2)
+                    .foregroundColor(.fog)
+                    .frame(minWidth: 44, minHeight: 44)
+            }
+            .accessibilityLabel("Dismiss hint")
+        }
+    }
+```
+
+and `chip(_:)` gains, between `.buttonStyle(.plain)` and `.accessibilityElement`:
+
+```swift
+        .onLongPressGesture {
+            guard onRelease != nil else { return }
+            themeToRelease = theme
+        }
+```
+
+plus, after `.accessibilityHint(...)` — gesture parity, not gesture-only:
+
+```swift
+        .accessibilityAction(named: ReleasedThreadsCopy.voiceOverActionName) {
+            guard onRelease != nil else { return }
+            themeToRelease = theme
+        }
+```
+
+`WalkSummaryView+Threads.swift` — the slot passes both handlers and the release fades/reflows:
+
+```swift
+    @ViewBuilder
+    var threadsCardSlot: some View {
+        if let threadsCardModel {
+            ThreadsCardSection(
+                model: threadsCardModel,
+                onThemeTap: { selectedCardTheme = $0 },
+                onRelease: { releaseTheme($0) }
+            )
+            .transition(.opacity)
+        }
+    }
+
+    func releaseTheme(_ theme: ThreadsCardTheme) {
+        ReleasedThreadsStore.shared.release(displayTerm: theme.displayTerm, lemmas: theme.lemmas)
+        withAnimation(.easeOut(duration: 0.4)) {
+            threadsCardModel = ThreadsCardModelBuilder.removing(
+                displayTerm: theme.displayTerm, from: threadsCardModel
+            )
+        }
+    }
+```
+
+- [ ] **Step 6: Wire the thread view**
+
+`ThreadHistoryView.swift` — add `@Environment(\.dismiss) private var dismiss` and `@State private var showReleaseConfirm = false` to the struct, insert a term header as the first child of the ScrollView's VStack, and pop on release (the spec's mid-view transition):
+
+```swift
+                termHeader
+```
+
+```swift
+    private var termHeader: some View {
+        Text(displayTerm)
+            .font(Constants.Typography.displayMedium)
+            .foregroundColor(.ink)
+            .frame(maxWidth: .infinity)
+            .onLongPressGesture { showReleaseConfirm = true }
+            .accessibilityAction(named: ReleasedThreadsCopy.voiceOverActionName) {
+                showReleaseConfirm = true
+            }
+    }
+```
+
+and on the ScrollView's modifier chain, next to the existing sheets:
+
+```swift
+        .alert(
+            ReleasedThreadsCopy.releaseTitle(displayTerm),
+            isPresented: $showReleaseConfirm
+        ) {
+            Button(ReleasedThreadsCopy.releaseConfirm) {
+                ReleasedThreadsStore.shared.release(displayTerm: displayTerm, lemmas: cohortLemmas)
+                dismiss()
+            }
+            Button(ReleasedThreadsCopy.releaseCancel, role: .cancel) {}
+        } message: {
+            Text(ReleasedThreadsCopy.releaseMessage)
+        }
+```
+
+(When the thread view was pushed from the summary card, the summary's card is stale after this pop — the `.task(id:)` reload doesn't refire on dismiss, so ALSO add `.onChange(of: selectedCardTheme) { _, newValue in if newValue == nil { Task { await loadThreadsCard() } } }` to the WalkSummaryView modifier chain, right after the Task 4 sheet. A release made inside the thread view is then reflected the moment the sheet closes.)
+
+- [ ] **Step 7: The settings list**
+
+`Pilgrim/Scenes/Settings/ReleasedThreadsListView.swift`:
+
+```swift
+import SwiftUI
+
+/// Released threads, newest first — tapping an entry welcomes the cohort
+/// back. The row that leads here is hidden when this list would be empty.
+struct ReleasedThreadsListView: View {
+
+    @State private var entries: [ReleasedThread] = ReleasedThreadsStore.shared.all
+    @State private var entryToRestore: ReleasedThread?
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter
+    }()
+
+    var body: some View {
+        List {
+            ForEach(entries, id: \.displayTerm) { entry in
+                Button {
+                    entryToRestore = entry
+                } label: {
+                    HStack {
+                        Text(entry.displayTerm)
+                            .font(Constants.Typography.body)
+                            .foregroundColor(.ink)
+                        Spacer()
+                        Text(Self.dateFormatter.string(from: entry.releasedAt))
+                            .font(Constants.Typography.caption)
+                            .foregroundColor(.fog)
+                    }
+                    .frame(minHeight: 44)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityHint("Double tap to welcome this thread back")
+                .listRowBackground(Color.parchmentSecondary)
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .canvasBackground()
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                Text("Released threads")
+                    .font(Constants.Typography.heading)
+                    .foregroundColor(.ink)
+            }
+        }
+        .alert(
+            entryToRestore.map { ReleasedThreadsCopy.welcomeBackTitle($0.displayTerm) } ?? "",
+            isPresented: Binding(
+                get: { entryToRestore != nil },
+                set: { if !$0 { entryToRestore = nil } }
+            ),
+            presenting: entryToRestore
+        ) { entry in
+            Button(ReleasedThreadsCopy.welcomeBackConfirm) {
+                ReleasedThreadsStore.shared.welcomeBack(displayTerm: entry.displayTerm)
+                entries = ReleasedThreadsStore.shared.all
+                entryToRestore = nil
+            }
+            Button(ReleasedThreadsCopy.welcomeBackCancel, role: .cancel) {
+                entryToRestore = nil
+            }
+        } message: { _ in
+            Text(ReleasedThreadsCopy.welcomeBackMessage)
+        }
+    }
+}
+```
+
+`VoiceCard.swift` — add `@State private var hasReleasedThreads = !ReleasedThreadsStore.shared.isEmpty` (line 9, with the other state), refresh it in `.onAppear` (`hasReleasedThreads = !ReleasedThreadsStore.shared.isEmpty`), and add the row directly below the Thought Threads `settingToggle` block:
+
+```swift
+            if threadsAfterWalks && hasReleasedThreads {
+                NavigationLink {
+                    ReleasedThreadsListView()
+                } label: {
+                    settingNavRow(label: "Released threads")
+                }
+            }
+```
+
+- [ ] **Step 8: Build + full UnitTests suite — PASS** (baseline 1269 + 47). Commit.
+
+```bash
+git add Pilgrim/Models/Threads/ReleasedThreadsCopy.swift Pilgrim/Models/Threads/ThreadsCardModel.swift Pilgrim/Models/Preferences/UserPreferences.swift Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift Pilgrim/Scenes/WalkSummary/ThreadHistoryView.swift Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift Pilgrim/Scenes/Settings/ReleasedThreadsListView.swift Pilgrim/Scenes/Settings/SettingsCards/VoiceCard.swift UnitTests/ReleasedThreadsInteractionTests.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat(threads): let this one go — reversible releases with gesture parity and a welcome back"
+```
+
+---
+
+### Task 6: Lunation machinery — moons, boundaries, eligibility
+
+**Files:**
+- Modify: `Pilgrim/Models/LunarPhase.swift` (two constants drop `private`)
+- Create: `Pilgrim/Models/Threads/LunationCalendar.swift`
+- Create: `Pilgrim/Models/Threads/LunationRecapState.swift`
+- Modify: `Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift` (first-card-shown marker)
+- Test: `UnitTests/LunationCalendarTests.swift`, `UnitTests/LunationRecapStateTests.swift`
+
+**Interfaces:**
+- Consumes: `LunarPhase.synodicMonth` / `LunarPhase.knownNewMoon` (internal after this task — the same reference the phase math uses, so phase and lunation arithmetic can never disagree), `UserPreferences.threadsAfterWalks`.
+- Produces (used by Task 7):
+  - `struct Lunation: Equatable, Identifiable` — `{ index: Int, start: Date, end: Date, fullMoon: Date }`, `id == index`
+  - `LunationCalendar.lunation(at:)` / `.lunation(containing:)` / `.mostRecentClosed(asOf:)` / `.moonName(for:in:)` (timezone-pinned month-moon name table)
+  - `final class LunationRecapState` — `static let shared`; `init(defaults:)`; `firstCardShownAt`; `markFirstCardShown(now:)` (set-once); `lastActedLunationIndex`; `markActedOn(_:)`; `invitation(forWalkDated:now:) -> Lunation?`
+
+- [ ] **Step 1: Write the failing tests**
+
+`UnitTests/LunationCalendarTests.swift`:
+
+```swift
+import XCTest
+@testable import Pilgrim
+
+final class LunationCalendarTests: XCTestCase {
+
+    func testLunation_boundariesAreContiguous() {
+        let lunation = LunationCalendar.lunation(at: 300)
+        XCTAssertEqual(LunationCalendar.lunation(containing: lunation.start).index, 300)
+        XCTAssertEqual(LunationCalendar.lunation(containing: lunation.end.addingTimeInterval(-1)).index, 300)
+        XCTAssertEqual(LunationCalendar.lunation(containing: lunation.end).index, 301,
+                       "the close instant belongs to the next lunation")
+        XCTAssertEqual(lunation.end, LunationCalendar.lunation(at: 301).start)
+    }
+
+    func testMostRecentClosed_isThePreviousLunation() {
+        let lunation = LunationCalendar.lunation(at: 300)
+        let closed = LunationCalendar.mostRecentClosed(asOf: lunation.start.addingTimeInterval(86400))
+        XCTAssertEqual(closed.index, 299)
+    }
+
+    func testFullMoon_isTheMidpoint() {
+        let lunation = LunationCalendar.lunation(at: 300)
+        XCTAssertEqual(
+            lunation.fullMoon.timeIntervalSince(lunation.start),
+            lunation.end.timeIntervalSince(lunation.fullMoon),
+            accuracy: 1
+        )
+    }
+
+    func testMoonName_derivesFromFullMoonMonthInTimezone() {
+        let nearMonthEdge = Lunation(
+            index: 0,
+            start: DateFactory.makeDate(2024, 8, 17, 11, 0, 0),
+            end: DateFactory.makeDate(2024, 9, 15, 23, 0, 0),
+            fullMoon: DateFactory.makeDate(2024, 8, 31, 23, 0, 0)
+        )
+        XCTAssertEqual(
+            LunationCalendar.moonName(for: nearMonthEdge, in: TimeZone(identifier: "UTC")!),
+            "Sturgeon Moon"
+        )
+        XCTAssertEqual(
+            LunationCalendar.moonName(for: nearMonthEdge, in: TimeZone(identifier: "Pacific/Auckland")!),
+            "Corn Moon",
+            "the same instant is already September in Auckland — the name follows the device's timezone"
+        )
+    }
+
+    func testMoonName_allTwelveMonthsCovered() {
+        for month in 1...12 {
+            let lunation = Lunation(
+                index: 0,
+                start: DateFactory.makeDate(2024, month, 1),
+                end: DateFactory.makeDate(2024, month, 29),
+                fullMoon: DateFactory.makeDate(2024, month, 15, 12, 0, 0)
+            )
+            let name = LunationCalendar.moonName(for: lunation, in: TimeZone(identifier: "UTC")!)
+            XCTAssertTrue(name.hasSuffix("Moon"))
+        }
+    }
+}
+```
+
+`UnitTests/LunationRecapStateTests.swift`:
+
+```swift
+import XCTest
+@testable import Pilgrim
+
+final class LunationRecapStateTests: XCTestCase {
+
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+    private var state: LunationRecapState!
+    private var savedToggle = true
+
+    /// A fixed lunation grid: `closed` = lunation 300, `now` one day after
+    /// it closed, `walkAfter` a walk dated after the boundary.
+    private let closed = LunationCalendar.lunation(at: 300)
+    private var now: Date { closed.end.addingTimeInterval(86400) }
+    private var walkAfter: Date { closed.end.addingTimeInterval(3600) }
+
+    override func setUpWithError() throws {
+        suiteName = "LunationRecapStateTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+        state = LunationRecapState(defaults: defaults)
+        savedToggle = UserPreferences.threadsAfterWalks.value
+        UserPreferences.threadsAfterWalks.value = true
+    }
+
+    override func tearDownWithError() throws {
+        UserPreferences.threadsAfterWalks.value = savedToggle
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    private func showFirstCard(before boundary: Date) {
+        state.markFirstCardShown(now: boundary.addingTimeInterval(-10 * 86400))
+    }
+
+    func testInvitation_requiresFirstCardShown() {
+        XCTAssertNil(state.invitation(forWalkDated: walkAfter, now: now),
+                     "the recap must never be a walker's first contact with the feature")
+        showFirstCard(before: closed.end)
+        XCTAssertNotNil(state.invitation(forWalkDated: walkAfter, now: now))
+    }
+
+    func testInvitation_boundaryInsideBackfilledHistoryNeverInvites() {
+        state.markFirstCardShown(now: closed.end.addingTimeInterval(3600))
+        XCTAssertNil(state.invitation(forWalkDated: walkAfter, now: now),
+                     "a lunation that closed before the first card belongs to backfilled history")
+    }
+
+    func testInvitation_walkDatedBeforeBoundary_neverInvites() {
+        showFirstCard(before: closed.end)
+        XCTAssertNil(state.invitation(
+            forWalkDated: closed.end.addingTimeInterval(-3600), now: now
+        ), "old summaries read the same whenever opened")
+    }
+
+    func testInvitation_reEvaluatesUntilActedOn() {
+        showFirstCard(before: closed.end)
+        XCTAssertNotNil(state.invitation(forWalkDated: walkAfter, now: now))
+        XCTAssertNotNil(state.invitation(forWalkDated: walkAfter, now: now),
+                        "the flag records acted-on, not first opportunity — pending transcriptions don't cost the month")
+        state.markActedOn(closed)
+        XCTAssertNil(state.invitation(forWalkDated: walkAfter, now: now))
+    }
+
+    func testInvitation_nextLunationSupersedes() {
+        showFirstCard(before: closed.end)
+        state.markActedOn(closed)
+        let next = LunationCalendar.lunation(at: 301)
+        let laterNow = next.end.addingTimeInterval(86400)
+        let laterWalk = next.end.addingTimeInterval(3600)
+        XCTAssertEqual(state.invitation(forWalkDated: laterWalk, now: laterNow)?.index, 301,
+                       "acting on one moon never silences the next")
+    }
+
+    func testInvitation_onlyTheMostRecentClosedLunationInvites() {
+        showFirstCard(before: closed.end)
+        let next = LunationCalendar.lunation(at: 301)
+        let laterNow = next.end.addingTimeInterval(86400)
+        XCTAssertEqual(state.invitation(forWalkDated: walkAfter, now: laterNow), nil,
+                       "once the next lunation closes, a walk dated inside the previous one no longer invites — Past recaps keeps it reachable")
+    }
+
+    func testMarkFirstCardShown_setOnce() {
+        let first = DateFactory.makeDate(2026, 8, 1, 9, 0, 0)
+        state.markFirstCardShown(now: first)
+        state.markFirstCardShown(now: first.addingTimeInterval(86400))
+        XCTAssertEqual(state.firstCardShownAt, first)
+    }
+
+    func testInvitation_toggleOffMeansOff() {
+        showFirstCard(before: closed.end)
+        UserPreferences.threadsAfterWalks.value = false
+        XCTAssertNil(state.invitation(forWalkDated: walkAfter, now: now))
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure** (`-only-testing:UnitTests/LunationCalendarTests -only-testing:UnitTests/LunationRecapStateTests`). Expected: FAIL — types don't exist.
+
+- [ ] **Step 3: Implement**
+
+`LunarPhase.swift` — the two constants the calendar needs drop `private` (values unchanged):
+
+```swift
+    static let synodicMonth = 29.53058770576
+    static let knownNewMoon = DateComponents(
+        calendar: .init(identifier: .gregorian),
+        timeZone: TimeZone(identifier: "UTC"),
+        year: 2000, month: 1, day: 6, hour: 18, minute: 14
+    ).date!
+```
+
+`Pilgrim/Models/Threads/LunationCalendar.swift`:
+
+```swift
+import Foundation
+
+/// One synodic month: the stretch between two new-moon instants, indexed
+/// from the same 2000-01-06 reference LunarPhase uses, so phase math and
+/// lunation arithmetic can never disagree.
+struct Lunation: Equatable, Identifiable {
+    let index: Int
+    let start: Date
+    let end: Date
+    let fullMoon: Date
+
+    var id: Int { index }
+}
+
+enum LunationCalendar {
+
+    private static let lunationLength = LunarPhase.synodicMonth * 86400
+
+    /// Every boundary Date is minted by this one expression, so
+    /// `lunation(at: n).end == lunation(at: n + 1).start` holds exactly —
+    /// never `start + length`, which drifts by a ulp and splits boundaries.
+    private static func newMoonDate(at index: Int) -> Date {
+        LunarPhase.knownNewMoon.addingTimeInterval(Double(index) * lunationLength)
+    }
+
+    static func lunation(at index: Int) -> Lunation {
+        Lunation(
+            index: index,
+            start: newMoonDate(at: index),
+            end: newMoonDate(at: index + 1),
+            fullMoon: newMoonDate(at: index).addingTimeInterval(lunationLength / 2)
+        )
+    }
+
+    /// The floor division can land one off at exact boundary instants
+    /// (Double round-off) — the two correction guards make the close
+    /// instant belong to the next lunation, deterministically.
+    static func lunation(containing date: Date) -> Lunation {
+        var index = Int(floor(date.timeIntervalSince(LunarPhase.knownNewMoon) / lunationLength))
+        if date >= newMoonDate(at: index + 1) { index += 1 }
+        if date < newMoonDate(at: index) { index -= 1 }
+        return lunation(at: index)
+    }
+
+    /// The lunation that most recently closed — the only moon that may
+    /// invite. Once the next one closes, the previous moves to Past recaps.
+    static func mostRecentClosed(asOf date: Date) -> Lunation {
+        lunation(at: lunation(containing: date).index - 1)
+    }
+
+    /// Traditional full-moon month names, January through December.
+    static let monthMoonNames = [
+        "Wolf Moon", "Snow Moon", "Worm Moon", "Pink Moon",
+        "Flower Moon", "Strawberry Moon", "Buck Moon", "Sturgeon Moon",
+        "Corn Moon", "Hunter's Moon", "Beaver Moon", "Cold Moon"
+    ]
+
+    /// The moon's name derives from the calendar month of its full-moon
+    /// instant in the given timezone (spec: timezone moon naming) — the
+    /// same set moon can honestly carry different names in Lisbon and
+    /// Auckland, because the walker's sky is the one that counts.
+    static func moonName(for lunation: Lunation, in timeZone: TimeZone = .current) -> String {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        return monthMoonNames[calendar.component(.month, from: lunation.fullMoon) - 1]
+    }
+}
+```
+
+`Pilgrim/Models/Threads/LunationRecapState.swift`:
+
+```swift
+import Foundation
+
+/// Persistence + eligibility for the lunation recap invitation. The acted
+/// flag records "acted on", not "first opportunity" — pending
+/// transcriptions don't cost the walker the month. Ephemeral by design:
+/// loss on reinstall is accepted (unlike the released set, these are
+/// bookkeeping, not walker decisions).
+final class LunationRecapState {
+
+    static let shared = LunationRecapState(defaults: .standard)
+
+    static let firstCardShownKey = "threadsFirstCardShownAt"
+    static let lastActedKey = "threadsRecapLastActedLunation"
+
+    private let defaults: UserDefaults
+
+    init(defaults: UserDefaults) {
+        self.defaults = defaults
+    }
+
+    var firstCardShownAt: Date? {
+        guard let epoch = defaults.object(forKey: Self.firstCardShownKey) as? Double else { return nil }
+        return Date(timeIntervalSince1970: epoch)
+    }
+
+    /// Set once, on the first per-walk card the walker ever sees — the card
+    /// shows its work one walk at a time before any aggregate speaks.
+    func markFirstCardShown(now: Date = Date()) {
+        guard firstCardShownAt == nil else { return }
+        defaults.set(now.timeIntervalSince1970, forKey: Self.firstCardShownKey)
+    }
+
+    var lastActedLunationIndex: Int? {
+        defaults.object(forKey: Self.lastActedKey) as? Int
+    }
+
+    func markActedOn(_ lunation: Lunation) {
+        defaults.set(lunation.index, forKey: Self.lastActedKey)
+    }
+
+    /// The lunation whose set moon may invite from this walk's summary, or
+    /// nil. Re-evaluates on every qualifying post-boundary summary until the
+    /// invitation is tapped or the next lunation closes.
+    func invitation(forWalkDated walkDate: Date, now: Date = Date()) -> Lunation? {
+        guard UserPreferences.threadsAfterWalks.value else { return nil }
+        guard let firstShown = firstCardShownAt else { return nil }
+        let closed = LunationCalendar.mostRecentClosed(asOf: now)
+        guard closed.end > firstShown else { return nil }
+        guard closed.index > (lastActedLunationIndex ?? Int.min) else { return nil }
+        guard walkDate >= closed.end else { return nil }
+        return closed
+    }
+}
+```
+
+`ThreadsCardSection.swift` — the card records the walker's first contact. On the outermost VStack's modifier chain (after `.cornerRadius`):
+
+```swift
+        .onAppear {
+            LunationRecapState.shared.markFirstCardShown()
+        }
+```
+
+- [ ] **Step 4: Run both classes — PASS** (5 + 9 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Models/LunarPhase.swift Pilgrim/Models/Threads/LunationCalendar.swift Pilgrim/Models/Threads/LunationRecapState.swift Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift UnitTests/LunationCalendarTests.swift UnitTests/LunationRecapStateTests.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat(threads): lunation machinery — timezone-named moons, first-card gate, acted-on invitations"
+```
+
+---
+
+### Task 7: The lunation recap — sheet, invitation row, past recaps
+
+**Files:**
+- Create: `Pilgrim/Models/Threads/LunationRecapModel.swift`
+- Create: `Pilgrim/Scenes/WalkSummary/LunationRecapView.swift`
+- Create: `Pilgrim/Scenes/Settings/PastRecapsListView.swift`
+- Modify: `Pilgrim/Models/Data/DataManager.swift` (`voiceRecordingPaceIndex()` next to `voiceRecordingWalkIndex()`)
+- Modify: `Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift` (two `@State`s, one onAppear line, one `.sheet`)
+- Modify: `Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift` (invitation row above the card)
+- Modify: `Pilgrim/Scenes/Settings/SettingsCards/VoiceCard.swift` (Past recaps row)
+- Test: `UnitTests/LunationRecapModelTests.swift`
+
+**Interfaces:**
+- Consumes: Tasks 2, 3 (`ThreadsTexture`), 6; `ThreadHistoryView` (Task 4) for theme tap-through; `DataManager.voiceRecordingWalkIndex()`.
+- Produces:
+  - `struct LunationRecapTheme: Equatable, Identifiable, Hashable` — `{ displayTerm, lemmas, walkCount, isNewThisMoon }`
+  - `struct LunationRecapModel: Equatable` — `{ moonName, walkCount, themes, textureLine, quietLine }`
+  - `LunationRecapCopy.themeLine(term:walkCount:totalWalks:)` ("in N of M walks" — structurally distinct from the card's ordinal copy by design), `.newThisMoon`, `.nothingHeld`, `.noWords`, `.invitation(moonName:)`
+  - `LunationRecapModelBuilder.model(lunation:moonName:contexts:walkIndex:paceByRecording:released:backfillComplete:)` (pure, live-computed at sheet open)
+  - `@MainActor DataManager.voiceRecordingPaceIndex() -> [UUID: Double]` (verify the attribute name `_wordsPerMinute` against PilgrimV7.swift:241 — it is `Value.Optional<Double>("wordsPerMinute")`)
+  - `LunationRecapView(lunation:)` sheet; `PastRecapsListView` + `PastRecapsListView.closedLunations(now:state:)`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+import XCTest
+@testable import Pilgrim
+
+final class LunationRecapModelTests: XCTestCase {
+
+    private let lunation = LunationCalendar.lunation(at: 300)
+
+    private func context(_ uuid: UUID, lemma: String?, insight: Int = 0) -> TranscriptContext {
+        TranscriptContext(
+            schemaVersion: 1, recordingUUID: uuid, transcriptHash: "h",
+            languageCode: "en", wordCount: 200,
+            themes: lemma.map { [Theme(
+                lemma: $0, displayTerm: $0, mentionCount: 3, salience: 0.015,
+                mentions: [ThemeMention(start: 0, length: 4)]
+            )] } ?? [],
+            markers: MarkerPack(
+                wordCount: 200, absolutistCount: 0, firstPersonCount: 0,
+                insightCount: insight, causationCount: 0, discrepancyCount: 0,
+                futureCount: 0, pastCount: 0, sentiment: nil
+            )
+        )
+    }
+
+    private func build(
+        contexts: [TranscriptContext],
+        walkIndex: [UUID: (walkUUID: UUID, date: Date)],
+        paces: [UUID: Double] = [:],
+        released: Set<String> = [],
+        backfillComplete: Bool = true
+    ) -> LunationRecapModel {
+        LunationRecapModelBuilder.model(
+            lunation: lunation, moonName: "Sturgeon Moon",
+            contexts: contexts, walkIndex: walkIndex,
+            paceByRecording: paces, released: released,
+            backfillComplete: backfillComplete
+        )
+    }
+
+    /// Three analyzed walks inside the moon; "move" spoken in two of them.
+    private func fixture() -> (contexts: [TranscriptContext], walkIndex: [UUID: (walkUUID: UUID, date: Date)]) {
+        let recs = [UUID(), UUID(), UUID()]
+        let walks = [UUID(), UUID(), UUID()]
+        let contexts = [
+            context(recs[0], lemma: "move"),
+            context(recs[1], lemma: "move"),
+            context(recs[2], lemma: nil)
+        ]
+        var walkIndex: [UUID: (walkUUID: UUID, date: Date)] = [:]
+        for (offset, rec) in recs.enumerated() {
+            walkIndex[rec] = (walks[offset], lunation.start.addingTimeInterval(Double(offset + 1) * 86400))
+        }
+        return (contexts, walkIndex)
+    }
+
+    func testModel_countsWalksAndThemes() {
+        let (contexts, walkIndex) = fixture()
+        let model = build(contexts: contexts, walkIndex: walkIndex)
+        XCTAssertEqual(model.walkCount, 3)
+        XCTAssertEqual(model.themes.map(\.displayTerm), ["move"])
+        XCTAssertEqual(model.themes.first?.walkCount, 2)
+        XCTAssertNil(model.quietLine)
+    }
+
+    func testThemeLine_countCopyPinned() {
+        XCTAssertEqual(
+            LunationRecapCopy.themeLine(term: "the move", walkCount: 6, totalWalks: 9),
+            "'the move' — walked with you in 6 of 9 walks"
+        )
+        XCTAssertEqual(
+            LunationRecapCopy.themeLine(term: "father", walkCount: 1, totalWalks: 1),
+            "'father' — walked with you in 1 of 1 walks",
+            "a single-walk moon still uses count copy — spec sparse state"
+        )
+    }
+
+    func testScopeDivergence_recapAndCardPhrasingsAreStructurallyDistinct() {
+        let recap = LunationRecapCopy.themeLine(term: "move", walkCount: 3, totalWalks: 4)
+        let card = ThreadsCardCopy.statusNote(for: .recurring(walksInWindow: 3))!
+        XCTAssertTrue(recap.contains("walked with you in"))
+        XCTAssertFalse(card.contains("walked with you in"))
+        XCTAssertTrue(card.hasSuffix("walk now"),
+                      "lunation counts vs trailing-window ordinals must never read as the same metric disagreeing")
+    }
+
+    func testNewThisMoon_gatedOnBackfill() {
+        let (contexts, walkIndex) = fixture()
+        XCTAssertEqual(build(contexts: contexts, walkIndex: walkIndex).themes.first?.isNewThisMoon, true)
+        XCTAssertEqual(
+            build(contexts: contexts, walkIndex: walkIndex, backfillComplete: false).themes.first?.isNewThisMoon,
+            false,
+            "firsts are full-history origin claims — suppressed until backfill completes"
+        )
+    }
+
+    func testNewThisMoon_falseWhenThreadPredatesTheMoon() {
+        var (contexts, walkIndex) = fixture()
+        let earlierRec = UUID()
+        contexts.append(context(earlierRec, lemma: "move"))
+        walkIndex[earlierRec] = (UUID(), lunation.start.addingTimeInterval(-10 * 86400))
+        XCTAssertEqual(build(contexts: contexts, walkIndex: walkIndex).themes.first?.isNewThisMoon, false)
+    }
+
+    func testReleasedFiltering_leavesTheQuietLine() {
+        let (contexts, walkIndex) = fixture()
+        let model = build(contexts: contexts, walkIndex: walkIndex, released: ["move"])
+        XCTAssertTrue(model.themes.isEmpty)
+        XCTAssertEqual(model.walkCount, 3, "the moon's walk count stands even when nothing is named")
+        XCTAssertEqual(model.quietLine, "nothing held on to name this time")
+    }
+
+    func testZeroAnalyzedWalks_hasItsOwnQuietLine() {
+        let model = build(contexts: [], walkIndex: [:])
+        XCTAssertEqual(model.walkCount, 0)
+        XCTAssertEqual(model.quietLine, "no recorded words walked this moon")
+    }
+
+    func testWalksOutsideTheLunation_doNotCount() {
+        let rec = UUID()
+        let walkIndex = [rec: (walkUUID: UUID(), date: lunation.end.addingTimeInterval(3600))]
+        let model = build(contexts: [context(rec, lemma: "move")], walkIndex: walkIndex)
+        XCTAssertEqual(model.walkCount, 0, "the window is [start, end) — the close belongs to the next moon")
+    }
+
+    func testTexture_paceAndInsightFromTheMoonsRecordings() {
+        let (contexts, walkIndex) = fixture()
+        let insightful = contexts.map { original in
+            TranscriptContext(
+                schemaVersion: 1, recordingUUID: original.recordingUUID, transcriptHash: "h",
+                languageCode: "en", wordCount: 200, themes: original.themes,
+                markers: MarkerPack(
+                    wordCount: 200, absolutistCount: 0, firstPersonCount: 0,
+                    insightCount: 2, causationCount: 0, discrepancyCount: 0,
+                    futureCount: 0, pastCount: 0, sentiment: nil
+                )
+            )
+        }
+        let paces = Dictionary(uniqueKeysWithValues: walkIndex.keys.map { ($0, 80.0) })
+        let model = build(contexts: insightful, walkIndex: walkIndex, paces: paces)
+        XCTAssertEqual(model.textureLine, "Spoken slowly, with words of insight.")
+    }
+
+    func testInvitationCopy_pinned() {
+        XCTAssertEqual(
+            LunationRecapCopy.invitation(moonName: "Sturgeon Moon"),
+            "The Sturgeon Moon has set — see what walked with you."
+        )
+    }
+
+    func testClosedLunations_boundedByFirstCard() {
+        let suiteName = "PastRecapsTests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let state = LunationRecapState(defaults: defaults)
+        let now = LunationCalendar.lunation(at: 303).start.addingTimeInterval(86400)
+
+        XCTAssertTrue(PastRecapsListView.closedLunations(now: now, state: state).isEmpty,
+                      "no first card, no reachable moons")
+
+        state.markFirstCardShown(now: LunationCalendar.lunation(at: 300).start.addingTimeInterval(86400))
+        XCTAssertEqual(
+            PastRecapsListView.closedLunations(now: now, state: state).map(\.index),
+            [302, 301, 300],
+            "every moon closed since first contact, newest first — a missed line never costs the month"
+        )
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure** (`-only-testing:UnitTests/LunationRecapModelTests`). Expected: FAIL — types don't exist.
+
+- [ ] **Step 3: Implement the model and copy**
+
+`Pilgrim/Models/Threads/LunationRecapModel.swift`:
+
+```swift
+import Foundation
+
+struct LunationRecapTheme: Equatable, Identifiable, Hashable {
+    let displayTerm: String
+    let lemmas: [String]
+    let walkCount: Int
+    let isNewThisMoon: Bool
+
+    var id: String { displayTerm }
+}
+
+struct LunationRecapModel: Equatable {
+    let moonName: String
+    let walkCount: Int
+    let themes: [LunationRecapTheme]
+    let textureLine: String?
+    let quietLine: String?
+}
+
+enum LunationRecapCopy {
+
+    /// Lunation-scoped counts — deliberately a different sentence shape
+    /// from the card's trailing-window ordinals ("third walk now"), so the
+    /// two scopes never read as the same metric disagreeing. Always
+    /// "walks", even for one (spec sparse state: "in 1 of 1 walks").
+    static func themeLine(term: String, walkCount: Int, totalWalks: Int) -> String {
+        "'\(term)' — walked with you in \(walkCount) of \(totalWalks) walks"
+    }
+
+    static let newThisMoon = "new this moon"
+    static let nothingHeld = "nothing held on to name this time"
+    static let noWords = "no recorded words walked this moon"
+
+    static func invitation(moonName: String) -> String {
+        "The \(moonName) has set — see what walked with you."
+    }
+}
+
+enum LunationRecapModelBuilder {
+
+    static let maxThemes = 6
+    static let insightFloor = 3
+
+    /// Pure and live-computed at sheet open — its counts may exceed the
+    /// invitation moment's, by design. Window is [start, end): the close
+    /// instant belongs to the next moon.
+    static func model(
+        lunation: Lunation,
+        moonName: String,
+        contexts: [TranscriptContext],
+        walkIndex: [UUID: (walkUUID: UUID, date: Date)],
+        paceByRecording: [UUID: Double],
+        released: Set<String>,
+        backfillComplete: Bool
+    ) -> LunationRecapModel {
+        let inMoon: (Date) -> Bool = { $0 >= lunation.start && $0 < lunation.end }
+        let analyzed = Set(contexts.map(\.recordingUUID))
+        let moonRecordings = walkIndex.filter { analyzed.contains($0.key) && inMoon($0.value.date) }
+        let totalWalks = Set(moonRecordings.values.map(\.walkUUID)).count
+
+        guard totalWalks > 0 else {
+            return LunationRecapModel(
+                moonName: moonName, walkCount: 0, themes: [],
+                textureLine: nil, quietLine: LunationRecapCopy.noWords
+            )
+        }
+
+        let threads = ThreadStore.build(contexts: contexts, walks: walkIndex, released: released)
+        let cohorts = Dictionary(
+            grouping: threads.filter { thread in
+                thread.appearances.contains { inMoon($0.date) }
+            },
+            by: \.displayTerm
+        )
+
+        let themes = cohorts
+            .map { term, cohort -> LunationRecapTheme in
+                let appearances = cohort.flatMap(\.appearances)
+                let walkCount = Set(appearances.filter { inMoon($0.date) }.map(\.walkUUID)).count
+                let earliest = appearances.map(\.date).min()
+                return LunationRecapTheme(
+                    displayTerm: term,
+                    lemmas: cohort.map(\.lemma).sorted(),
+                    walkCount: walkCount,
+                    isNewThisMoon: backfillComplete && earliest.map(inMoon) == true
+                )
+            }
+            .sorted { ($0.walkCount, $1.displayTerm) > ($1.walkCount, $0.displayTerm) }
+            .prefix(maxThemes)
+
+        let moonRecordingSet = Set(moonRecordings.keys)
+        let insightTotal = contexts
+            .filter { moonRecordingSet.contains($0.recordingUUID) }
+            .compactMap(\.markers)
+            .reduce(0) { $0 + $1.insightCount }
+        let wpms = moonRecordingSet.compactMap { paceByRecording[$0] }
+        let meanWPM = wpms.isEmpty ? nil : wpms.reduce(0, +) / Double(wpms.count)
+
+        return LunationRecapModel(
+            moonName: moonName,
+            walkCount: totalWalks,
+            themes: Array(themes),
+            textureLine: ThreadsTexture.line(
+                meanWordsPerMinute: meanWPM,
+                hasInsight: insightTotal >= insightFloor
+            ),
+            quietLine: themes.isEmpty ? LunationRecapCopy.nothingHeld : nil
+        )
+    }
+}
+```
+
+In `DataManager.swift`, next to `voiceRecordingWalkIndex()`:
+
+```swift
+    /// Recording UUID → words-per-minute, for the recap's pace texture.
+    /// Main-actor only: `dataStack.fetchAll` asserts Thread.isMainThread.
+    @MainActor
+    public static func voiceRecordingPaceIndex() -> [UUID: Double] {
+        let recordings = (try? dataStack.fetchAll(From<VoiceRecording>())) ?? []
+        var index: [UUID: Double] = [:]
+        for recording in recordings {
+            guard let uuid = recording._uuid.value,
+                  let wpm = recording._wordsPerMinute.value else { continue }
+            index[uuid] = wpm
+        }
+        return index
+    }
+```
+
+- [ ] **Step 4: Implement the sheet and the settings list**
+
+`Pilgrim/Scenes/WalkSummary/LunationRecapView.swift`:
+
+```swift
+import SwiftUI
+
+/// The moon's quiet accounting — pulled, never pushed. Content is computed
+/// live at open; themes tap through to their thread views. Deterministic
+/// template copy; the only digits are the spec-sanctioned "in N of M walks".
+struct LunationRecapView: View {
+
+    let lunation: Lunation
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var model: LunationRecapModel?
+    @State private var selectedTheme: LunationRecapTheme?
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                if let model {
+                    content(model)
+                        .padding(Constants.UI.Padding.normal)
+                }
+            }
+            .canvasBackground()
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .principal) {
+                    Text(model?.moonName ?? "")
+                        .font(Constants.Typography.heading)
+                        .foregroundColor(.ink)
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Done") { dismiss() }
+                        .foregroundColor(.stone)
+                }
+            }
+            .navigationDestination(item: $selectedTheme) { theme in
+                ThreadHistoryView(displayTerm: theme.displayTerm, cohortLemmas: theme.lemmas)
+            }
+            .task { await load() }
+        }
+    }
+
+    private func content(_ model: LunationRecapModel) -> some View {
+        VStack(spacing: Constants.UI.Padding.normal) {
+            Image(systemName: "moon")
+                .font(.title2)
+                .foregroundColor(.fog)
+            Text(model.walkCount == 1 ? "1 walk this moon" : "\(model.walkCount) walks this moon")
+                .font(Constants.Typography.body)
+                .foregroundColor(.ink)
+
+            if let quiet = model.quietLine {
+                Text(quiet)
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog)
+                    .multilineTextAlignment(.center)
+            }
+
+            ForEach(model.themes) { theme in
+                themeRow(theme, totalWalks: model.walkCount)
+            }
+
+            if let texture = model.textureLine {
+                Text(texture)
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog)
+                    .multilineTextAlignment(.center)
+            }
+        }
+    }
+
+    private func themeRow(_ theme: LunationRecapTheme, totalWalks: Int) -> some View {
+        Button {
+            selectedTheme = theme
+        } label: {
+            VStack(alignment: .leading, spacing: Constants.UI.Padding.xs) {
+                Text(LunationRecapCopy.themeLine(
+                    term: theme.displayTerm, walkCount: theme.walkCount, totalWalks: totalWalks
+                ))
+                .font(Constants.Typography.body)
+                .foregroundColor(.ink)
+                .multilineTextAlignment(.leading)
+                if theme.isNewThisMoon {
+                    Text(LunationRecapCopy.newThisMoon)
+                        .font(Constants.Typography.caption)
+                        .foregroundColor(.moss)
+                }
+            }
+            .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+            .padding(Constants.UI.Padding.normal)
+            .background(Color.parchmentSecondary)
+            .cornerRadius(Constants.UI.CornerRadius.normal)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityHint("Double tap to view this thread's history")
+    }
+
+    @MainActor
+    private func load() async {
+        let walkIndex = DataManager.voiceRecordingWalkIndex()
+        let paces = DataManager.voiceRecordingPaceIndex()
+        let released = ReleasedThreadsStore.shared.releasedLemmas
+        let backfillComplete = ThreadsBackfill.isComplete
+        let moonName = LunationCalendar.moonName(for: lunation)
+        let lunation = self.lunation
+
+        model = await Task.detached(priority: .userInitiated) {
+            LunationRecapModelBuilder.model(
+                lunation: lunation, moonName: moonName,
+                contexts: TranscriptContextStore.shared.loadAll(),
+                walkIndex: walkIndex, paceByRecording: paces,
+                released: released, backfillComplete: backfillComplete
+            )
+        }.value
+    }
+}
+```
+
+`Pilgrim/Scenes/Settings/PastRecapsListView.swift`:
+
+```swift
+import SwiftUI
+
+/// Closed moons since the walker's first card, newest first — a missed
+/// invitation line never costs the month. Each row opens the same
+/// live-computed recap sheet.
+struct PastRecapsListView: View {
+
+    @State private var lunations: [Lunation] = PastRecapsListView.closedLunations()
+    @State private var selected: Lunation?
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        return formatter
+    }()
+
+    static func closedLunations(now: Date = Date(), state: LunationRecapState = .shared) -> [Lunation] {
+        guard let firstShown = state.firstCardShownAt else { return [] }
+        var result: [Lunation] = []
+        var index = LunationCalendar.mostRecentClosed(asOf: now).index
+        while index >= 0 {
+            let lunation = LunationCalendar.lunation(at: index)
+            guard lunation.end > firstShown else { break }
+            result.append(lunation)
+            index -= 1
+        }
+        return result
+    }
+
+    var body: some View {
+        List {
+            ForEach(lunations) { lunation in
+                Button {
+                    selected = lunation
+                } label: {
+                    HStack {
+                        Text(LunationCalendar.moonName(for: lunation))
+                            .font(Constants.Typography.body)
+                            .foregroundColor(.ink)
+                        Spacer()
+                        Text(Self.dateFormatter.string(from: lunation.end))
+                            .font(Constants.Typography.caption)
+                            .foregroundColor(.fog)
+                    }
+                    .frame(minHeight: 44)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityHint("Double tap to open this moon's recap")
+                .listRowBackground(Color.parchmentSecondary)
+            }
+        }
+        .scrollContentBackground(.hidden)
+        .canvasBackground()
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                Text("Past recaps")
+                    .font(Constants.Typography.heading)
+                    .foregroundColor(.ink)
+            }
+        }
+        .sheet(item: $selected) { lunation in
+            LunationRecapView(lunation: lunation)
+        }
+    }
+}
+```
+
+- [ ] **Step 5: Wire the invitation row and settings**
+
+1. `WalkSummaryView.swift` — add two `@State`s: `@State var recapInvitation: Lunation?` and `@State var recapSheet: Lunation?`. In `.onAppear` (after `loadReliquaryCandidates()`):
+
+```swift
+                recapInvitation = LunationRecapState.shared.invitation(forWalkDated: walk.startDate)
+```
+
+and after the Task 4 `.sheet(item: $selectedCardTheme)` block:
+
+```swift
+            .sheet(item: $recapSheet) { lunation in
+                LunationRecapView(lunation: lunation)
+            }
+```
+
+2. `WalkSummaryView+Threads.swift` — the invitation renders as its own row below the intention card, above the per-walk card; when the triggering walk has no analyzed transcript, `threadsCardModel` is nil and the row renders alone in the card's slot — placement falls out of the slot order:
+
+```swift
+    @ViewBuilder
+    var threadsCardSlot: some View {
+        if let recapInvitation {
+            lunationInvitationRow(recapInvitation)
+        }
+        if let threadsCardModel {
+            ThreadsCardSection(
+                model: threadsCardModel,
+                onThemeTap: { selectedCardTheme = $0 },
+                onRelease: { releaseTheme($0) }
+            )
+            .transition(.opacity)
+        }
+    }
+
+    func lunationInvitationRow(_ lunation: Lunation) -> some View {
+        Button {
+            LunationRecapState.shared.markActedOn(lunation)
+            recapInvitation = nil
+            recapSheet = lunation
+        } label: {
+            HStack(spacing: Constants.UI.Padding.small) {
+                Image(systemName: "moon")
+                    .font(.caption)
+                    .foregroundColor(.fog)
+                Text(LunationRecapCopy.invitation(
+                    moonName: LunationCalendar.moonName(for: lunation)
+                ))
+                .font(Constants.Typography.caption)
+                .foregroundColor(.ink)
+                .multilineTextAlignment(.leading)
+                Spacer()
+            }
+            .padding(Constants.UI.Padding.normal)
+            .frame(maxWidth: .infinity, minHeight: 44)
+            .background(Color.parchmentSecondary)
+            .cornerRadius(Constants.UI.CornerRadius.normal)
+        }
+        .buttonStyle(.plain)
+        .accessibilityElement(children: .combine)
+        .accessibilityHint("Double tap to open the moon's recap")
+    }
+```
+
+3. `VoiceCard.swift` — add `@State private var hasPastRecaps = !PastRecapsListView.closedLunations().isEmpty`, refresh in `.onAppear`, and add below the Released threads row:
+
+```swift
+            if threadsAfterWalks && hasPastRecaps {
+                NavigationLink {
+                    PastRecapsListView()
+                } label: {
+                    settingNavRow(label: "Past recaps")
+                }
+            }
+```
+
+- [ ] **Step 6: Run `LunationRecapModelTests` (12 tests) then the full suite — PASS** (baseline 1269 + 73: Tasks 1-7 added 14 + 6 + 12 + 9 + 6 + 14 + 12).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add Pilgrim/Models/Threads/LunationRecapModel.swift Pilgrim/Scenes/WalkSummary/LunationRecapView.swift Pilgrim/Scenes/Settings/PastRecapsListView.swift Pilgrim/Models/Data/DataManager.swift Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift Pilgrim/Scenes/Settings/SettingsCards/VoiceCard.swift UnitTests/LunationRecapModelTests.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat(threads): the lunation recap — the moon sets, the month speaks in counts, pulled never pushed"
+```
+
+---
+
+### Task 8: Chips live — the field gate opens
+
+**Files:**
+- Modify: `Pilgrim/Models/Threads/ThreadIntentionSuggestions.swift` (flip `pendingFieldGate`)
+- Modify: `UnitTests/ThreadIntentionSuggestionsTests.swift` (update the pinning test)
+
+**Interfaces:**
+- Consumes: field gate outcome recorded in the spec addendum ("Chips: cleared to ship").
+- Produces: `ThreadIntentionSuggestions.pendingFieldGate == false` — the chips section in `IntentionSettingView` renders for real. No other code changes: the section, the "Recurring" header (IntentionSettingView.swift:137), the `select` engine, and the toggle-off guard all shipped live-but-dark in Stage 2.
+
+- [ ] **Step 1: Update the pinning test first** — in `ThreadIntentionSuggestionsTests.swift`, replace `testCurrent_pendingFieldGate_shipsDark` (lines 118-130) with:
+
+```swift
+    func testFieldGate_passed_chipsAreLive() {
+        XCTAssertFalse(ThreadIntentionSuggestions.pendingFieldGate,
+                       "field gate passed 2026-08-24 (spec addendum) — chips ship live in 1.12.0")
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails** (`-only-testing:UnitTests/ThreadIntentionSuggestionsTests`). Expected: the new test FAILS against the still-true flag; `testCurrent_toggleOff_returnsEmptyWithoutTouchingTheStore` still passes (toggle-off is a separate guard and must survive the flip).
+
+- [ ] **Step 3: Flip the flag** — in `ThreadIntentionSuggestions.swift`, replace the `pendingFieldGate` declaration and its comment:
+
+```swift
+    /// The human field gate passed 2026-08-24 (spec addendum: "Chips:
+    /// cleared to ship") — chips render in IntentionSettingView from 1.12.0.
+    /// The header ships as "Recurring"; a softer-variant copy pass is a
+    /// tracked fast-follow, judged against real chip words.
+    static let pendingFieldGate = false
+```
+
+- [ ] **Step 4: Run the class — PASS.** Verify the header string is committed: `grep -n '"Recurring"' Pilgrim/Scenes/ActiveWalk/IntentionSettingView.swift` returns line 137. Manually verify toggle-off interaction on simulator: Settings → Voice → Thought Threads off → intention sheet shows no Recurring section; on → chips appear once a theme recurs across two walks (demo mode `--demo-mode` seeds enough history).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Models/Threads/ThreadIntentionSuggestions.swift UnitTests/ThreadIntentionSuggestionsTests.swift
+git commit -m "feat(threads): chips live — the field gate opens, walk with what walks with you"
+```
+
+---
+
+### Task 9: Verification + release checklist (no code)
+
+**Files:** none — this task produces evidence and human checkpoints, not code.
+
+- [ ] **Step 1: Full suite reconciliation**
+
+Run: `xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tee /tmp/threads-stage34-suite.log | tail -5`
+Then: `grep -c "Test Case '" /tmp/threads-stage34-suite.log` (started lines count double if the log includes passed lines — reconcile with `xcrun xcresulttool` if in doubt).
+Expected: PASS, and the count reconciles to **1269 + 73 = 1342** started cases (Task 8 replaced one test, net zero). Any shortfall means a test file never joined the UnitTests target — go back to the pbxproj 4-entries check for that file.
+
+- [ ] **Step 2: Privacy grep gates**
+
+```bash
+grep -rn "TranscriptContext\|MarkerPack\|WalkThread" Pilgrim/Models/Share/ Pilgrim/Models/Data/PilgrimPackage/ | grep -v "TranscriptContextStore"
+grep -rn "ReleasedThread\|releasedThreads" Pilgrim/Models/Share/
+grep -rln "ReleasedThread" Pilgrim/Models/Data/PilgrimPackage/
+```
+
+Expected: line 1 and line 2 return **nothing** — derived analysis stays out of shares and exports, and the released set never enters `SharePayload` or the worker. (The `grep -v` allows the importer's pre-existing `TranscriptContextStore.shared.clearTombstones` call at PilgrimPackageImporter.swift:87 — store hygiene, not data egress; no other `TranscriptContext` reference may appear.) Line 3 returns **exactly three files** (`PilgrimPackageModels.swift`, `PilgrimPackageConverter.swift`, `PilgrimPackageImporter.swift`) — the sanctioned preferences-block carve-out and nothing else.
+
+- [ ] **Step 3: UI language gates**
+
+```bash
+grep -rn '"rising"\|"fading"\|"steady"' Pilgrim/Scenes/
+git diff main --stat -- '*Journal*'
+```
+
+Expected: both return nothing — no directional words anywhere in UI, and the journal is untouched (principle 4).
+
+- [ ] **Step 4: Full-repo SwiftLint** — `swiftlint` from the repo root (the pre-commit hook only checks staged files; edited files like `WalkSummaryView.swift` and `AttentionDirectives.swift` may have crossed a length threshold mid-plan). Expected: zero errors. If `WalkSummaryView`'s type body approaches 750, move members to `WalkSummaryView+Threads.swift` — never raise the limit.
+
+- [ ] **Step 5: Manual smoke on simulator (iPhone 17 Pro, demo mode)**
+
+1. Launch with `--demo-mode`, open a Camino walk summary with transcripts: the card appears below the intention card, chips carry ordinal statuses, no digits anywhere on the card.
+2. Tap a chip → thread view, newest first, "where it began" on the oldest, "open the map" opens the origin map centered on the pin.
+3. Long-press a chip → confirm reads exactly "Let 'X' go? / You can welcome it back anytime." → release → card reflows (or fades out entirely when it was the last theme); reopen the AI-prompts sheet → the released term is gone from the dossier on this very open.
+4. Settings → Voice: "Released threads" row appeared; welcome the theme back; the row hides again once empty.
+5. Toggle Thought Threads off → summary is pixel-identical to a card-less build; intention sheet shows no chips; both settings rows hidden.
+6. VoiceOver pass: each chip is one element announcing "theme, status", hint "Double tap to view history", custom action "Let this go"; Dynamic Type at AX sizes wraps chips, never truncates.
+7. Lunation: temporarily set the device clock forward past the next new moon (or seed `threadsFirstCardShownAt` back one lunation via the debugger) → a summary for a walk dated after the boundary shows the invitation row; an older walk's summary does not; tapping opens the recap; the row never returns after acting; Settings → Voice → Past recaps reaches the same sheet.
+
+- [ ] **Step 6: RELEASE checklist — human checkpoints (STOP here; these gate distribution, not merge)**
+
+1. **Internal TestFlight first.** Build 1.12.0 goes to the internal group only. No public TestFlight, no App Store submission yet.
+2. **LLM-readback QA (release gate from the spec addendum, still PENDING):** the walker/product owner pastes representative REAL dossiers from the internal build — including elevated absolutist/self-focus profiles — into the major consumer LLMs and iterates `PromptAssembler.responseContract`'s handling note until no response contains clinical or diagnostic language. This is a human judgment task on real data; it cannot be pre-verified by this plan.
+3. **Gentleness pass on the confirm strings:** the walker/product owner reads `ReleasedThreadsCopy` on-device (release, welcome-back, caption) and adjusts wording in that one file if anything reads clinical or abrupt; update `ReleasedThreadsInteractionTests` in the same commit if strings change.
+4. Only after 2 and 3 pass: public TestFlight / App Store submission per `scripts/release.sh` and the `/release` skill. Remember: TestFlight dispatch requires the user's explicit go-ahead — never trigger `gh workflow run testflight.yml` from this plan.
+
+---
+
+## Verification (whole plan)
+
+- [ ] Full suite green at 1342 cases (Task 9 Step 1 evidence attached to the PR).
+- [ ] All grep gates clean (Task 9 Steps 2-3 output attached).
+- [ ] SwiftLint clean, full repo.
+- [ ] Manual smoke checklist completed on iPhone 17 Pro simulator.
+- [ ] Release checkpoints acknowledged as OPEN items in the PR description — the branch merges; 1.12.0 does not ship externally until the LLM-readback QA and gentleness pass are recorded.
+
+## Spec coverage map (addendum behavior → task)
+
+| Spec addendum behavior | Task |
+|---|---|
+| Filtering call graph: ThreadStore.build drops released; recurringWord skip promotes next; intentionEcho exempt | T2 |
+| Lemma-cohort release + atomic welcome-back | T1 (store) + T3 (cohort assembly) + T5 (UI) |
+| Released set's own change token folded into dossier + suggestions memo keys; release visible on next open | T1 + T2 |
+| `.pilgrim` preferences-block carve-out (export, import merge, old-file tolerance) | T1 |
+| Delete All Data clears releases | T1 |
+| Confirm copy exact strings, leads with reversibility | T5 |
+| Mid-view transitions: card fades/reflows; thread view pops | T5 |
+| VoiceOver custom action "Let this go" (gesture parity, not gesture-only) | T5 |
+| One-time dismissible caption on first card appearance | T5 |
+| Settings "Released threads" hidden-when-empty, welcome-back confirm | T5 |
+| Card below intention card; transcribed+themes only; otherwise pixel-identical | T3 |
+| Top-4 salience themes, first-time/nth-walk ordinal statuses, backfill-gated origin claims | T3 |
+| State-only texture line (pace mechanical from wpm; insight words traceable on tap) | T3 |
+| Card accessibility: wrap, single VoiceOver element per chip, 44 pt targets | T3 (+T4 hint, +T5 action) |
+| Thread view: full history newest-first, date/place/excerpt, tap-through to summary | T4 |
+| Excerpt slicing from mention offsets, grapheme-safe, hash-guarded | T4 |
+| "Where it began" label + origin map (route-sample-nearest-timestamp, 120 s tolerance, hide on failure, resolve at open) | T4 |
+| Deleted origin walk → earliest surviving appearance becomes the origin | T4 (record-derived, nothing persisted) |
+| Timezone moon naming (month of full-moon instant, device timezone) | T6 |
+| Lunation boundary index pinned to LunarPhase's reference | T6 |
+| First-card-shown marker; backfilled-history boundaries never invite | T6 |
+| Acted-on (not first-opportunity) invitation state; re-evaluates until tapped or superseded | T6 |
+| Walk-dated invitations — never on historical summaries | T6 (eligibility) + T7 (row) |
+| Invitation row placement: own row below intention card, above per-walk card; renders alone when walk unanalyzed | T7 |
+| Recap live-computed at open; counts may exceed invitation moment's | T7 |
+| Recap content: moon name, walk count, "in N of M walks" themes tappable to thread view, new-this-moon firsts, texture line | T7 |
+| No directional language in recap; released filtered | T7 (via T2) + T9 grep |
+| Sparse states: "in 1 of 1 walks"; "nothing held on to name this time"; zero-walk moon | T7 |
+| Scope-divergence phrasing (lunation counts vs trailing-window ordinals, structurally distinct) | T7 (pinned test) |
+| Past recaps settings list, hidden-when-empty, missed line never costs the month | T7 |
+| Accessibility extends to recap sheet + both settings lists | T7 (rows) + T5 (list) |
+| Chips live: pendingFieldGate → false; header ships "Recurring"; softer variant is a fast-follow | T8 |
+| Toggle off = off everywhere (card, thread nav, chips, invitation, settings rows) | T3/T4/T5/T6/T7 guards + T9 smoke |
+| Rollout: internal TF first; LLM-readback QA + gentleness pass gate external release | T9 |

--- a/docs/superpowers/plans/2026-08-24-thought-threads-stage3-4.md
+++ b/docs/superpowers/plans/2026-08-24-thought-threads-stage3-4.md
@@ -4,22 +4,22 @@
 
 **Goal:** The engine earns its surfaces. Stage 3+4 ships the "What walked with you" card, the thread history view with excerpts and the origin map, "Let this one go" releases with a `.pilgrim` carve-out, the lunation recap with its walk-dated invitation, and flips the intention chips live — everything specified in `docs/superpowers/specs/2026-08-22-thought-threads-design.md` "### Stage 3 — card + thread view" and the whole "## Stage 3+4 addendum (2026-08-24)".
 
-**Architecture:** All new logic lives as pure model builders in `Pilgrim/Models/Threads/` (testable without UI), with thin SwiftUI files in `Pilgrim/Scenes/WalkSummary/` and `Pilgrim/Scenes/Settings/`. `ThreadStore.build` gains a released-lemma filter parameter — the single choke point covering card, thread view, dossier trajectories, quiet-this-walk lines, intention chips, and the recap; `AttentionDirectives.recurringWord` gets the one bypass-path skip. The released set is a new UserDefaults-backed store with its own change token, cleared by Delete All Data, and round-tripped through the `.pilgrim` preferences block (the sanctioned carve-out). Lunation machinery extends `LunarPhase`'s existing constants. Nothing touches the CoreStore schema, `SharePayload`, or the network.
+**Architecture:** All new logic lives as pure model builders in `Pilgrim/Models/Threads/` (testable without UI), with thin SwiftUI files in `Pilgrim/Scenes/WalkSummary/` and `Pilgrim/Scenes/Settings/`. `ThreadStore.build` gains a released-lemma filter parameter — the single choke point covering card, thread view, dossier trajectories, quiet-this-walk lines, intention chips, and the recap; `AttentionDirectives.recurringWord` gets the one bypass-path skip. The released set is a new UserDefaults-backed store with its own change token, cleared by Delete All Data, and round-tripped through the `.pilgrim` preferences block (the sanctioned carve-out); welcome-backs are recorded as decisions too, so import merge is latest-decision-wins per cohort and a stale backup can never silently override a walker's later reversal. Lunation machinery extends `LunarPhase`'s existing constants. Nothing touches the CoreStore schema, `SharePayload`, or the network.
 
 **Tech Stack:** Swift, SwiftUI, CoreStore (reads only, existing helpers), CoreLocation (route-sample lookup + reverse geocoding), Mapbox via the existing `PilgrimMapView`, XCTest.
 
 ## Global Constraints
 
 - iOS 18 minimum; no new dependencies; no CoreStore schema changes (`PilgrimV7` stays current). Frozen identifiers stay frozen: `_workout`, `"workout"`, `"Workout"` etc. are SQL names — never "fix" them.
-- Nothing leaves the device. The released set's ONLY egress is the `.pilgrim` preferences block (spec: scoped carve-out, `zodiacSystem` precedent — the lemmas already appear verbatim in exported transcripts). `TranscriptContext`, `MarkerPack`, and `WalkThread` never appear in `Pilgrim/Models/Share/` or `Pilgrim/Models/Data/PilgrimPackage/`; `ReleasedThread` appears in `PilgrimPackage` only in the three sanctioned carve-out sites (models field, converter mapping, importer merge). Task 9's grep gates enforce exactly this.
+- Nothing leaves the device. The released set's ONLY egress is the `.pilgrim` preferences block (spec: scoped carve-out, `zodiacSystem` precedent — the lemmas already appear verbatim in exported transcripts). `TranscriptContext`, `MarkerPack`, and `WalkThread` never appear in `Pilgrim/Models/Share/` or `Pilgrim/Models/Data/PilgrimPackage/`; `ReleasedThread`/`WelcomedBackThread` appear in `PilgrimPackage` only in the three sanctioned carve-out sites (models field, converter mapping, importer merge — the released list and the welcome-back list travel together so latest-decision-wins merge works across backups). Task 9's grep gates enforce exactly this.
 - The journal is untouched — no file under any Journal scene changes in this plan.
-- **No directional words in UI** ("rising", "fading", trend talk) and no metric digits in card/status copy. Ordinal words ("third walk now") and dates are fine. Digits are allowed ONLY where the spec sanctions them: the recap's "in N of M walks" counts and thread-view dates.
+- **No directional words in UI** ("rising", "fading", trend talk) and no metric digits in card/status copy. Ordinal words ("third walk now") and dates are fine. Digits are allowed ONLY where the spec sanctions them: the recap's "in N of M walks" counts, the recap headline's walks-with-recorded-words count ("3 walks with recorded words this moon" — scoped so it never reads as the journal's walk total disagreeing), and thread-view dates.
 - `threadsAfterWalks` off means off everywhere: card, thread navigation, chips, recap invitation, and both settings rows all gate on it.
 - Deterministic output everywhere: same inputs, same UI. Ties break by the existing `recurringWord` convention (highest count, then alphabetical).
 - **pbxproj, the 4-entries lesson:** every new Swift file needs FOUR entries in `Pilgrim.xcodeproj/project.pbxproj` — a `PBXBuildFile`, a `PBXFileReference`, a children entry in the right `PBXGroup`, and a `PBXSourcesBuildPhase` entry in the right target (app files → `Pilgrim` target, test files → `UnitTests` target). Copy the entry pattern of a sibling file in the same group. A file missing any one of the four compiles on your machine and breaks the build for everyone else.
 - Test command (per class): `xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/<ClassName> 2>&1 | tail -20`
-- **Suite reconciliation:** the pre-plan full-suite baseline is **1269** "Test Case '...' started" lines. After each task, the delta must equal the tests you added (count via `grep -c "Test Case '" <log>` or `xcrun xcresulttool`). A test file that silently never joined the target is exactly the failure mode this reconciliation catches.
-- Comment policy: self-documenting code; comments only for constraints code can't show. SwiftLint errors at 750 lines/type and 60 lines/function — keep new SwiftUI in focused files; WalkSummary additions go in a `WalkSummaryView+Threads.swift` extension (the `+Map.swift` pattern), with only `@State` declarations added to the main struct.
+- **Suite reconciliation:** the pre-plan full-suite baseline is **1269** "Test Case '...' started" lines. After each task, the delta must equal the tests you added (count via `grep -c "Test Case '.*' started" <log>` — anchor on `started`; the unanchored form also matches the passed/failed lines and counts roughly double — or `xcrun xcresulttool`). A test file that silently never joined the target is exactly the failure mode this reconciliation catches.
+- Comment policy: self-documenting code; comments only for constraints code can't show. SwiftLint errors at 750 lines/type and 100 lines/function (60 lines/function is only a warning) — keep new SwiftUI in focused files; WalkSummary additions go in a `WalkSummaryView+Threads.swift` extension (the `+Map.swift` pattern), with only `@State` declarations and one-line slots added to the main struct. `WalkSummaryView`'s main struct already sits ~669 lines against the 750 error ceiling: Tasks 3, 4, and 7 each run `swiftlint lint Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift` after touching it, so a crossing is caught in the task that caused it, not at Task 9.
 - The custom `ProgressView` shadows SwiftUI's — qualify as `SwiftUI.ProgressView` if ever needed.
 - Typography: `Constants.Typography.*` only. Spacing: `Constants.UI.Padding.*`. Colors: the wabi-sabi palette (ink, fog, moss, stone, parchment, dawn).
 - CoreStore fetches assert main-thread: every `DataManager.*Index()`/`*Snapshot()` call happens on the main actor; detached tasks receive plain values.
@@ -34,17 +34,19 @@
 - Modify: `Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageConverter.swift` (`buildManifest` export + `releasedThreads(from:)` import mapping)
 - Modify: `Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageImporter.swift` (`DecodedPackage` field + merge on import success)
 - Modify: `Pilgrim/Models/Data/DataManager.swift` (seam + `deleteAll` clearing hook)
-- Test: `UnitTests/ReleasedThreadsStoreTests.swift`, `UnitTests/ReleasedThreadsPackageTests.swift`, extend `UnitTests/DataManagerThreadsDeletionTests.swift`
+- Test: `UnitTests/ReleasedThreadsStoreTests.swift`, `UnitTests/ReleasedThreadsPackageTests.swift`, extend `UnitTests/DataManagerThreadsDeletionTests.swift`, extend `UnitTests/PilgrimPackageExporterArchivedTests.swift` (setUp clear only — the new buildManifest defaults read the test host's standard defaults)
 
 **Interfaces:**
 - Consumes: `UserDefaults`, `PilgrimDateCoding` (existing `.secondsSince1970` manifest coding), `DataManager.deleteAll` success path (DataManager.swift:842-859), `PilgrimPackageImporter.importPackage` success hook (PilgrimPackageImporter.swift:84-92).
 - Produces (used by Tasks 2, 3, 5, 7):
   - `struct ReleasedThread: Codable, Equatable` — `{ displayTerm: String, lemmas: [String], releasedAt: Date }`
-  - `final class ReleasedThreadsStore` — `static let shared`; `init(defaults: UserDefaults)`; `var changeCount: Int` (session memo token, bumps on every mutation); `var all: [ReleasedThread]` (releasedAt-descending, term-ascending); `var releasedLemmas: Set<String>`; `var isEmpty: Bool`; `func release(displayTerm:lemmas:releasedAt:)` (merges cohorts for an already-released term); `func welcomeBack(displayTerm:)` (removes the cohort atomically); `func merge(_:)` (import union, earliest date wins); `func clear()` (Delete All hook)
+  - `struct WelcomedBackThread: Codable, Equatable` — `{ displayTerm: String, welcomedBackAt: Date }` (a welcome-back is a decision too — recorded so import merge can apply latest-decision-wins; this is what makes the spec's reversibility promise survive backups)
+  - `final class ReleasedThreadsStore` — `static let shared`; `init(defaults: UserDefaults)`; `var changeCount: Int` (session memo token, bumps on every mutation); `var all: [ReleasedThread]` (releasedAt-descending, term-ascending); `var welcomedBack: [WelcomedBackThread]` (term-ascending, for export); `var releasedLemmas: Set<String>`; `var isEmpty: Bool` (released list only — the settings row keys off it); `func release(displayTerm:lemmas:releasedAt:)` (merges cohorts for an already-released term, clears the term's welcome-back record); `func welcomeBack(displayTerm:at:)` (removes the cohort atomically, records the decision with its date); `func merge(released:welcomedBack:)` (import merge, latest decision wins per cohort — an imported release older than a local welcome-back does NOT re-release, and vice versa; two releases union lemmas keeping the earlier date so repeated imports stay stable); `func clear()` (Delete All hook, clears both lists)
   - `struct PilgrimReleasedThread: Codable` — `{ term: String, lemmas: [String], releasedAt: Date }`
-  - `PilgrimPreferences.releasedThreads: [PilgrimReleasedThread]?` (nil-defaulted init parameter — every existing construction site compiles unchanged; old `.pilgrim` files decode nil; old importers ignore the unknown key)
-  - `PilgrimPackageConverter.releasedThreads(from: PilgrimPreferences) -> [ReleasedThread]`
-  - `DecodedPackage.releasedThreads: [ReleasedThread]`
+  - `struct PilgrimWelcomedBackThread: Codable` — `{ term: String, welcomedBackAt: Date }`
+  - `PilgrimPreferences.releasedThreads: [PilgrimReleasedThread]?` + `PilgrimPreferences.welcomedBackThreads: [PilgrimWelcomedBackThread]?` (nil-defaulted init parameters — every existing construction site compiles unchanged; old `.pilgrim` files decode nil; old importers ignore the unknown keys)
+  - `PilgrimPackageConverter.releasedThreads(from: PilgrimPreferences) -> [ReleasedThread]` + `.welcomedBackThreads(from:) -> [WelcomedBackThread]`
+  - `DecodedPackage.releasedThreads: [ReleasedThread]` + `.welcomedBackThreads: [WelcomedBackThread]`
   - `DataManager.releasedThreadsStore: ReleasedThreadsStore` (test seam, defaults `.shared`)
 
 - [ ] **Step 1: Write the failing tests**
@@ -120,21 +122,45 @@ final class ReleasedThreadsStoreTests: XCTestCase {
 
     func testMerge_unionsByTermKeepingEarliestDate() {
         store.release(displayTerm: "the move", lemmas: ["move"], releasedAt: released)
-        store.merge([
+        store.merge(released: [
             ReleasedThread(displayTerm: "the move", lemmas: ["moving"],
                            releasedAt: released.addingTimeInterval(-86400)),
             ReleasedThread(displayTerm: "father", lemmas: ["father"], releasedAt: released)
-        ])
+        ], welcomedBack: [])
         XCTAssertEqual(Set(store.all.map(\.displayTerm)), ["the move", "father"])
         let move = store.all.first { $0.displayTerm == "the move" }
         XCTAssertEqual(move?.lemmas, ["move", "moving"])
         XCTAssertEqual(move?.releasedAt, released.addingTimeInterval(-86400))
     }
 
+    func testMerge_staleImportedRelease_doesNotUndoWelcomeBack() {
+        store.release(displayTerm: "father", lemmas: ["father"], releasedAt: released)
+        store.welcomeBack(displayTerm: "father", at: released.addingTimeInterval(7 * 86400))
+        store.merge(released: [
+            ReleasedThread(displayTerm: "father", lemmas: ["father"], releasedAt: released)
+        ], welcomedBack: [])
+        XCTAssertTrue(store.all.isEmpty,
+                      "the walker's welcome-back is the later decision — importing an old backup never silently re-releases")
+        XCTAssertEqual(store.welcomedBack.map(\.displayTerm), ["father"])
+    }
+
+    func testMerge_staleImportedWelcomeBack_doesNotUndoRelease() {
+        store.release(displayTerm: "father", lemmas: ["father"], releasedAt: released)
+        store.merge(released: [], welcomedBack: [
+            WelcomedBackThread(displayTerm: "father",
+                               welcomedBackAt: released.addingTimeInterval(-86400))
+        ])
+        XCTAssertEqual(store.all.map(\.displayTerm), ["father"],
+                       "released again after that welcome-back — the newer local release stands")
+    }
+
     func testClear_emptiesEverything() {
         store.release(displayTerm: "a", lemmas: ["a"], releasedAt: released)
+        store.welcomeBack(displayTerm: "a")
+        store.release(displayTerm: "b", lemmas: ["b"], releasedAt: released)
         store.clear()
         XCTAssertTrue(store.isEmpty)
+        XCTAssertTrue(store.welcomedBack.isEmpty)
         XCTAssertTrue(ReleasedThreadsStore(defaults: defaults).isEmpty)
     }
 }
@@ -150,24 +176,35 @@ final class ReleasedThreadsPackageTests: XCTestCase {
 
     private let released = DateFactory.makeDate(2026, 8, 20, 9, 0, 0)
 
-    private func preferences(releasedThreads: [PilgrimReleasedThread]?) -> PilgrimPreferences {
+    private func preferences(
+        releasedThreads: [PilgrimReleasedThread]?,
+        welcomedBack: [PilgrimWelcomedBackThread]? = nil
+    ) -> PilgrimPreferences {
         PilgrimPreferences(
             distanceUnit: "km", altitudeUnit: "m", speedUnit: "km/h", energyUnit: "kJ",
             celestialAwareness: false, zodiacSystem: "tropical", beginWithIntention: false,
-            releasedThreads: releasedThreads
+            releasedThreads: releasedThreads,
+            welcomedBackThreads: welcomedBack
         )
     }
 
     func testPreferences_roundTripWithReleasedThreads() throws {
-        let original = preferences(releasedThreads: [
-            PilgrimReleasedThread(term: "the move", lemmas: ["move", "moving"], releasedAt: released)
-        ])
+        let original = preferences(
+            releasedThreads: [
+                PilgrimReleasedThread(term: "the move", lemmas: ["move", "moving"], releasedAt: released)
+            ],
+            welcomedBack: [
+                PilgrimWelcomedBackThread(term: "father", welcomedBackAt: released)
+            ]
+        )
         let data = try PilgrimDateCoding.makeEncoder().encode(original)
         let decoded = try PilgrimDateCoding.makeDecoder().decode(PilgrimPreferences.self, from: data)
         XCTAssertEqual(decoded.releasedThreads?.count, 1)
         XCTAssertEqual(decoded.releasedThreads?[0].term, "the move")
         XCTAssertEqual(decoded.releasedThreads?[0].lemmas, ["move", "moving"])
         XCTAssertEqual(decoded.releasedThreads?[0].releasedAt, released)
+        XCTAssertEqual(decoded.welcomedBackThreads?.map(\.term), ["father"])
+        XCTAssertEqual(decoded.welcomedBackThreads?.first?.welcomedBackAt, released)
     }
 
     func testPreferences_oldJSONWithoutKey_decodesNil() throws {
@@ -178,25 +215,30 @@ final class ReleasedThreadsPackageTests: XCTestCase {
         let decoded = try PilgrimDateCoding.makeDecoder()
             .decode(PilgrimPreferences.self, from: Data(old.utf8))
         XCTAssertNil(decoded.releasedThreads)
+        XCTAssertNil(decoded.welcomedBackThreads)
     }
 
     func testBuildManifest_mapsReleasedThreads() {
         let manifest = PilgrimPackageConverter.buildManifest(
             walkCount: 0, events: [],
-            releasedThreads: [ReleasedThread(displayTerm: "the move", lemmas: ["move"], releasedAt: released)]
+            releasedThreads: [ReleasedThread(displayTerm: "the move", lemmas: ["move"], releasedAt: released)],
+            welcomedBackThreads: [WelcomedBackThread(displayTerm: "father", welcomedBackAt: released)]
         )
         XCTAssertEqual(manifest.preferences.releasedThreads?.map(\.term), ["the move"])
         XCTAssertEqual(manifest.preferences.releasedThreads?.first?.releasedAt, released)
+        XCTAssertEqual(manifest.preferences.welcomedBackThreads?.map(\.term), ["father"])
     }
 
     func testBuildManifest_emptyReleasedSet_omitsKey() throws {
         let manifest = PilgrimPackageConverter.buildManifest(
-            walkCount: 0, events: [], releasedThreads: []
+            walkCount: 0, events: [], releasedThreads: [], welcomedBackThreads: []
         )
         XCTAssertNil(manifest.preferences.releasedThreads)
+        XCTAssertNil(manifest.preferences.welcomedBackThreads)
         let json = String(decoding: try PilgrimDateCoding.makeEncoder().encode(manifest), as: UTF8.self)
         XCTAssertFalse(json.contains("releasedThreads"),
                        "a walker who released nothing exports a byte-identical preferences block")
+        XCTAssertFalse(json.contains("welcomedBackThreads"))
     }
 
     func testImportMapping_fromPreferences() {
@@ -207,6 +249,14 @@ final class ReleasedThreadsPackageTests: XCTestCase {
             ReleasedThread(displayTerm: "father", lemmas: ["father"], releasedAt: released)
         ])
         XCTAssertEqual(PilgrimPackageConverter.releasedThreads(from: preferences(releasedThreads: nil)), [])
+        XCTAssertEqual(
+            PilgrimPackageConverter.welcomedBackThreads(from: preferences(
+                releasedThreads: nil,
+                welcomedBack: [PilgrimWelcomedBackThread(term: "father", welcomedBackAt: released)]
+            )),
+            [WelcomedBackThread(displayTerm: "father", welcomedBackAt: released)]
+        )
+        XCTAssertEqual(PilgrimPackageConverter.welcomedBackThreads(from: preferences(releasedThreads: nil)), [])
     }
 }
 ```
@@ -256,16 +306,26 @@ struct ReleasedThread: Codable, Equatable {
     let releasedAt: Date
 }
 
-/// UserDefaults-persisted released set. Releases are walker decisions, not
-/// derived analysis — they survive relaunch, ride in the `.pilgrim`
-/// preferences block (the sanctioned carve-out), and Delete All Data clears
-/// them with everything else. Analysis and stored contexts are untouched by
-/// release, so it is fully reversible.
+/// A welcome-back is a decision too, recorded with its date so import merge
+/// can honor whichever decision came last. Without the record, a stale
+/// backup's release would silently override the walker's later reversal —
+/// the spec's reversibility promise has to survive backups.
+struct WelcomedBackThread: Codable, Equatable {
+    let displayTerm: String
+    let welcomedBackAt: Date
+}
+
+/// UserDefaults-persisted released set. Releases and welcome-backs are
+/// walker decisions, not derived analysis — they survive relaunch, ride in
+/// the `.pilgrim` preferences block (the sanctioned carve-out), and Delete
+/// All Data clears them with everything else. Analysis and stored contexts
+/// are untouched by release, so it is fully reversible.
 final class ReleasedThreadsStore {
 
     static let shared = ReleasedThreadsStore(defaults: .standard)
 
     static let defaultsKey = "releasedThreads"
+    static let welcomedBackKey = "welcomedBackThreads"
 
     private let defaults: UserDefaults
     private let lock = NSLock()
@@ -288,7 +348,15 @@ final class ReleasedThreadsStore {
     var all: [ReleasedThread] {
         lock.lock()
         defer { lock.unlock() }
-        return load()
+        return loadReleased()
+    }
+
+    /// Welcome-back records, term-ascending — exported beside the released
+    /// list so import merge can compare decisions by date.
+    var welcomedBack: [WelcomedBackThread] {
+        lock.lock()
+        defer { lock.unlock() }
+        return loadWelcomedBack()
     }
 
     var releasedLemmas: Set<String> {
@@ -298,7 +366,8 @@ final class ReleasedThreadsStore {
     var isEmpty: Bool { all.isEmpty }
 
     func release(displayTerm: String, lemmas: [String], releasedAt: Date = Date()) {
-        mutate { entries in
+        mutate { entries, welcomes in
+            welcomes.removeAll { $0.displayTerm == displayTerm }
             if let index = entries.firstIndex(where: { $0.displayTerm == displayTerm }) {
                 entries[index] = ReleasedThread(
                     displayTerm: displayTerm,
@@ -313,19 +382,29 @@ final class ReleasedThreadsStore {
         }
     }
 
-    func welcomeBack(displayTerm: String) {
-        mutate { entries in
+    func welcomeBack(displayTerm: String, at date: Date = Date()) {
+        mutate { entries, welcomes in
             entries.removeAll { $0.displayTerm == displayTerm }
+            welcomes.removeAll { $0.displayTerm == displayTerm }
+            welcomes.append(WelcomedBackThread(displayTerm: displayTerm, welcomedBackAt: date))
         }
     }
 
-    /// Import merge: a union of decisions, never an overwrite — releases made
-    /// on this device and releases carried in the package both stand. The
-    /// earlier release date wins so repeated imports stay stable.
-    func merge(_ imported: [ReleasedThread]) {
-        guard !imported.isEmpty else { return }
-        mutate { entries in
-            for thread in imported {
+    /// Import merge: latest decision wins, per cohort. Two releases union
+    /// their lemmas and keep the earlier date so repeated imports stay
+    /// stable; a release and a welcome-back for the same term are compared
+    /// by date and the older decision yields. On a tie the local state
+    /// stands — re-importing the same package is a no-op.
+    func merge(released importedReleased: [ReleasedThread],
+               welcomedBack importedWelcomedBack: [WelcomedBackThread]) {
+        guard !importedReleased.isEmpty || !importedWelcomedBack.isEmpty else { return }
+        mutate { entries, welcomes in
+            for thread in importedReleased {
+                if let welcome = welcomes.first(where: { $0.displayTerm == thread.displayTerm }),
+                   welcome.welcomedBackAt >= thread.releasedAt {
+                    continue // the walker's welcome-back is the later decision — never silently re-release
+                }
+                welcomes.removeAll { $0.displayTerm == thread.displayTerm }
                 if let index = entries.firstIndex(where: { $0.displayTerm == thread.displayTerm }) {
                     entries[index] = ReleasedThread(
                         displayTerm: thread.displayTerm,
@@ -336,31 +415,58 @@ final class ReleasedThreadsStore {
                     entries.append(thread)
                 }
             }
+            for welcome in importedWelcomedBack {
+                if let entry = entries.first(where: { $0.displayTerm == welcome.displayTerm }),
+                   entry.releasedAt >= welcome.welcomedBackAt {
+                    continue // released again after that welcome-back — the newer release stands
+                }
+                entries.removeAll { $0.displayTerm == welcome.displayTerm }
+                if let index = welcomes.firstIndex(where: { $0.displayTerm == welcome.displayTerm }) {
+                    welcomes[index] = WelcomedBackThread(
+                        displayTerm: welcome.displayTerm,
+                        welcomedBackAt: max(welcomes[index].welcomedBackAt, welcome.welcomedBackAt)
+                    )
+                } else {
+                    welcomes.append(welcome)
+                }
+            }
         }
     }
 
     /// Delete All Data hook — walker decisions clear with everything else.
     func clear() {
-        mutate { entries in
+        mutate { entries, welcomes in
             entries.removeAll()
+            welcomes.removeAll()
         }
     }
 
-    private func mutate(_ body: (inout [ReleasedThread]) -> Void) {
+    private func mutate(_ body: (inout [ReleasedThread], inout [WelcomedBackThread]) -> Void) {
         lock.lock()
         defer { lock.unlock() }
-        var entries = load()
-        body(&entries)
+        var entries = loadReleased()
+        var welcomes = loadWelcomedBack()
+        body(&entries, &welcomes)
         entries.sort { ($0.releasedAt, $1.displayTerm) > ($1.releasedAt, $0.displayTerm) }
+        welcomes.sort { $0.displayTerm < $1.displayTerm }
         if let data = try? JSONEncoder().encode(entries) {
             defaults.set(data, forKey: Self.defaultsKey)
+        }
+        if let data = try? JSONEncoder().encode(welcomes) {
+            defaults.set(data, forKey: Self.welcomedBackKey)
         }
         _changeCount += 1
     }
 
-    private func load() -> [ReleasedThread] {
+    private func loadReleased() -> [ReleasedThread] {
         guard let data = defaults.data(forKey: Self.defaultsKey),
               let entries = try? JSONDecoder().decode([ReleasedThread].self, from: data) else { return [] }
+        return entries
+    }
+
+    private func loadWelcomedBack() -> [WelcomedBackThread] {
+        guard let data = defaults.data(forKey: Self.welcomedBackKey),
+              let entries = try? JSONDecoder().decode([WelcomedBackThread].self, from: data) else { return [] }
         return entries
     }
 }
@@ -381,9 +487,13 @@ struct PilgrimPreferences: Codable {
     let beginWithIntention: Bool
     /// Released thought threads — the one sanctioned derived-data carve-out
     /// (walker decisions, like zodiacSystem; the lemmas already appear
-    /// verbatim in the exported transcripts). Optional so pre-1.12 files
-    /// decode and pre-1.12 importers ignore the unknown key.
+    /// verbatim in the exported transcripts). Welcome-backs ride beside the
+    /// releases: both are decisions, and import merge compares them by date
+    /// so a stale backup's release can never override a later reversal.
+    /// Optional so pre-1.12 files decode and pre-1.12 importers ignore the
+    /// unknown keys.
     let releasedThreads: [PilgrimReleasedThread]?
+    let welcomedBackThreads: [PilgrimWelcomedBackThread]?
 
     init(
         distanceUnit: String,
@@ -393,7 +503,8 @@ struct PilgrimPreferences: Codable {
         celestialAwareness: Bool,
         zodiacSystem: String,
         beginWithIntention: Bool,
-        releasedThreads: [PilgrimReleasedThread]? = nil
+        releasedThreads: [PilgrimReleasedThread]? = nil,
+        welcomedBackThreads: [PilgrimWelcomedBackThread]? = nil
     ) {
         self.distanceUnit = distanceUnit
         self.altitudeUnit = altitudeUnit
@@ -403,6 +514,7 @@ struct PilgrimPreferences: Codable {
         self.zodiacSystem = zodiacSystem
         self.beginWithIntention = beginWithIntention
         self.releasedThreads = releasedThreads
+        self.welcomedBackThreads = welcomedBackThreads
     }
 }
 
@@ -411,16 +523,22 @@ struct PilgrimReleasedThread: Codable {
     let lemmas: [String]
     let releasedAt: Date
 }
+
+struct PilgrimWelcomedBackThread: Codable {
+    let term: String
+    let welcomedBackAt: Date
+}
 ```
 
-2. `PilgrimPackageConverter.swift` — in `buildManifest` (line 241), add a defaulted parameter and pass the mapped field into the `PilgrimPreferences(...)` construction (line 252):
+2. `PilgrimPackageConverter.swift` — in `buildManifest` (line 241), add two defaulted parameters and pass the mapped fields into the `PilgrimPreferences(...)` construction (line 252):
 
 ```swift
     static func buildManifest(
         walkCount: Int,
         events: [PilgrimEvent],
         archivedEntries: [PilgrimArchivedWalk] = [],
-        releasedThreads: [ReleasedThread] = ReleasedThreadsStore.shared.all
+        releasedThreads: [ReleasedThread] = ReleasedThreadsStore.shared.all,
+        welcomedBackThreads: [WelcomedBackThread] = ReleasedThreadsStore.shared.welcomedBack
     ) -> PilgrimManifest {
 ```
 
@@ -430,10 +548,13 @@ and inside, extend the existing `PilgrimPreferences(` construction with:
             beginWithIntention: UserPreferences.beginWithIntention.value,
             releasedThreads: releasedThreads.isEmpty ? nil : releasedThreads.map {
                 PilgrimReleasedThread(term: $0.displayTerm, lemmas: $0.lemmas, releasedAt: $0.releasedAt)
+            },
+            welcomedBackThreads: welcomedBackThreads.isEmpty ? nil : welcomedBackThreads.map {
+                PilgrimWelcomedBackThread(term: $0.displayTerm, welcomedBackAt: $0.welcomedBackAt)
             }
 ```
 
-Add the import mapping helper next to `convertEvents(_:)`:
+Add the import mapping helpers next to `convertEvents(_:)`:
 
 ```swift
     /// Import-side mapping for the released-threads carve-out. Pure, so the
@@ -443,19 +564,28 @@ Add the import mapping helper next to `convertEvents(_:)`:
             ReleasedThread(displayTerm: $0.term, lemmas: $0.lemmas, releasedAt: $0.releasedAt)
         }
     }
+
+    static func welcomedBackThreads(from preferences: PilgrimPreferences) -> [WelcomedBackThread] {
+        (preferences.welcomedBackThreads ?? []).map {
+            WelcomedBackThread(displayTerm: $0.term, welcomedBackAt: $0.welcomedBackAt)
+        }
+    }
 ```
 
-3. `PilgrimPackageImporter.swift` — add `let releasedThreads: [ReleasedThread]` to `DecodedPackage` (line 54), populate it in `unpackAndDecode`'s final `DecodedPackage(...)` construction with `releasedThreads: PilgrimPackageConverter.releasedThreads(from: manifest.preferences)`, and in the `importPackage` success hook (line 86) add the merge between the tombstone clear and the backfill reset:
+3. `PilgrimPackageImporter.swift` — add `let releasedThreads: [ReleasedThread]` and `let welcomedBackThreads: [WelcomedBackThread]` to `DecodedPackage` (line 54), populate them in `unpackAndDecode`'s final `DecodedPackage(...)` construction with `releasedThreads: PilgrimPackageConverter.releasedThreads(from: manifest.preferences)` and `welcomedBackThreads: PilgrimPackageConverter.welcomedBackThreads(from: manifest.preferences)`, and in the `importPackage` success hook (line 86) add the merge between the tombstone clear and the backfill reset:
 
 ```swift
                         if case .success = result {
                             TranscriptContextStore.shared.clearTombstones(for: importedRecordingUUIDs)
-                            ReleasedThreadsStore.shared.merge(package.releasedThreads)
+                            ReleasedThreadsStore.shared.merge(
+                                released: package.releasedThreads,
+                                welcomedBack: package.welcomedBackThreads
+                            )
                             ThreadsBackfill.reset()
                         }
 ```
 
-Any test fixture constructing `DecodedPackage` directly gains `releasedThreads: []`.
+Any test fixture constructing `DecodedPackage` directly gains `releasedThreads: [], welcomedBackThreads: []`.
 
 4. `DataManager.swift` — add the seam next to the existing `transcriptContextStore` seam:
 
@@ -472,16 +602,23 @@ and in `deleteAll`'s `.success` branch (line 844-855), after `UserPreferences.cl
 
 The call sits in the transaction-success completion, preserving the Data Safety rule: walker decisions are only cleared once the database wipe committed.
 
-- [ ] **Step 5: Run all three test classes — PASS**
+5. `UnitTests/PilgrimPackageExporterArchivedTests.swift` — `buildManifest`'s new defaults read `ReleasedThreadsStore.shared`, i.e. the test host's persistent standard defaults. Add (or extend) `setUpWithError` in that class so a simulator that dogfooded a release can't inject `releasedThreads` into these manifests:
 
-Run: `xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/ReleasedThreadsStoreTests -only-testing:UnitTests/ReleasedThreadsPackageTests -only-testing:UnitTests/DataManagerThreadsDeletionTests 2>&1 | tail -20`
-Expected: PASS — 8 + 5 new tests, plus the existing DataManagerThreadsDeletionTests still green.
+```swift
+        UserDefaults.standard.removeObject(forKey: ReleasedThreadsStore.defaultsKey)
+        UserDefaults.standard.removeObject(forKey: ReleasedThreadsStore.welcomedBackKey)
+```
+
+- [ ] **Step 5: Run the test classes — PASS**
+
+Run: `xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/ReleasedThreadsStoreTests -only-testing:UnitTests/ReleasedThreadsPackageTests -only-testing:UnitTests/DataManagerThreadsDeletionTests -only-testing:UnitTests/PilgrimPackageExporterArchivedTests 2>&1 | tail -20`
+Expected: PASS — 10 + 5 new tests plus the new deleteAll clearing test, and the existing DataManagerThreadsDeletionTests / PilgrimPackageExporterArchivedTests still green.
 
 - [ ] **Step 6: Commit**
 
 ```bash
-git add Pilgrim/Models/Threads/ReleasedThreadsStore.swift Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageModels.swift Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageConverter.swift Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageImporter.swift Pilgrim/Models/Data/DataManager.swift UnitTests/ReleasedThreadsStoreTests.swift UnitTests/ReleasedThreadsPackageTests.swift UnitTests/DataManagerThreadsDeletionTests.swift Pilgrim.xcodeproj/project.pbxproj
-git commit -m "feat(threads): released set — cohort releases, Delete All clearing, .pilgrim carve-out"
+git add Pilgrim/Models/Threads/ReleasedThreadsStore.swift Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageModels.swift Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageConverter.swift Pilgrim/Models/Data/PilgrimPackage/PilgrimPackageImporter.swift Pilgrim/Models/Data/DataManager.swift UnitTests/ReleasedThreadsStoreTests.swift UnitTests/ReleasedThreadsPackageTests.swift UnitTests/DataManagerThreadsDeletionTests.swift UnitTests/PilgrimPackageExporterArchivedTests.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat(threads): released set — cohort releases, latest-decision-wins merge, Delete All clearing, .pilgrim carve-out"
 ```
 
 ---
@@ -492,8 +629,8 @@ git commit -m "feat(threads): released set — cohort releases, Delete All clear
 - Modify: `Pilgrim/Models/Threads/ThreadStore.swift` (`build` gains `released` parameter)
 - Modify: `Pilgrim/Models/Prompt/AttentionDirectives.swift` (`detect` + `recurringWord` gain the released skip)
 - Modify: `Pilgrim/Models/Threads/ThreadsDossierBuilder.swift` (released filter + memo token)
-- Modify: `Pilgrim/Models/Threads/ThreadIntentionSuggestions.swift` (released filter + memo token)
-- Test: `UnitTests/ThreadsReleaseFilteringTests.swift`
+- Modify: `Pilgrim/Models/Threads/ThreadIntentionSuggestions.swift` (released filter + memo token + injectable walkIndex)
+- Test: `UnitTests/ThreadsReleaseFilteringTests.swift`, extend `UnitTests/AttentionDirectivesTests.swift` (setUp clear only — the new detect default reads the test host's standard defaults)
 
 **Interfaces:**
 - Consumes: `ReleasedThreadsStore` (Task 1); existing `ThreadStore` / `AttentionDirectives` / builder / suggestions surfaces.
@@ -501,7 +638,7 @@ git commit -m "feat(threads): released set — cohort releases, Delete All clear
   - `ThreadStore.build(contexts:walks:released:)` — `released: Set<String> = []`; a released lemma founds no thread, covering card, thread view, dossier trajectories, quiet-this-walk lines, chips, and the recap in one place.
   - `AttentionDirectives.detect(context:detectedLanguageCode:releasedLemmas:)` — `releasedLemmas: Set<String> = ReleasedThreadsStore.shared.releasedLemmas`; only `recurringWord` consumes it (the one surfacing path that bypasses ThreadStore); the next-ranked candidate is promoted. `intentionEcho` is deliberately exempt — it only quotes words from the walker's own stated intention.
   - `ThreadsDossierBuilder.build(walkUUID:recordings:walkIndex:store:releasedStore:)` — memo key now includes the released store's change token.
-  - `ThreadIntentionSuggestions.current(asOf:store:releasedStore:)` — same token in its memo key.
+  - `ThreadIntentionSuggestions.current(asOf:store:releasedStore:walkIndex:)` — same token in its memo key; `walkIndex` is injectable (nil = live CoreStore index) so Task 8's wiring test can drive `current()` end to end.
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -633,7 +770,7 @@ final class ThreadsReleaseFilteringTests: XCTestCase {
         let filtered = ThreadStore.build(contexts: contexts, walks: walks, released: ["move"])
         XCTAssertTrue(ThreadIntentionSuggestions.select(
             threads: filtered, asOf: base.addingTimeInterval(6 * 86400)
-        ).isEmpty, "chips read the same filtered aggregation as everything else")
+        ).isEmpty, "select over release-filtered threads yields nothing — ranking only; the async current() wiring is pinned by Task 8's testCurrent_releaseVisibleOnNextCall")
     }
 }
 ```
@@ -798,11 +935,14 @@ In `ThreadIntentionSuggestions.swift`, replace the memo declaration and `current
     static func current(
         asOf: Date = Date(),
         store: TranscriptContextStore = .shared,
-        releasedStore: ReleasedThreadsStore = .shared
+        releasedStore: ReleasedThreadsStore = .shared,
+        walkIndex: [UUID: (walkUUID: UUID, date: Date)]? = nil
     ) async -> [String] {
         guard !pendingFieldGate else { return [] }
         guard UserPreferences.threadsAfterWalks.value else { return [] }
-        let walkIndex = DataManager.voiceRecordingWalkIndex()
+        // walkIndex is injectable for Task 8's wiring test; production
+        // callers pass nil and read the live CoreStore index on the main actor.
+        let walkIndex = walkIndex ?? DataManager.voiceRecordingWalkIndex()
         guard !walkIndex.isEmpty else { return [] }
 
         let day = Calendar.current.startOfDay(for: asOf)
@@ -830,13 +970,20 @@ In `ThreadIntentionSuggestions.swift`, replace the memo declaration and `current
 
 - [ ] **Step 6: Run the new class, then the neighbors it touched**
 
+First, in `UnitTests/AttentionDirectivesTests.swift`, add (or extend) `setUpWithError` with the same two-key clear as Task 1's exporter tests — `detect`'s new default reads `ReleasedThreadsStore.shared` from the test host's persistent standard defaults, and a simulator that dogfooded a release would otherwise flake the recurring-word assertions non-reproducibly:
+
+```swift
+        UserDefaults.standard.removeObject(forKey: ReleasedThreadsStore.defaultsKey)
+        UserDefaults.standard.removeObject(forKey: ReleasedThreadsStore.welcomedBackKey)
+```
+
 Run: `xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/ThreadsReleaseFilteringTests -only-testing:UnitTests/ThreadStoreTests -only-testing:UnitTests/ThreadsDossierTests -only-testing:UnitTests/ThreadIntentionSuggestionsTests -only-testing:UnitTests/AttentionDirectivesTests 2>&1 | tail -20`
 Expected: PASS — 6 new tests; every pre-existing test in the four neighbor classes untouched by the defaulted parameters.
 
 - [ ] **Step 7: Commit**
 
 ```bash
-git add Pilgrim/Models/Threads/ThreadStore.swift Pilgrim/Models/Prompt/AttentionDirectives.swift Pilgrim/Models/Threads/ThreadsDossierBuilder.swift Pilgrim/Models/Threads/ThreadIntentionSuggestions.swift UnitTests/ThreadsReleaseFilteringTests.swift Pilgrim.xcodeproj/project.pbxproj
+git add Pilgrim/Models/Threads/ThreadStore.swift Pilgrim/Models/Prompt/AttentionDirectives.swift Pilgrim/Models/Threads/ThreadsDossierBuilder.swift Pilgrim/Models/Threads/ThreadIntentionSuggestions.swift UnitTests/ThreadsReleaseFilteringTests.swift UnitTests/AttentionDirectivesTests.swift Pilgrim.xcodeproj/project.pbxproj
 git commit -m "feat(threads): released cohorts vanish everywhere — one ThreadStore filter, one recurringWord skip, tokened memos"
 ```
 
@@ -849,7 +996,7 @@ git commit -m "feat(threads): released cohorts vanish everywhere — one ThreadS
 - Create: `Pilgrim/Models/Threads/ThreadsCardModel.swift`
 - Create: `Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift`
 - Create: `Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift`
-- Modify: `Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift` (one `@State`, one slot in the VStack, one `.task`, `transcriptions` drops `private`)
+- Modify: `Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift` (one `@State`, one slot in the VStack, one `.task`, `transcriptions` drops `private`, init gains a `showsThreadsCard` recursion-cut flag)
 - Test: `UnitTests/ThreadsCardModelTests.swift`
 
 **Interfaces:**
@@ -929,11 +1076,15 @@ final class ThreadsCardModelTests: XCTestCase {
     func testModel_topFourBySalienceDeterministicTies() {
         let walk = UUID()
         let recordings = (0..<5).map { _ in UUID() }
-        let lemmas = ["alder", "birch", "cedar", "dawn", "elm"]
+        // "elm" is built BEFORE "dawn" and the two tie exactly on mentions
+        // and salience — the top-4 cut is decided by the alphabetical
+        // tie-break, not insertion order.
+        let lemmas = ["alder", "birch", "cedar", "elm", "dawn"]
+        let mentionCounts = [5, 4, 3, 2, 2]
         let threads = lemmas.enumerated().map { index, lemma in
             WalkThread(lemma: lemma, displayTerm: lemma, appearances: [
                 appearance(recording: recordings[index], walk: walk, date: base,
-                           mentions: 5 - index, salience: Double(5 - index) / 200)
+                           mentions: mentionCounts[index], salience: Double(mentionCounts[index]) / 200)
             ])
         }
         let contexts = Dictionary(uniqueKeysWithValues: recordings.map { ($0, context($0)) })
@@ -943,7 +1094,7 @@ final class ThreadsCardModelTests: XCTestCase {
             contextsByRecording: contexts, backfillComplete: true
         )
         XCTAssertEqual(model?.themes.map(\.displayTerm), ["alder", "birch", "cedar", "dawn"],
-                       "top four by salience; the fifth theme waits in the thread view")
+                       "top four by salience; 'dawn' and 'elm' tie exactly and the alphabetical tie-break keeps 'dawn'")
     }
 
     func testModel_cohortMergesSharedDisplayTerm() {
@@ -987,6 +1138,27 @@ final class ThreadsCardModelTests: XCTestCase {
         )
         XCTAssertEqual(model?.themes.first?.statusNote, "second walk now",
                        "a first-time claim is only true if NO lemma in the cohort appeared earlier")
+    }
+
+    func testCohortLemmas_includeSiblingsAbsentFromThisWalk() {
+        let walk = UUID()
+        let recNow = UUID()
+        let threads = [
+            WalkThread(lemma: "move", displayTerm: "the move", appearances: [
+                appearance(recording: recNow, walk: walk, date: base, mentions: 3, salience: 0.015)
+            ]),
+            WalkThread(lemma: "moving", displayTerm: "the move", appearances: [
+                appearance(recording: UUID(), walk: UUID(),
+                           date: base.addingTimeInterval(-10 * 86400), mentions: 2, salience: 0.01)
+            ])
+        ]
+        let model = ThreadsCardModelBuilder.model(
+            walkUUID: walk, threads: threads,
+            recordings: [(uuid: recNow, transcript: "w", wordsPerMinute: nil)],
+            contextsByRecording: [recNow: context(recNow)], backfillComplete: true
+        )
+        XCTAssertEqual(model?.themes.first?.lemmas, ["move", "moving"],
+                       "release acts on every lemma sharing the display term — including a sibling with no appearance in this walk")
     }
 
     func testModel_noActiveThreads_returnsNil() {
@@ -1165,15 +1337,16 @@ enum ThreadsCardModelBuilder {
         contextsByRecording: [UUID: TranscriptContext],
         backfillComplete: Bool
     ) -> ThreadsCardModel? {
-        let active = threads.filter { thread in
-            thread.appearances.contains { $0.walkUUID == walkUUID }
-        }
-        guard !active.isEmpty else { return nil }
-
         // Two lemmas can share a display term (move/moving → "the move"):
-        // one chip per term, and release later acts on the whole cohort,
-        // so the cohort is assembled here.
-        let cohorts = Dictionary(grouping: active, by: \.displayTerm)
+        // one chip per term, and release later acts on the whole cohort. The
+        // grouping runs over ALL threads first — a sibling lemma whose
+        // appearances are all in earlier walks still joins its cohort, so
+        // status history and release lemma sets stay cohort-complete — and
+        // only cohorts present in this walk keep a chip. mentions/salience
+        // below filter to walkUUID, so ranking is unaffected.
+        let cohorts = Dictionary(grouping: threads, by: \.displayTerm)
+            .filter { $0.value.contains { $0.appearances.contains { $0.walkUUID == walkUUID } } }
+        guard !cohorts.isEmpty else { return nil }
 
         let totalWords = recordings
             .compactMap { contextsByRecording[$0.uuid]?.wordCount }
@@ -1238,7 +1411,7 @@ enum ThreadsCardModelBuilder {
 }
 ```
 
-- [ ] **Step 5: Run the model tests — PASS** (`-only-testing:UnitTests/ThreadsCardModelTests`, expected 12 tests).
+- [ ] **Step 5: Run the model tests — PASS** (`-only-testing:UnitTests/ThreadsCardModelTests`, expected 13 tests).
 
 - [ ] **Step 6: Implement the card view and loader**
 
@@ -1383,12 +1556,13 @@ extension WalkSummaryView {
 
     @ViewBuilder
     var threadsCardSlot: some View {
-        if let threadsCardModel {
+        if showsThreadsCard, let threadsCardModel {
             ThreadsCardSection(model: threadsCardModel)
         }
     }
 
     func loadThreadsCard() async {
+        guard showsThreadsCard else { return }
         threadsCardModel = await ThreadsCardLoader.load(walk: walk, transcriptions: transcriptions)
     }
 }
@@ -1396,9 +1570,10 @@ extension WalkSummaryView {
 
 In `WalkSummaryView.swift`:
 1. The `@State private var transcriptions` declaration (line 18) drops `private` (the extension file needs it — same pattern as the camera state, see the comment at lines 36-38): `@State var transcriptions: [UUID: String] = [:]`
-2. Add below the other `@State` declarations: `@State var threadsCardModel: ThreadsCardModel?`
-3. In the body's `VStack`, directly below `intentionCard` (line 80): `threadsCardSlot`
-4. On the `ScrollView` modifier chain, after the `.onReceive(CollectiveRouteCatalogService.shared.$catalog)` block:
+2. The init gains a recursion-cut flag: `init(walk: WalkInterface, showsThreadsCard: Bool = true)`, storing `let showsThreadsCard: Bool` next to `let walk` and assigning it first in the init body. Every existing call site compiles unchanged via the default. Tap-through summaries presented from `ThreadHistoryView` pass `false` (Task 4): without it, summary → card chip → thread view → entry row → summary recurses unboundedly, and every stacked level is a full Mapbox-bearing `WalkSummaryView` with route caches — exactly the compounding-memory pattern the resource-safety doctrine forbids. The flag cuts the cycle at one level.
+3. Add below the other `@State` declarations: `@State var threadsCardModel: ThreadsCardModel?`
+4. In the body's `VStack`, directly below `intentionCard` (line 80): `threadsCardSlot`
+5. On the `ScrollView` modifier chain, after the `.onReceive(CollectiveRouteCatalogService.shared.$catalog)` block:
 
 ```swift
             .task(id: transcriptions.count) {
@@ -1411,7 +1586,8 @@ In `WalkSummaryView.swift`:
 - [ ] **Step 7: Build the app target, run the full UnitTests suite**
 
 Run: `xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests 2>&1 | tail -5`
-Expected: PASS; "Test Case '" count = 1269 + 32 (Tasks 1-3 tests: 14 + 6 + 12).
+Expected: PASS; `grep -c "Test Case '.*' started"` count = 1269 + 35 (Tasks 1-3 tests: 16 + 6 + 13).
+Then: `swiftlint lint Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift` — zero errors; the struct sits ~669/750 against type_body_length, so this task's additions to the main struct stay limited to the init flag, `@State` declarations, and one-line slots (everything else lives in the extension file).
 
 - [ ] **Step 8: Commit**
 
@@ -1433,10 +1609,10 @@ git commit -m "feat(threads): the card — what walked with you, in ordinal word
 - Test: `UnitTests/ThreadHistoryModelTests.swift`
 
 **Interfaces:**
-- Consumes: `ThreadStore.build(contexts:walks:released:)` (Task 2), `ThemeMention` character offsets (Character/grapheme counts, produced via `text.distance` in `TranscriptNLP`), `TranscriptContextStore.hash(of:)`, `DataManager.transcribedRecordingsSnapshot()` / `.voiceRecordingWalkIndex()` (both `@MainActor`), `DataManager.dataStack.fetchOne(From<Walk>().where(\._uuid == uuid))` (the WalkSummaryView idiom, line 325), `WalkSummaryView.computeSegments(for:)`, `PilgrimMapView` (all-defaults init, `initialCamera: MapCameraSeed.Seed`), `PilgrimAnnotation.Kind.voiceRecording(label:)`, `WalkSummaryView(walk:)` presented via `.sheet(item:)` (Walk is Identifiable — the RecordingsListView idiom, line 55).
+- Consumes: `ThreadStore.build(contexts:walks:released:)` (Task 2), `ThreadsBackfill.isComplete` (origin claims are suppressed pre-backfill, exactly like the card's first-time status), `ThemeMention` character offsets (Character/grapheme counts, produced via `text.distance` in `TranscriptNLP`), `TranscriptContextStore.hash(of:)`, `DataManager.transcribedRecordingsSnapshot()` / `.voiceRecordingWalkIndex()` (both `@MainActor`), `DataManager.dataStack.fetchOne(From<Walk>().where(\._uuid == uuid))` (the WalkSummaryView idiom, line 325), `WalkSummaryView.computeSegments(for:)`, `PilgrimMapView` (all-defaults init, `initialCamera: MapCameraSeed.Seed`), `PilgrimAnnotation.Kind.voiceRecording(label:)`, `WalkSummaryView(walk:showsThreadsCard:)` presented via `.sheet(item:)` (Walk is Identifiable — the RecordingsListView idiom, line 55; tap-through summaries pass `showsThreadsCard: false`, the Task 3 recursion cut).
 - Produces (used by Tasks 5, 7):
   - `struct ThreadHistoryEntry: Equatable` — `{ recordingUUID: UUID, walkUUID: UUID, date: Date, excerpt: String?, isOrigin: Bool }`
-  - `ThreadHistoryModelBuilder.entries(cohort:contextsByRecording:transcriptsByRecording:) -> [ThreadHistoryEntry]` (newest first, oldest flagged origin)
+  - `ThreadHistoryModelBuilder.entries(cohort:contextsByRecording:transcriptsByRecording:backfillComplete:) -> [ThreadHistoryEntry]` (newest first; oldest flagged origin ONLY when backfill is complete — no entry carries `isOrigin` pre-backfill, which hides both the footer and the origin-map action)
   - `ThreadHistoryModelBuilder.excerpt(for:context:transcript:)` / `.slice(_:around:radius:)` (grapheme-safe)
   - `ThreadOriginResolver.coordinate(recordingStart:samples:) -> CLLocationCoordinate2D?` (nearest route sample within `tolerance` = 120 s)
   - `ThreadHistoryView(displayTerm:cohortLemmas:)` (pushed inside a NavigationStack)
@@ -1464,11 +1640,26 @@ final class ThreadHistoryModelTests: XCTestCase {
             appearance(recording: $1, walk: UUID(), date: base.addingTimeInterval(Double($0) * 86400))
         })
         let entries = ThreadHistoryModelBuilder.entries(
-            cohort: [thread], contextsByRecording: [:], transcriptsByRecording: [:]
+            cohort: [thread], contextsByRecording: [:], transcriptsByRecording: [:],
+            backfillComplete: true
         )
         XCTAssertEqual(entries.map(\.recordingUUID), [recs[2], recs[1], recs[0]])
         XCTAssertEqual(entries.map(\.isOrigin), [false, false, true],
                        "the oldest entry carries 'where it began'")
+    }
+
+    func testEntries_backfillIncomplete_suppressesOrigin() {
+        let recs = [UUID(), UUID()]
+        let thread = WalkThread(lemma: "move", displayTerm: "the move", appearances: recs.enumerated().map {
+            appearance(recording: $1, walk: UUID(), date: base.addingTimeInterval(Double($0) * 86400))
+        })
+        let entries = ThreadHistoryModelBuilder.entries(
+            cohort: [thread], contextsByRecording: [:], transcriptsByRecording: [:],
+            backfillComplete: false
+        )
+        XCTAssertEqual(entries.count, 2)
+        XCTAssertTrue(entries.allSatisfy { !$0.isOrigin },
+                      "origin claims stay suppressed pre-backfill — no 'where it began' footer, no origin-map action")
     }
 
     func testEntries_onePerRecordingAcrossCohort() {
@@ -1480,7 +1671,8 @@ final class ThreadHistoryModelTests: XCTestCase {
                        appearances: [appearance(recording: rec, walk: walk, date: base, mentions: 2)])
         ]
         let entries = ThreadHistoryModelBuilder.entries(
-            cohort: cohort, contextsByRecording: [:], transcriptsByRecording: [:]
+            cohort: cohort, contextsByRecording: [:], transcriptsByRecording: [:],
+            backfillComplete: true
         )
         XCTAssertEqual(entries.count, 1, "two cohort lemmas in one recording is still one moment")
     }
@@ -1548,6 +1740,15 @@ final class ThreadHistoryModelTests: XCTestCase {
         XCTAssertFalse(atStart!.hasPrefix("…"), "no leading ellipsis when the slice reaches the start")
     }
 
+    func testSlice_noWhitespaceWindow_degeneratesToBareEllipsis() {
+        let transcript = String(repeating: "a", count: 200)
+        let excerpt = ThreadHistoryModelBuilder.slice(
+            transcript, around: ThemeMention(start: 100, length: 5), radius: 30
+        )
+        XCTAssertEqual(excerpt, "…",
+                       "a truncated window with no whitespace trims to a bare ellipsis — pinned so any future formatting change is deliberate, not accidental")
+    }
+
     func testOriginResolver_toleranceBoundary() {
         let start = base
         let sample: (Date) -> (timestamp: Date, latitude: Double, longitude: Double) = {
@@ -1599,13 +1800,18 @@ enum ThreadHistoryModelBuilder {
 
     static let excerptRadius = 60
 
-    /// Newest first; the oldest entry carries the origin label. One entry
-    /// per recording — when two cohort lemmas appear in the same recording,
-    /// the strongest theme (mention count, then lemma) provides the excerpt.
+    /// Newest first; the oldest entry carries the origin label — but only
+    /// once the one-time backfill has completed. Until then "where it began"
+    /// would be a claim about walks not yet analyzed, so origin flags are
+    /// suppressed rather than risked (spec), hiding both the footer and the
+    /// origin-map action. One entry per recording — when two cohort lemmas
+    /// appear in the same recording, the strongest theme (mention count,
+    /// then lemma) provides the excerpt.
     static func entries(
         cohort: [WalkThread],
         contextsByRecording: [UUID: TranscriptContext],
-        transcriptsByRecording: [UUID: String]
+        transcriptsByRecording: [UUID: String],
+        backfillComplete: Bool
     ) -> [ThreadHistoryEntry] {
         let lemmas = Set(cohort.map(\.lemma))
         let appearancesByRecording = Dictionary(
@@ -1632,6 +1838,7 @@ enum ThreadHistoryModelBuilder {
             .sorted { ($0.date, $0.recordingUUID.uuidString) > ($1.date, $1.recordingUUID.uuidString) }
 
         guard let oldest = sorted.last else { return [] }
+        guard backfillComplete else { return sorted }
         return Array(sorted.dropLast()) + [ThreadHistoryEntry(
             recordingUUID: oldest.recordingUUID,
             walkUUID: oldest.walkUUID,
@@ -1706,7 +1913,7 @@ enum ThreadOriginResolver {
 }
 ```
 
-- [ ] **Step 4: Run the model tests — PASS** (`-only-testing:UnitTests/ThreadHistoryModelTests`, expected 9 tests).
+- [ ] **Step 4: Run the model tests — PASS** (`-only-testing:UnitTests/ThreadHistoryModelTests`, expected 11 tests).
 
 - [ ] **Step 5: Implement the view**
 
@@ -1718,28 +1925,41 @@ import CoreStore
 import CoreLocation
 
 /// Best-effort reverse geocoding of each walk's starting point — resolved
-/// once per walk, capped per screen so a long history cannot hammer the
-/// geocoder; a missing place simply doesn't render.
+/// once per walk, capped per screen, and strictly serialized: CLGeocoder
+/// fails a pending request when a new one is submitted, so concurrent
+/// per-row requests would silently lose most place names. One FIFO Task
+/// awaits each lookup before starting the next; a missing place simply
+/// doesn't render. The Task handle is cancelled when the view disappears.
 @MainActor
 final class ThreadPlaceResolver: ObservableObject {
 
     @Published private(set) var places: [UUID: String] = [:]
-    private var requested: Set<UUID> = []
     private let geocoder = CLGeocoder()
+    private var resolveTask: Task<Void, Never>?
     private static let maxResolutions = 12
 
-    func resolve(walkUUID: UUID) {
-        guard !requested.contains(walkUUID), requested.count < Self.maxResolutions else { return }
-        requested.insert(walkUUID)
-        guard let walk = try? DataManager.dataStack.fetchOne(
-            From<Walk>().where(\._uuid == walkUUID)
-        ), let first = walk.routeData.first else { return }
-        let location = CLLocation(latitude: first.latitude, longitude: first.longitude)
-        Task {
-            guard let placemark = try? await geocoder.reverseGeocodeLocation(location).first,
-                  let name = placemark.locality ?? placemark.name else { return }
-            places[walkUUID] = name
+    /// Called exactly once, from load(), with the entries' distinct walk
+    /// UUIDs in display order — never per row.
+    func resolveAll(walkUUIDs: [UUID]) {
+        guard resolveTask == nil else { return }
+        let pending = walkUUIDs.prefix(Self.maxResolutions)
+        resolveTask = Task {
+            for walkUUID in pending {
+                guard !Task.isCancelled else { return }
+                guard let walk = try? DataManager.dataStack.fetchOne(
+                    From<Walk>().where(\._uuid == walkUUID)
+                ), let first = walk.routeData.first else { continue }
+                let location = CLLocation(latitude: first.latitude, longitude: first.longitude)
+                guard let placemark = try? await geocoder.reverseGeocodeLocation(location).first,
+                      let name = placemark.locality ?? placemark.name else { continue }
+                places[walkUUID] = name
+            }
         }
+    }
+
+    func cancel() {
+        resolveTask?.cancel()
+        resolveTask = nil
     }
 }
 
@@ -1788,12 +2008,17 @@ struct ThreadHistoryView: View {
             }
         }
         .sheet(item: $selectedWalk) { walk in
-            WalkSummaryView(walk: walk)
+            // showsThreadsCard: false is the Task 3 recursion cut — a
+            // tap-through summary must not offer another threads card, or
+            // summary → thread → summary stacks Mapbox-bearing views
+            // without bound.
+            WalkSummaryView(walk: walk, showsThreadsCard: false)
         }
         .sheet(item: $presentedOriginMap) { data in
             ThreadOriginMapView(displayTerm: displayTerm, data: data)
         }
         .task { await load() }
+        .onDisappear { placeResolver.cancel() }
     }
 
     private func entryRow(_ entry: ThreadHistoryEntry) -> some View {
@@ -1835,7 +2060,6 @@ struct ThreadHistoryView: View {
         .padding(Constants.UI.Padding.normal)
         .background(Color.parchmentSecondary)
         .cornerRadius(Constants.UI.CornerRadius.normal)
-        .task { placeResolver.resolve(walkUUID: entry.walkUUID) }
     }
 
     private var originFooter: some View {
@@ -1869,6 +2093,7 @@ struct ThreadHistoryView: View {
                 .map { ($0.uuid, $0.transcript) }
         )
         let released = ReleasedThreadsStore.shared.releasedLemmas
+        let backfillComplete = ThreadsBackfill.isComplete
         let lemmas = Set(cohortLemmas)
 
         entries = await Task.detached(priority: .userInitiated) { () -> [ThreadHistoryEntry] in
@@ -1880,10 +2105,15 @@ struct ThreadHistoryView: View {
             return ThreadHistoryModelBuilder.entries(
                 cohort: threads.filter { lemmas.contains($0.lemma) },
                 contextsByRecording: contextsByRecording,
-                transcriptsByRecording: transcripts
+                transcriptsByRecording: transcripts,
+                backfillComplete: backfillComplete
             )
         }.value
         origin = resolveOrigin()
+        var seenWalks: Set<UUID> = []
+        placeResolver.resolveAll(
+            walkUUIDs: entries.map(\.walkUUID).filter { seenWalks.insert($0).inserted }
+        )
     }
 
     /// Resolution happens when the view opens — never persisted, so a
@@ -1998,7 +2228,7 @@ struct ThreadOriginMapView: View {
 ```swift
     @ViewBuilder
     var threadsCardSlot: some View {
-        if let threadsCardModel {
+        if showsThreadsCard, let threadsCardModel {
             ThreadsCardSection(
                 model: threadsCardModel,
                 onThemeTap: { selectedCardTheme = $0 }
@@ -2007,7 +2237,7 @@ struct ThreadOriginMapView: View {
     }
 ```
 
-- [ ] **Step 7: Build + full UnitTests suite — PASS** (baseline 1269 + 41). Commit.
+- [ ] **Step 7: Build + full UnitTests suite — PASS** (baseline 1269 + 46). Then `swiftlint lint Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift` — zero errors (the ~669/750 type_body_length headroom check, per Global Constraints). Commit.
 
 ```bash
 git add Pilgrim/Models/Threads/ThreadHistoryModel.swift Pilgrim/Scenes/WalkSummary/ThreadHistoryView.swift Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift UnitTests/ThreadHistoryModelTests.swift Pilgrim.xcodeproj/project.pbxproj
@@ -2024,6 +2254,7 @@ git commit -m "feat(threads): thread view — the walker's own words, newest fir
 - Modify: `Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift` (long-press, VoiceOver action, confirm, caption)
 - Modify: `Pilgrim/Scenes/WalkSummary/ThreadHistoryView.swift` (term header with long-press + confirm, pops on release)
 - Modify: `Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift` (release handler, card fade-out)
+- Modify: `Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift` (`.onChange(of: selectedCardTheme)` reload — Step 6's parenthetical)
 - Modify: `Pilgrim/Models/Preferences/UserPreferences.swift` (caption-shown flag)
 - Modify: `Pilgrim/Models/Threads/ThreadsCardModel.swift` (`removing(displayTerm:from:)`)
 - Modify: `Pilgrim/Scenes/Settings/SettingsCards/VoiceCard.swift` (hidden-when-empty settings row)
@@ -2217,22 +2448,43 @@ struct ThreadsCardSection: View {
     }
 ```
 
-and `chip(_:)` gains, between `.buttonStyle(.plain)` and `.accessibilityElement`:
+and `chip(_:)` is replaced wholesale — the Task 4 `Button` wrapper goes away. A long-press gesture attached to a `Button` competes with the Button's own tap recognizer and one of the two stops firing reliably; no file in this repo combines them, and the house pattern for tap + long-press coexistence is `PhotoCarouselView.swift:122-128` — `.contentShape(Rectangle())` + `.onTapGesture` + `.onLongPressGesture(minimumDuration: 0.4)` on a plain view (`MeditationView.swift:62-69` is the other precedent). VoiceOver parity is unaffected: custom accessibility actions bypass gesture recognizers entirely, and `.isButton` restores the trait the `Button` used to convey:
 
 ```swift
-        .onLongPressGesture {
+    private func chip(_ theme: ThreadsCardTheme) -> some View {
+        VStack(spacing: 2) {
+            Text(theme.displayTerm)
+                .font(Constants.Typography.body)
+                .foregroundColor(.ink)
+            if let note = theme.statusNote {
+                Text(note)
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .frame(minHeight: 44)
+        .background(Capsule().fill(Color.moss.opacity(0.1)))
+        .contentShape(Rectangle())
+        .onTapGesture {
+            onThemeTap?(theme)
+        }
+        .onLongPressGesture(minimumDuration: 0.4) {
             guard onRelease != nil else { return }
             themeToRelease = theme
         }
-```
-
-plus, after `.accessibilityHint(...)` — gesture parity, not gesture-only:
-
-```swift
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isButton)
+        .accessibilityLabel(
+            theme.statusNote.map { "\(theme.displayTerm), \($0)" } ?? theme.displayTerm
+        )
+        .accessibilityHint(onThemeTap == nil ? "" : "Double tap to view history")
         .accessibilityAction(named: ReleasedThreadsCopy.voiceOverActionName) {
             guard onRelease != nil else { return }
             themeToRelease = theme
         }
+    }
 ```
 
 `WalkSummaryView+Threads.swift` — the slot passes both handlers and the release fades/reflows:
@@ -2240,7 +2492,7 @@ plus, after `.accessibilityHint(...)` — gesture parity, not gesture-only:
 ```swift
     @ViewBuilder
     var threadsCardSlot: some View {
-        if let threadsCardModel {
+        if showsThreadsCard, let threadsCardModel {
             ThreadsCardSection(
                 model: threadsCardModel,
                 onThemeTap: { selectedCardTheme = $0 },
@@ -2273,13 +2525,16 @@ plus, after `.accessibilityHint(...)` — gesture parity, not gesture-only:
         Text(displayTerm)
             .font(Constants.Typography.displayMedium)
             .foregroundColor(.ink)
-            .frame(maxWidth: .infinity)
+            .frame(maxWidth: .infinity, minHeight: 44)
+            .contentShape(Rectangle())
             .onLongPressGesture { showReleaseConfirm = true }
             .accessibilityAction(named: ReleasedThreadsCopy.voiceOverActionName) {
                 showReleaseConfirm = true
             }
     }
 ```
+
+(The `.frame(maxWidth: .infinity, minHeight: 44).contentShape(Rectangle())` pair matches every other interactive row in this plan — a transparent `Text` alone hit-tests only its glyph bounding box, so without it the long-press target would be narrower and shorter than the visual row and under the 44 pt minimum.)
 
 and on the ScrollView's modifier chain, next to the existing sheets:
 
@@ -2298,7 +2553,7 @@ and on the ScrollView's modifier chain, next to the existing sheets:
         }
 ```
 
-(When the thread view was pushed from the summary card, the summary's card is stale after this pop — the `.task(id:)` reload doesn't refire on dismiss, so ALSO add `.onChange(of: selectedCardTheme) { _, newValue in if newValue == nil { Task { await loadThreadsCard() } } }` to the WalkSummaryView modifier chain, right after the Task 4 sheet. A release made inside the thread view is then reflected the moment the sheet closes.)
+(When the thread view was pushed from the summary card, the summary's card is stale after this pop — the `.task(id:)` reload doesn't refire on dismiss, so ALSO add `.onChange(of: selectedCardTheme) { _, newValue in if newValue == nil { Task { await loadThreadsCard() } } }` to the WalkSummaryView modifier chain, right after the Task 4 sheet. A release made inside the thread view is then reflected the moment the sheet closes. Task 7 extends this same pattern to the recap sheet path with `.onChange(of: recapSheet)`, and re-keys the recap view's own load on the released token — the release lifecycle stays consistent across all three surfaces.)
 
 - [ ] **Step 7: The settings list**
 
@@ -2387,7 +2642,7 @@ struct ReleasedThreadsListView: View {
             }
 ```
 
-- [ ] **Step 8: Build + full UnitTests suite — PASS** (baseline 1269 + 47). Commit.
+- [ ] **Step 8: Build + full UnitTests suite — PASS** (baseline 1269 + 52). Commit.
 
 ```bash
 git add Pilgrim/Models/Threads/ReleasedThreadsCopy.swift Pilgrim/Models/Threads/ThreadsCardModel.swift Pilgrim/Models/Preferences/UserPreferences.swift Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift Pilgrim/Scenes/WalkSummary/ThreadHistoryView.swift Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift Pilgrim/Scenes/Settings/ReleasedThreadsListView.swift Pilgrim/Scenes/Settings/SettingsCards/VoiceCard.swift UnitTests/ReleasedThreadsInteractionTests.swift Pilgrim.xcodeproj/project.pbxproj
@@ -2403,14 +2658,15 @@ git commit -m "feat(threads): let this one go — reversible releases with gestu
 - Create: `Pilgrim/Models/Threads/LunationCalendar.swift`
 - Create: `Pilgrim/Models/Threads/LunationRecapState.swift`
 - Modify: `Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift` (first-card-shown marker)
-- Test: `UnitTests/LunationCalendarTests.swift`, `UnitTests/LunationRecapStateTests.swift`
+- Modify: `Pilgrim/Models/Data/DataManager.swift` (`deleteAll` also clears the recap state and the caption flag — beside Task 1's `releasedThreadsStore.clear()`)
+- Test: `UnitTests/LunationCalendarTests.swift`, `UnitTests/LunationRecapStateTests.swift`, extend `UnitTests/DataManagerThreadsDeletionTests.swift`
 
 **Interfaces:**
 - Consumes: `LunarPhase.synodicMonth` / `LunarPhase.knownNewMoon` (internal after this task — the same reference the phase math uses, so phase and lunation arithmetic can never disagree), `UserPreferences.threadsAfterWalks`.
 - Produces (used by Task 7):
   - `struct Lunation: Equatable, Identifiable` — `{ index: Int, start: Date, end: Date, fullMoon: Date }`, `id == index`
   - `LunationCalendar.lunation(at:)` / `.lunation(containing:)` / `.mostRecentClosed(asOf:)` / `.moonName(for:in:)` (timezone-pinned month-moon name table)
-  - `final class LunationRecapState` — `static let shared`; `init(defaults:)`; `firstCardShownAt`; `markFirstCardShown(now:)` (set-once); `lastActedLunationIndex`; `markActedOn(_:)`; `invitation(forWalkDated:now:) -> Lunation?`
+  - `final class LunationRecapState` — `static let shared`; `init(defaults:)`; `firstCardShownAt`; `markFirstCardShown(now:)` (set-once); `lastActedLunationIndex`; `markActedOn(_:)` (monotonic — opening an older moon from Past recaps never regresses the index); `invitation(forWalkDated:now:) -> Lunation?` (ignores acted indices beyond the current lunation — a forward-set clock cannot silence months of real invitations); `clear()` (Delete All hook — the first-card gate re-arms exactly as a reinstall would)
 
 - [ ] **Step 1: Write the failing tests**
 
@@ -2574,7 +2830,43 @@ final class LunationRecapStateTests: XCTestCase {
         UserPreferences.threadsAfterWalks.value = false
         XCTAssertNil(state.invitation(forWalkDated: walkAfter, now: now))
     }
+
+    func testInvitation_futureActedIndexIsIgnored() {
+        showFirstCard(before: closed.end)
+        state.markActedOn(LunationCalendar.lunation(at: 305))
+        XCTAssertEqual(state.invitation(forWalkDated: walkAfter, now: now)?.index, 300,
+                       "an acted index from a forward-set clock is ignored — it cannot silence months of real invitations")
+    }
+
+    func testMarkActedOn_isMonotonic() {
+        state.markActedOn(closed)
+        state.markActedOn(LunationCalendar.lunation(at: 298))
+        XCTAssertEqual(state.lastActedLunationIndex, 300,
+                       "opening an older moon from Past recaps never regresses the acted index")
+    }
 }
+```
+
+Append to `UnitTests/DataManagerThreadsDeletionTests.swift` (beside Task 1's release-clearing test — Delete All must reset the recap bookkeeping exactly as a reinstall would; a surviving `firstCardShownAt` resurrects pre-wipe moons as ghost Past-recap rows and turns the first post-wipe walk into a junk "no recorded words" invitation):
+
+```swift
+    func testDeleteAll_clearsRecapStateAndCaptionFlag() {
+        LunationRecapState.shared.clear()
+        LunationRecapState.shared.markFirstCardShown()
+        LunationRecapState.shared.markActedOn(LunationCalendar.lunation(at: 300))
+        UserPreferences.threadsReleaseCaptionShown.value = true
+
+        let deleted = expectation(description: "deleted all")
+        DataManager.deleteAll { success, _ in
+            XCTAssertTrue(success)
+            deleted.fulfill()
+        }
+        wait(for: [deleted], timeout: 5)
+        XCTAssertNil(LunationRecapState.shared.firstCardShownAt,
+                     "the first-card gate re-arms — a wipe is a fresh start, like a reinstall")
+        XCTAssertNil(LunationRecapState.shared.lastActedLunationIndex)
+        XCTAssertFalse(UserPreferences.threadsReleaseCaptionShown.value)
+    }
 ```
 
 - [ ] **Step 2: Run to verify failure** (`-only-testing:UnitTests/LunationCalendarTests -only-testing:UnitTests/LunationRecapStateTests`). Expected: FAIL — types don't exist.
@@ -2703,8 +2995,11 @@ final class LunationRecapState {
         defaults.object(forKey: Self.lastActedKey) as? Int
     }
 
+    /// Monotonic: opening an older moon from Past recaps also marks it
+    /// acted-on, and must never regress the index and resurrect an
+    /// already-dismissed invitation.
     func markActedOn(_ lunation: Lunation) {
-        defaults.set(lunation.index, forKey: Self.lastActedKey)
+        defaults.set(max(lunation.index, lastActedLunationIndex ?? Int.min), forKey: Self.lastActedKey)
     }
 
     /// The lunation whose set moon may invite from this walk's summary, or
@@ -2715,11 +3010,33 @@ final class LunationRecapState {
         guard let firstShown = firstCardShownAt else { return nil }
         let closed = LunationCalendar.mostRecentClosed(asOf: now)
         guard closed.end > firstShown else { return nil }
-        guard closed.index > (lastActedLunationIndex ?? Int.min) else { return nil }
+        // An acted index beyond the current lunation can only come from a
+        // forward-set clock (the manual smoke does exactly this) — ignore
+        // it, so months of real invitations aren't silenced after the
+        // clock returns.
+        let currentIndex = LunationCalendar.lunation(containing: now).index
+        let lastActed = lastActedLunationIndex.flatMap { $0 > currentIndex ? nil : $0 }
+        guard closed.index > (lastActed ?? Int.min) else { return nil }
         guard walkDate >= closed.end else { return nil }
         return closed
     }
+
+    /// Delete All Data hook — the first-card gate re-arms exactly as a
+    /// reinstall would. Without this, a surviving firstCardShownAt
+    /// resurrects pre-wipe moons as ghost Past-recap rows and turns the
+    /// first post-wipe walk into a junk "no recorded words" invitation.
+    func clear() {
+        defaults.removeObject(forKey: Self.firstCardShownKey)
+        defaults.removeObject(forKey: Self.lastActedKey)
+    }
 }
+```
+
+`DataManager.swift` — in `deleteAll`'s `.success` branch, directly after Task 1's `releasedThreadsStore.clear()` line (same transaction-success discipline — recap bookkeeping resets only once the database wipe committed):
+
+```swift
+                LunationRecapState.shared.clear()
+                UserPreferences.threadsReleaseCaptionShown.value = false
 ```
 
 `ThreadsCardSection.swift` — the card records the walker's first contact. On the outermost VStack's modifier chain (after `.cornerRadius`):
@@ -2730,13 +3047,15 @@ final class LunationRecapState {
         }
 ```
 
-- [ ] **Step 4: Run both classes — PASS** (5 + 9 tests).
+- [ ] **Step 4: Run the three touched classes — PASS** (5 + 10 tests, plus the new deleteAll recap-clearing test)
+
+Run: `xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' -only-testing:UnitTests/LunationCalendarTests -only-testing:UnitTests/LunationRecapStateTests -only-testing:UnitTests/DataManagerThreadsDeletionTests 2>&1 | tail -20`
 
 - [ ] **Step 5: Commit**
 
 ```bash
-git add Pilgrim/Models/LunarPhase.swift Pilgrim/Models/Threads/LunationCalendar.swift Pilgrim/Models/Threads/LunationRecapState.swift Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift UnitTests/LunationCalendarTests.swift UnitTests/LunationRecapStateTests.swift Pilgrim.xcodeproj/project.pbxproj
-git commit -m "feat(threads): lunation machinery — timezone-named moons, first-card gate, acted-on invitations"
+git add Pilgrim/Models/LunarPhase.swift Pilgrim/Models/Threads/LunationCalendar.swift Pilgrim/Models/Threads/LunationRecapState.swift Pilgrim/Scenes/WalkSummary/ThreadsCardSection.swift Pilgrim/Models/Data/DataManager.swift UnitTests/LunationCalendarTests.swift UnitTests/LunationRecapStateTests.swift UnitTests/DataManagerThreadsDeletionTests.swift Pilgrim.xcodeproj/project.pbxproj
+git commit -m "feat(threads): lunation machinery — timezone-named moons, first-card gate, acted-on invitations, wipe re-arms the gate"
 ```
 
 ---
@@ -2747,7 +3066,7 @@ git commit -m "feat(threads): lunation machinery — timezone-named moons, first
 - Create: `Pilgrim/Models/Threads/LunationRecapModel.swift`
 - Create: `Pilgrim/Scenes/WalkSummary/LunationRecapView.swift`
 - Create: `Pilgrim/Scenes/Settings/PastRecapsListView.swift`
-- Modify: `Pilgrim/Models/Data/DataManager.swift` (`voiceRecordingPaceIndex()` next to `voiceRecordingWalkIndex()`)
+- Modify: `Pilgrim/Models/Data/DataManager+VoiceRecording.swift` (`voiceRecordingPaceIndex()` next to `voiceRecordingWalkIndex()` — that is the file the walk-index/snapshot helpers live in, NOT DataManager.swift)
 - Modify: `Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift` (two `@State`s, one onAppear line, one `.sheet`)
 - Modify: `Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift` (invitation row above the card)
 - Modify: `Pilgrim/Scenes/Settings/SettingsCards/VoiceCard.swift` (Past recaps row)
@@ -2758,9 +3077,9 @@ git commit -m "feat(threads): lunation machinery — timezone-named moons, first
 - Produces:
   - `struct LunationRecapTheme: Equatable, Identifiable, Hashable` — `{ displayTerm, lemmas, walkCount, isNewThisMoon }`
   - `struct LunationRecapModel: Equatable` — `{ moonName, walkCount, themes, textureLine, quietLine }`
-  - `LunationRecapCopy.themeLine(term:walkCount:totalWalks:)` ("in N of M walks" — structurally distinct from the card's ordinal copy by design), `.newThisMoon`, `.nothingHeld`, `.noWords`, `.invitation(moonName:)`
+  - `LunationRecapCopy.themeLine(term:walkCount:totalWalks:)` ("in N of M walks" — structurally distinct from the card's ordinal copy by design), `.headline(walkCount:)` ("N walks with recorded words this moon" — the claim is scoped to analyzed-transcript walks so it never reads as the journal's walk total disagreeing), `.newThisMoon`, `.nothingHeld`, `.noWords`, `.invitation(moonName:)`
   - `LunationRecapModelBuilder.model(lunation:moonName:contexts:walkIndex:paceByRecording:released:backfillComplete:)` (pure, live-computed at sheet open)
-  - `@MainActor DataManager.voiceRecordingPaceIndex() -> [UUID: Double]` (verify the attribute name `_wordsPerMinute` against PilgrimV7.swift:241 — it is `Value.Optional<Double>("wordsPerMinute")`)
+  - `@MainActor DataManager.voiceRecordingPaceIndex() -> [UUID: Double]` — a two-column `queryAttributes` fetch mirroring its neighbors in `DataManager+VoiceRecording.swift` (verify the attribute name `_wordsPerMinute` against PilgrimV7.swift:241 — it is `Value.Optional<Double>("wordsPerMinute")`)
   - `LunationRecapView(lunation:)` sheet; `PastRecapsListView` + `PastRecapsListView.closedLunations(now:state:)`
 
 - [ ] **Step 1: Write the failing tests**
@@ -2773,12 +3092,12 @@ final class LunationRecapModelTests: XCTestCase {
 
     private let lunation = LunationCalendar.lunation(at: 300)
 
-    private func context(_ uuid: UUID, lemma: String?, insight: Int = 0) -> TranscriptContext {
+    private func context(_ uuid: UUID, lemma: String?, displayTerm: String? = nil, insight: Int = 0) -> TranscriptContext {
         TranscriptContext(
             schemaVersion: 1, recordingUUID: uuid, transcriptHash: "h",
             languageCode: "en", wordCount: 200,
             themes: lemma.map { [Theme(
-                lemma: $0, displayTerm: $0, mentionCount: 3, salience: 0.015,
+                lemma: $0, displayTerm: displayTerm ?? $0, mentionCount: 3, salience: 0.015,
                 mentions: [ThemeMention(start: 0, length: 4)]
             )] } ?? [],
             markers: MarkerPack(
@@ -2868,12 +3187,31 @@ final class LunationRecapModelTests: XCTestCase {
         XCTAssertEqual(build(contexts: contexts, walkIndex: walkIndex).themes.first?.isNewThisMoon, false)
     }
 
+    func testNewThisMoon_falseWhenSiblingLemmaPredatesTheMoon() {
+        var (contexts, walkIndex) = fixture()
+        let earlierRec = UUID()
+        contexts.append(context(earlierRec, lemma: "moving", displayTerm: "move"))
+        walkIndex[earlierRec] = (UUID(), lunation.start.addingTimeInterval(-10 * 86400))
+        XCTAssertEqual(build(contexts: contexts, walkIndex: walkIndex).themes.first?.isNewThisMoon, false,
+                       "a sibling lemma of the same display term predating the moon makes the theme returning, not new — cohorts group over ALL threads")
+    }
+
     func testReleasedFiltering_leavesTheQuietLine() {
         let (contexts, walkIndex) = fixture()
         let model = build(contexts: contexts, walkIndex: walkIndex, released: ["move"])
         XCTAssertTrue(model.themes.isEmpty)
         XCTAssertEqual(model.walkCount, 3, "the moon's walk count stands even when nothing is named")
         XCTAssertEqual(model.quietLine, "nothing held on to name this time")
+    }
+
+    func testRecapPathRelease_rebuildDropsThemeAndLeavesQuietLine() {
+        let (contexts, walkIndex) = fixture()
+        XCTAssertEqual(build(contexts: contexts, walkIndex: walkIndex).themes.map(\.displayTerm), ["move"],
+                       "fixture sanity — the theme is present before the release")
+        let after = build(contexts: contexts, walkIndex: walkIndex, released: ["move"])
+        XCTAssertTrue(after.themes.isEmpty)
+        XCTAssertEqual(after.quietLine, "nothing held on to name this time",
+                       "the released-token re-key rebuilds the recap the moment the thread view pops — a released theme drops out instead of dead-ending")
     }
 
     func testZeroAnalyzedWalks_hasItsOwnQuietLine() {
@@ -2887,6 +3225,20 @@ final class LunationRecapModelTests: XCTestCase {
         let walkIndex = [rec: (walkUUID: UUID(), date: lunation.end.addingTimeInterval(3600))]
         let model = build(contexts: [context(rec, lemma: "move")], walkIndex: walkIndex)
         XCTAssertEqual(model.walkCount, 0, "the window is [start, end) — the close belongs to the next moon")
+    }
+
+    func testWalkCount_ignoresWalksWithoutAnalyzedWords() {
+        var (contexts, walkIndex) = fixture()
+        walkIndex[UUID()] = (UUID(), lunation.start.addingTimeInterval(5 * 86400))
+        let model = build(contexts: contexts, walkIndex: walkIndex)
+        XCTAssertEqual(model.walkCount, 3,
+                       "an untranscribed recording's walk doesn't count — the headline copy scopes the claim to walks with recorded words for exactly this reason")
+    }
+
+    func testHeadline_scopedToWalksWithRecordedWords() {
+        XCTAssertEqual(LunationRecapCopy.headline(walkCount: 3), "3 walks with recorded words this moon")
+        XCTAssertEqual(LunationRecapCopy.headline(walkCount: 1), "1 walk with recorded words this moon",
+                       "the qualifier keeps the count honest against a journal showing more walks this moon")
     }
 
     func testTexture_paceAndInsightFromTheMoonsRecordings() {
@@ -2931,6 +3283,20 @@ final class LunationRecapModelTests: XCTestCase {
             "every moon closed since first contact, newest first — a missed line never costs the month"
         )
     }
+
+    func testClosedLunations_boundaryEndEqualsFirstShown_excluded() {
+        let suiteName = "PastRecapsBoundary-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let state = LunationRecapState(defaults: defaults)
+        state.markFirstCardShown(now: LunationCalendar.lunation(at: 300).end)
+        let now = LunationCalendar.lunation(at: 302).start.addingTimeInterval(86400)
+        XCTAssertEqual(
+            PastRecapsListView.closedLunations(now: now, state: state).map(\.index),
+            [301],
+            "a moon closing at the exact first-shown instant belongs to backfilled history — the strict `>` is deliberate and pinned"
+        )
+    }
 }
 ```
 
@@ -2968,6 +3334,17 @@ enum LunationRecapCopy {
     /// "walks", even for one (spec sparse state: "in 1 of 1 walks").
     static func themeLine(term: String, walkCount: Int, totalWalks: Int) -> String {
         "'\(term)' — walked with you in \(walkCount) of \(totalWalks) walks"
+    }
+
+    /// The headline counts only walks with analyzed transcripts, so the
+    /// copy scopes the claim: a walker with fifteen journal walks and three
+    /// transcribed must never read "3 walks this moon" as the journal
+    /// disagreeing with itself. The zero state ("no recorded words walked
+    /// this moon") already carries the same frame.
+    static func headline(walkCount: Int) -> String {
+        walkCount == 1
+            ? "1 walk with recorded words this moon"
+            : "\(walkCount) walks with recorded words this moon"
     }
 
     static let newThisMoon = "new this moon"
@@ -3009,12 +3386,13 @@ enum LunationRecapModelBuilder {
         }
 
         let threads = ThreadStore.build(contexts: contexts, walks: walkIndex, released: released)
-        let cohorts = Dictionary(
-            grouping: threads.filter { thread in
-                thread.appearances.contains { inMoon($0.date) }
-            },
-            by: \.displayTerm
-        )
+        // Cohorts group over ALL threads first — a sibling lemma whose
+        // appearances all predate the moon still joins its cohort, so
+        // isNewThisMoon judges the cohort's full history (mirroring the
+        // card builder) — then only cohorts with at least one appearance
+        // inside the moon are named.
+        let cohorts = Dictionary(grouping: threads, by: \.displayTerm)
+            .filter { $0.value.contains { $0.appearances.contains { inMoon($0.date) } } }
 
         let themes = cohorts
             .map { term, cohort -> LunationRecapTheme in
@@ -3053,18 +3431,25 @@ enum LunationRecapModelBuilder {
 }
 ```
 
-In `DataManager.swift`, next to `voiceRecordingWalkIndex()`:
+In `Pilgrim/Models/Data/DataManager+VoiceRecording.swift`, next to `voiceRecordingWalkIndex()` (line 159 — the walk-index/snapshot helpers live in this extension file, not DataManager.swift; the Task 7 `git add` stages this file). Mirror the neighbors' two-column `queryAttributes` pattern — their own doc comments explain that `fetchAll` faulted in every recording row, one SQL round-trip each, and this function runs on every recap sheet open:
 
 ```swift
-    /// Recording UUID → words-per-minute, for the recap's pace texture.
-    /// Main-actor only: `dataStack.fetchAll` asserts Thread.isMainThread.
+    /// Recording UUID → words-per-minute, for the recap's pace texture. A
+    /// two-column `queryAttributes` fetch mirroring the snapshot queries
+    /// above. Main-actor only, like its neighbors.
     @MainActor
     public static func voiceRecordingPaceIndex() -> [UUID: Double] {
-        let recordings = (try? dataStack.fetchAll(From<VoiceRecording>())) ?? []
+        guard let rows = try? dataStack.queryAttributes(
+            From<VoiceRecording>().select(
+                NSDictionary.self,
+                .attribute(\._uuid),
+                .attribute(\._wordsPerMinute)
+            )
+        ) else { return [:] }
         var index: [UUID: Double] = [:]
-        for recording in recordings {
-            guard let uuid = recording._uuid.value,
-                  let wpm = recording._wordsPerMinute.value else { continue }
+        for row in rows {
+            guard let uuid = row["id"] as? UUID,
+                  let wpm = row["wordsPerMinute"] as? Double else { continue }
             index[uuid] = wpm
         }
         return index
@@ -3113,7 +3498,12 @@ struct LunationRecapView: View {
             .navigationDestination(item: $selectedTheme) { theme in
                 ThreadHistoryView(displayTerm: theme.displayTerm, cohortLemmas: theme.lemmas)
             }
-            .task { await load() }
+            // Re-keyed on the released token: a release made inside the
+            // pushed thread view pops back here, the pop re-evaluates this
+            // body, the id has changed, and load() reruns — the released
+            // theme drops out (the quiet line appears when emptied) and a
+            // re-tap can never open a dead-end empty history view.
+            .task(id: ReleasedThreadsStore.shared.changeCount) { await load() }
         }
     }
 
@@ -3122,7 +3512,7 @@ struct LunationRecapView: View {
             Image(systemName: "moon")
                 .font(.title2)
                 .foregroundColor(.fog)
-            Text(model.walkCount == 1 ? "1 walk this moon" : "\(model.walkCount) walks this moon")
+            Text(LunationRecapCopy.headline(walkCount: model.walkCount))
                 .font(Constants.Typography.body)
                 .foregroundColor(.ink)
 
@@ -3176,12 +3566,15 @@ struct LunationRecapView: View {
 
     @MainActor
     private func load() async {
+        // The local shadow must precede its first use — Swift resolves the
+        // unqualified name to the local for the WHOLE scope, so referencing
+        // it above its declaration is a compile error, not a property read.
+        let lunation = self.lunation
         let walkIndex = DataManager.voiceRecordingWalkIndex()
         let paces = DataManager.voiceRecordingPaceIndex()
         let released = ReleasedThreadsStore.shared.releasedLemmas
         let backfillComplete = ThreadsBackfill.isComplete
         let moonName = LunationCalendar.moonName(for: lunation)
-        let lunation = self.lunation
 
         model = await Task.detached(priority: .userInitiated) {
             LunationRecapModelBuilder.model(
@@ -3231,6 +3624,13 @@ struct PastRecapsListView: View {
         List {
             ForEach(lunations) { lunation in
                 Button {
+                    // Reading a recap here counts as acting on it — the
+                    // summary's invitation row stops nagging about a moon
+                    // the walker has already seen (spec-consistent: the
+                    // invitation exists to surface the recap, not to be
+                    // tapped for its own sake). markActedOn is monotonic,
+                    // so opening an OLDER moon never regresses the index.
+                    LunationRecapState.shared.markActedOn(lunation)
                     selected = lunation
                 } label: {
                     HStack {
@@ -3280,23 +3680,30 @@ and after the Task 4 `.sheet(item: $selectedCardTheme)` block:
             .sheet(item: $recapSheet) { lunation in
                 LunationRecapView(lunation: lunation)
             }
+            .onChange(of: recapSheet) { _, newValue in
+                if newValue == nil { Task { await loadThreadsCard() } }
+            }
 ```
+
+(The `.onChange(of: recapSheet)` is Task 5's `selectedCardTheme` pattern extended to the recap path: a release made inside the recap flow — recap → thread view → long-press release — reaches the summary card the moment the recap sheet closes, so the card can't keep offering to release an already-released cohort.)
 
 2. `WalkSummaryView+Threads.swift` — the invitation renders as its own row below the intention card, above the per-walk card; when the triggering walk has no analyzed transcript, `threadsCardModel` is nil and the row renders alone in the card's slot — placement falls out of the slot order:
 
 ```swift
     @ViewBuilder
     var threadsCardSlot: some View {
-        if let recapInvitation {
-            lunationInvitationRow(recapInvitation)
-        }
-        if let threadsCardModel {
-            ThreadsCardSection(
-                model: threadsCardModel,
-                onThemeTap: { selectedCardTheme = $0 },
-                onRelease: { releaseTheme($0) }
-            )
-            .transition(.opacity)
+        if showsThreadsCard {
+            if let recapInvitation {
+                lunationInvitationRow(recapInvitation)
+            }
+            if let threadsCardModel {
+                ThreadsCardSection(
+                    model: threadsCardModel,
+                    onThemeTap: { selectedCardTheme = $0 },
+                    onRelease: { releaseTheme($0) }
+                )
+                .transition(.opacity)
+            }
         }
     }
 
@@ -3341,12 +3748,12 @@ and after the Task 4 `.sheet(item: $selectedCardTheme)` block:
             }
 ```
 
-- [ ] **Step 6: Run `LunationRecapModelTests` (12 tests) then the full suite — PASS** (baseline 1269 + 73: Tasks 1-7 added 14 + 6 + 12 + 9 + 6 + 14 + 12).
+- [ ] **Step 6: Run `LunationRecapModelTests` (16 tests) then the full suite — PASS** (baseline 1269 + 84: Tasks 1-7 added 16 + 6 + 13 + 11 + 6 + 16 + 16). Then `swiftlint lint Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift` — zero errors (the ~669/750 type_body_length headroom check; this task added two `@State`s, one onAppear line, one sheet, and one onChange to the main struct).
 
 - [ ] **Step 7: Commit**
 
 ```bash
-git add Pilgrim/Models/Threads/LunationRecapModel.swift Pilgrim/Scenes/WalkSummary/LunationRecapView.swift Pilgrim/Scenes/Settings/PastRecapsListView.swift Pilgrim/Models/Data/DataManager.swift Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift Pilgrim/Scenes/Settings/SettingsCards/VoiceCard.swift UnitTests/LunationRecapModelTests.swift Pilgrim.xcodeproj/project.pbxproj
+git add Pilgrim/Models/Threads/LunationRecapModel.swift Pilgrim/Scenes/WalkSummary/LunationRecapView.swift Pilgrim/Scenes/Settings/PastRecapsListView.swift Pilgrim/Models/Data/DataManager+VoiceRecording.swift Pilgrim/Scenes/WalkSummary/WalkSummaryView.swift Pilgrim/Scenes/WalkSummary/WalkSummaryView+Threads.swift Pilgrim/Scenes/Settings/SettingsCards/VoiceCard.swift UnitTests/LunationRecapModelTests.swift Pilgrim.xcodeproj/project.pbxproj
 git commit -m "feat(threads): the lunation recap — the moon sets, the month speaks in counts, pulled never pushed"
 ```
 
@@ -3356,7 +3763,7 @@ git commit -m "feat(threads): the lunation recap — the moon sets, the month sp
 
 **Files:**
 - Modify: `Pilgrim/Models/Threads/ThreadIntentionSuggestions.swift` (flip `pendingFieldGate`)
-- Modify: `UnitTests/ThreadIntentionSuggestionsTests.swift` (update the pinning test)
+- Modify: `UnitTests/ThreadIntentionSuggestionsTests.swift` (replace the pinning test, add the `current()` release-wiring test — net +1)
 
 **Interfaces:**
 - Consumes: field gate outcome recorded in the spec addendum ("Chips: cleared to ship").
@@ -3371,7 +3778,58 @@ git commit -m "feat(threads): the lunation recap — the moon sets, the month sp
     }
 ```
 
-- [ ] **Step 2: Run to verify it fails** (`-only-testing:UnitTests/ThreadIntentionSuggestionsTests`). Expected: the new test FAILS against the still-true flag; `testCurrent_toggleOff_returnsEmptyWithoutTouchingTheStore` still passes (toggle-off is a separate guard and must survive the flip).
+and append the async wiring test the closed gate previously made impossible. Task 2's `testSuggestions_selectOverFilteredThreadsExcludesReleased` pins `select`'s ranking only — a bug in `current()`'s own wiring (omitting `released:` from its internal `ThreadStore.build` call, or a memo key that never sees the released token) would pass it. This test drives `current()` end to end through the Task 2 injection seams (mirroring `testDossierBuilder_releaseVisibleOnNextOpen`):
+
+```swift
+    @MainActor
+    func testCurrent_releaseVisibleOnNextCall() async {
+        let saved = UserPreferences.threadsAfterWalks.value
+        defer { UserPreferences.threadsAfterWalks.value = saved }
+        UserPreferences.threadsAfterWalks.value = true
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("SuggestionsWiring-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = TranscriptContextStore(directory: directory)
+
+        let suiteName = "SuggestionsWiring-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let releasedStore = ReleasedThreadsStore(defaults: defaults)
+
+        let base = DateFactory.makeDate(2024, 6, 1, 9, 0, 0)
+        let recA = UUID(), recB = UUID()
+        let walkIndex: [UUID: (walkUUID: UUID, date: Date)] = [
+            recA: (UUID(), base),
+            recB: (UUID(), base.addingTimeInterval(5 * 86400))
+        ]
+        for rec in [recA, recB] {
+            _ = store.save(TranscriptContext(
+                schemaVersion: 1, recordingUUID: rec, transcriptHash: "h",
+                languageCode: "en", wordCount: 200,
+                themes: [Theme(lemma: "move", displayTerm: "the move", mentionCount: 3,
+                               salience: 0.015, mentions: [ThemeMention(start: 0, length: 4)])],
+                markers: nil
+            ))
+        }
+
+        let asOf = base.addingTimeInterval(6 * 86400)
+        let before = await ThreadIntentionSuggestions.current(
+            asOf: asOf, store: store, releasedStore: releasedStore, walkIndex: walkIndex
+        )
+        XCTAssertEqual(before, ["walk with 'the move'"],
+                       "fixture sanity — the suggestion is live before the release")
+
+        releasedStore.release(displayTerm: "the move", lemmas: ["move"])
+        let after = await ThreadIntentionSuggestions.current(
+            asOf: asOf, store: store, releasedStore: releasedStore, walkIndex: walkIndex
+        )
+        XCTAssertTrue(after.isEmpty,
+                      "current()'s own build path filters released lemmas and its memo re-keys on the released token — visible on the very next call")
+    }
+```
+
+- [ ] **Step 2: Run to verify both fail** (`-only-testing:UnitTests/ThreadIntentionSuggestionsTests`). Expected: `testFieldGate_passed_chipsAreLive` FAILS against the still-true flag, and `testCurrent_releaseVisibleOnNextCall` FAILS at its `before` assertion (the closed gate returns `[]`); `testCurrent_toggleOff_returnsEmptyWithoutTouchingTheStore` still passes (toggle-off is a separate guard and must survive the flip).
 
 - [ ] **Step 3: Flip the flag** — in `ThreadIntentionSuggestions.swift`, replace the `pendingFieldGate` declaration and its comment:
 
@@ -3401,18 +3859,18 @@ git commit -m "feat(threads): chips live — the field gate opens, walk with wha
 - [ ] **Step 1: Full suite reconciliation**
 
 Run: `xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 17 Pro' 2>&1 | tee /tmp/threads-stage34-suite.log | tail -5`
-Then: `grep -c "Test Case '" /tmp/threads-stage34-suite.log` (started lines count double if the log includes passed lines — reconcile with `xcrun xcresulttool` if in doubt).
-Expected: PASS, and the count reconciles to **1269 + 73 = 1342** started cases (Task 8 replaced one test, net zero). Any shortfall means a test file never joined the UnitTests target — go back to the pbxproj 4-entries check for that file.
+Then: `grep -c "Test Case '.*' started" /tmp/threads-stage34-suite.log` (anchor on `started` — the unanchored `Test Case '` also matches the passed/failed lines and counts roughly double; reconcile with `xcrun xcresulttool` if in doubt).
+Expected: PASS, and the count reconciles to **1269 + 85 = 1354** started cases (Tasks 1-7 added 16 + 6 + 13 + 11 + 6 + 16 + 16 = 84; Task 8 replaced one test and added the current() wiring test, net +1). Any shortfall means a test file never joined the UnitTests target — go back to the pbxproj 4-entries check for that file.
 
 - [ ] **Step 2: Privacy grep gates**
 
 ```bash
 grep -rn "TranscriptContext\|MarkerPack\|WalkThread" Pilgrim/Models/Share/ Pilgrim/Models/Data/PilgrimPackage/ | grep -v "TranscriptContextStore"
-grep -rn "ReleasedThread\|releasedThreads" Pilgrim/Models/Share/
-grep -rln "ReleasedThread" Pilgrim/Models/Data/PilgrimPackage/
+grep -rn "ReleasedThread\|releasedThreads\|WelcomedBack\|welcomedBack" Pilgrim/Models/Share/
+grep -rln "ReleasedThread\|WelcomedBack" Pilgrim/Models/Data/PilgrimPackage/
 ```
 
-Expected: line 1 and line 2 return **nothing** — derived analysis stays out of shares and exports, and the released set never enters `SharePayload` or the worker. (The `grep -v` allows the importer's pre-existing `TranscriptContextStore.shared.clearTombstones` call at PilgrimPackageImporter.swift:87 — store hygiene, not data egress; no other `TranscriptContext` reference may appear.) Line 3 returns **exactly three files** (`PilgrimPackageModels.swift`, `PilgrimPackageConverter.swift`, `PilgrimPackageImporter.swift`) — the sanctioned preferences-block carve-out and nothing else.
+Expected: line 1 and line 2 return **nothing** — derived analysis stays out of shares and exports, and neither the released set nor the welcome-back records ever enter `SharePayload` or the worker. (The `grep -v` allows the importer's pre-existing `TranscriptContextStore.shared.clearTombstones` call at PilgrimPackageImporter.swift:87 — store hygiene, not data egress; no other `TranscriptContext` reference may appear.) Line 3 returns **exactly three files** (`PilgrimPackageModels.swift`, `PilgrimPackageConverter.swift`, `PilgrimPackageImporter.swift`) — the sanctioned preferences-block carve-out and nothing else.
 
 - [ ] **Step 3: UI language gates**
 
@@ -3428,12 +3886,13 @@ Expected: both return nothing — no directional words anywhere in UI, and the j
 - [ ] **Step 5: Manual smoke on simulator (iPhone 17 Pro, demo mode)**
 
 1. Launch with `--demo-mode`, open a Camino walk summary with transcripts: the card appears below the intention card, chips carry ordinal statuses, no digits anywhere on the card.
-2. Tap a chip → thread view, newest first, "where it began" on the oldest, "open the map" opens the origin map centered on the pin.
-3. Long-press a chip → confirm reads exactly "Let 'X' go? / You can welcome it back anytime." → release → card reflows (or fades out entirely when it was the last theme); reopen the AI-prompts sheet → the released term is gone from the dossier on this very open.
+2. Tap a chip → thread view, newest first, "where it began" on the oldest, "open the map" opens the origin map centered on the pin; date rows resolve their place names one by one (serialized geocoding — no silently missing places on a long thread); tap an entry row → that walk's summary opens WITHOUT a threads card (the recursion cut — a tap-through summary never offers another chip to tap through).
+3. Long-press a chip → confirm reads exactly "Let 'X' go? / You can welcome it back anytime." → release → card reflows (or fades out entirely when it was the last theme); a plain tap on a chip still navigates reliably (tap and long-press share the plain-view gesture pattern — verify both on the same chip); reopen the AI-prompts sheet → the released term is gone from the dossier on this very open.
 4. Settings → Voice: "Released threads" row appeared; welcome the theme back; the row hides again once empty.
 5. Toggle Thought Threads off → summary is pixel-identical to a card-less build; intention sheet shows no chips; both settings rows hidden.
-6. VoiceOver pass: each chip is one element announcing "theme, status", hint "Double tap to view history", custom action "Let this go"; Dynamic Type at AX sizes wraps chips, never truncates.
-7. Lunation: temporarily set the device clock forward past the next new moon (or seed `threadsFirstCardShownAt` back one lunation via the debugger) → a summary for a walk dated after the boundary shows the invitation row; an older walk's summary does not; tapping opens the recap; the row never returns after acting; Settings → Voice → Past recaps reaches the same sheet.
+6. VoiceOver pass: each chip is one element announcing "theme, status", hint "Double tap to view history", custom action "Let this go"; Dynamic Type at AX sizes wraps chips, never truncates; the thread view's term header long-press target spans the full row width.
+7. Lunation: temporarily set the device clock forward past the next new moon (or seed `threadsFirstCardShownAt` back one lunation via the debugger) → a summary for a walk dated after the boundary shows the invitation row; an older walk's summary does not; tapping opens the recap (headline reads "N walks with recorded words this moon"); the row never returns after acting; Settings → Voice → Past recaps reaches the same sheet, and opening a moon there also stops the invitation nagging. (The acted-index clamp makes the clock-forward step safe to undo — restoring the clock cannot leave invitations silenced.)
+8. Recap-path release: from a recap, tap a theme → thread view → long-press the term header → release → the pop returns to a REFRESHED recap (the theme is gone; the quiet line appears if it was the last); re-tapping cannot open an empty history view; close the recap sheet → the summary card no longer shows the released theme.
 
 - [ ] **Step 6: RELEASE checklist — human checkpoints (STOP here; these gate distribution, not merge)**
 
@@ -3446,7 +3905,7 @@ Expected: both return nothing — no directional words anywhere in UI, and the j
 
 ## Verification (whole plan)
 
-- [ ] Full suite green at 1342 cases (Task 9 Step 1 evidence attached to the PR).
+- [ ] Full suite green at 1354 cases (Task 9 Step 1 evidence attached to the PR).
 - [ ] All grep gates clean (Task 9 Steps 2-3 output attached).
 - [ ] SwiftLint clean, full repo.
 - [ ] Manual smoke checklist completed on iPhone 17 Pro simulator.
@@ -3458,9 +3917,10 @@ Expected: both return nothing — no directional words anywhere in UI, and the j
 |---|---|
 | Filtering call graph: ThreadStore.build drops released; recurringWord skip promotes next; intentionEcho exempt | T2 |
 | Lemma-cohort release + atomic welcome-back | T1 (store) + T3 (cohort assembly) + T5 (UI) |
-| Released set's own change token folded into dossier + suggestions memo keys; release visible on next open | T1 + T2 |
+| Released set's own change token folded into dossier + suggestions memo keys; release visible on next open | T1 + T2 (+ T8 wiring test) |
 | `.pilgrim` preferences-block carve-out (export, import merge, old-file tolerance) | T1 |
-| Delete All Data clears releases | T1 |
+| Import merge is latest-decision-wins per cohort (welcome-backs recorded as decisions; a stale backup's release never silently overrides a later reversal — the reversibility promise survives backups) | T1 |
+| Delete All Data clears releases, welcome-back records, recap state, and the caption flag (the first-card gate re-arms like a reinstall) | T1 + T6 |
 | Confirm copy exact strings, leads with reversibility | T5 |
 | Mid-view transitions: card fades/reflows; thread view pops | T5 |
 | VoiceOver custom action "Let this go" (gesture parity, not gesture-only) | T5 |
@@ -3470,9 +3930,11 @@ Expected: both return nothing — no directional words anywhere in UI, and the j
 | Top-4 salience themes, first-time/nth-walk ordinal statuses, backfill-gated origin claims | T3 |
 | State-only texture line (pace mechanical from wpm; insight words traceable on tap) | T3 |
 | Card accessibility: wrap, single VoiceOver element per chip, 44 pt targets | T3 (+T4 hint, +T5 action) |
-| Thread view: full history newest-first, date/place/excerpt, tap-through to summary | T4 |
+| Thread view: full history newest-first, date/place/excerpt (serialized geocoding), tap-through to summary | T4 |
+| Tap-through summaries suppress the threads card (`showsThreadsCard: false` — the summary → thread → summary recursion cut) | T3 (flag) + T4 (sheet) |
 | Excerpt slicing from mention offsets, grapheme-safe, hash-guarded | T4 |
 | "Where it began" label + origin map (route-sample-nearest-timestamp, 120 s tolerance, hide on failure, resolve at open) | T4 |
+| Thread-view origin claims backfill-gated — no isOrigin entry, footer, or map action until the sweep completes (mirrors the card and recap) | T4 |
 | Deleted origin walk → earliest surviving appearance becomes the origin | T4 (record-derived, nothing persisted) |
 | Timezone moon naming (month of full-moon instant, device timezone) | T6 |
 | Lunation boundary index pinned to LunarPhase's reference | T6 |
@@ -3481,11 +3943,13 @@ Expected: both return nothing — no directional words anywhere in UI, and the j
 | Walk-dated invitations — never on historical summaries | T6 (eligibility) + T7 (row) |
 | Invitation row placement: own row below intention card, above per-walk card; renders alone when walk unanalyzed | T7 |
 | Recap live-computed at open; counts may exceed invitation moment's | T7 |
-| Recap content: moon name, walk count, "in N of M walks" themes tappable to thread view, new-this-moon firsts, texture line | T7 |
-| No directional language in recap; released filtered | T7 (via T2) + T9 grep |
+| Recap content: moon name, walks-with-recorded-words headline, "in N of M walks" themes tappable to thread view, new-this-moon firsts, texture line | T7 |
+| Recap headline scoped to walks with recorded words (analyzed-transcript denominator, pinned against an untranscribed-walk fixture) | T7 |
+| No directional language in recap; released filtered; release inside the recap flow refreshes recap (released-token re-key) and summary card (recapSheet onChange) | T7 (via T2) + T9 grep + smoke 8 |
 | Sparse states: "in 1 of 1 walks"; "nothing held on to name this time"; zero-walk moon | T7 |
 | Scope-divergence phrasing (lunation counts vs trailing-window ordinals, structurally distinct) | T7 (pinned test) |
-| Past recaps settings list, hidden-when-empty, missed line never costs the month | T7 |
+| Past recaps settings list, hidden-when-empty, missed line never costs the month; viewing a recap there also marks it acted-on (kills the invitation nag — spec-consistent, the invitation exists to surface the recap; markActedOn is monotonic so older moons never regress the index) | T7 |
+| Clock-forward safety: acted indices beyond the current lunation are ignored | T6 |
 | Accessibility extends to recap sheet + both settings lists | T7 (rows) + T5 (list) |
 | Chips live: pendingFieldGate → false; header ships "Recurring"; softer variant is a fast-follow | T8 |
 | Toggle off = off everywhere (card, thread nav, chips, invitation, settings rows) | T3/T4/T5/T6/T7 guards + T9 smoke |

--- a/docs/superpowers/specs/2026-08-22-thought-threads-design.md
+++ b/docs/superpowers/specs/2026-08-22-thought-threads-design.md
@@ -388,45 +388,110 @@ clinical edge lives only in that hand-carried dossier.
 ### Let this one go (committed — ships with the card)
 
 A walker can release a thread. Long-press a theme (on the card or in the
-thread view) → a gentle confirm ("Let 'my father' go? It will no longer be
-noticed.") → the lemma joins a persisted released set. Every surfacing path
-filters released lemmas — ThreadStore aggregation (which covers the card,
-thread view, dossier trajectories, and intention chips) plus the dossier's
-per-recording theme lines. Analysis and stored contexts are untouched, so
-release is reversible: a small "Released threads" list under the Thought
-Threads settings area lets the walker welcome one back. Releasing is
-wabi-sabi, not deletion — the words remain in their transcripts; the app
-simply stops noticing.
+thread view) → a gentle confirm that leads with reversibility — "Let 'my
+father' go? You can welcome it back anytime." → the theme joins a persisted
+released set. Release acts on the display term's full lemma cohort (every
+lemma currently sharing that display term — two lemmas can share one, e.g.
+move/moving → "the move"), and welcome-back restores the cohort atomically.
+
+**Where filtering actually lives** (verified against the call graph):
+`ThreadStore.build` drops released lemmas — covering the card, thread view,
+dossier trajectories, quiet-this-walk lines, intention chips, and the recap
+— **plus** a released-lemma skip inside `AttentionDirectives.recurringWord`
+(the next-ranked candidate is promoted), which is the one surfacing path
+that bypasses ThreadStore. `intentionEcho` is deliberately exempt: it only
+quotes words from the walker's own stated intention — walker-authored, not
+app-noticed. The released set carries its own change token, folded into the
+dossier-builder and suggestions memo keys so a release is visible on the
+very next prompt or sheet open.
+
+Lifecycle: releases are walker decisions, not derived analysis — they ride
+in the `.pilgrim` preferences block (a scoped carve-out from the
+no-derived-data-in-exports rule, alongside `zodiacSystem` precedent; the
+lemmas already appear verbatim in exported transcripts) and Delete All Data
+clears the set with everything else. Analysis and stored contexts are
+untouched by release, so it is fully reversible.
+
+Interaction states: if a release empties the card while the summary is on
+screen, the card fades out and the summary reflows to its no-card state;
+the thread view pops to the previous screen if its own theme is released
+mid-view. Long-press gains a one-time dismissible caption on first card
+appearance ("long-press a theme to let it go") and each theme chip exposes
+a "Let this go" VoiceOver custom action — gesture parity, not
+gesture-only. The Settings "Released threads" row is hidden when empty;
+tapping an entry confirms "Welcome 'my father' back? Threads will notice
+it again." Releasing is wabi-sabi, not deletion — the words remain in
+their transcripts; the app simply stops noticing.
 
 ### Return to where it began (committed — ships with the thread view)
 
-The thread view's oldest entry ("where it began") gains one quiet action:
-open the origin walk's map, focused on the recording's start coordinate.
-Viewing, not navigation — the walker sees the place a thread first found
-words. If the origin recording has no GPS, the action simply doesn't render.
+The thread view's oldest entry gains one quiet action: open the origin
+walk's map — the existing historical summary map, static and read-only, no
+live-walk controls — centered on where the thread first found words. The
+walk and coordinate resolve at tap time (the route sample nearest the
+recording's start within a stated tolerance); on any failure — deleted
+walk, no route fix near that moment — the action simply doesn't render.
+Origin claims are claims about the record: if a walker deletes the origin
+walk, the record's earliest surviving appearance becomes "where it began,"
+because deletion is deliberate record-editing, consistent with how origin
+labels already work against analyzed history.
 
 ### The lunation recap (Stage 4, pulled forward — descriptive-only)
 
-When a lunation closes (existing `LunarPhase` boundaries), the first
-post-walk summary after the boundary shows one quiet invitation line —
-"The Sturgeon Moon has set — see what walked with you." — which opens the
-recap sheet (pulled, never pushed; the journal stays untouched; the
-invitation renders once per lunation and only when the closed moon held at
-least one analyzed walk).
+When a lunation closes (`LunarPhase` boundaries; the moon's name derives
+from the calendar month of its full-moon instant in the device's current
+timezone — implementation adds the month-moon name table `LunarPhase`
+lacks), summaries of walks **dated after the boundary** may carry one quiet
+invitation line — "The Sturgeon Moon has set — see what walked with you."
+— which opens the recap sheet. Pulled, never pushed; never on historical
+walk summaries (old summaries read the same whenever opened); the journal
+stays untouched.
 
-The recap holds: the moon's name and walk count; themes as plain counts
+**First-exposure gate:** recap eligibility begins only after the walker's
+first per-walk card has been shown (persisted marker). Lunation boundaries
+that closed inside backfilled history never invite — the recap must never
+be a walker's first contact with the feature; the card shows its work one
+walk at a time before any aggregate speaks.
+
+**Invitation semantics:** eligibility re-evaluates on every qualifying
+post-boundary summary until the invitation is tapped or the next lunation
+closes — the persisted flag records "acted on," not "first opportunity," so
+pending transcriptions don't cost the walker the month. The sheet computes
+live at open (its counts may exceed the invitation moment's). The
+last-acted lunation index lives in UserDefaults; loss on reinstall is
+accepted (ephemeral, unlike the released set). A "Past recaps" list under
+the Thought Threads settings area (mirroring "Released threads") keeps
+closed moons reachable, so a missed line never costs the month.
+
+**Content:** the moon's name and walk count; themes as plain counts
 ("'the move' — walked with you in 6 of 9 walks"), each tappable to its
-thread view; *new this moon* firsts (backfill-gated, computed against full
-history like all origin claims); and one state-only texture line from the
-safe markers ("spoken slowly, with words of insight"). **No directional
-language** — the original Stage 4 sketch's rising/steady/faded labels are
-superseded by design principle 1; trajectory remains dossier-only. Released
-lemmas are filtered here too. Deterministic template copy; no generation.
+thread view; *new this moon* firsts (full-history, backfill-gated, like
+all origin claims); one state-only texture line from the safe markers.
+**No directional language** — the original rising/steady/faded sketch is
+superseded by design principle 1; trajectory remains dossier-only.
+Released lemmas are filtered. Recap counts are lunation-scoped by design
+and will diverge from the card's trailing-30-day statuses — the phrasings
+stay structurally distinct ("in N of M walks" vs. ordinal "nth walk now")
+so they never read as the same metric disagreeing. Sparse states: a
+single-walk moon still uses count copy ("in 1 of 1 walks"); when release-
+filtering leaves no themes, the sheet shows moon name + walk count + a
+quiet line ("nothing held on to name this time"). Invitation placement:
+its own row below the intention card, above the per-walk card; when the
+triggering walk has no analyzed transcript it renders alone in the card's
+slot. Deterministic template copy; no generation.
 
 ### Stage 3+4 release shape (v1.12.0)
 
 Card + thread view (as specified in Stage 3 above, unchanged) + Let this
-one go + Return to where it began + chips live + lunation recap. The
-accessibility requirements in Stage 3 (Dynamic Type wrapping, VoiceOver
-chip elements, 44-point targets) extend to the recap sheet and released
-list. LLM-readback QA gates external release.
+one go + Return to where it began + chips live (header ships as
+"Recurring"; a softer-variant copy pass is a tracked fast-follow) + the
+lunation recap. Walker-facing exposure staggers by construction: the card
+appears with the first post-update analyzed walk; chips require a theme
+recurring across two walks; the recap requires a lunation to close after
+the first card — the bundle ships together but arrives gently, by design.
+Accessibility requirements from Stage 3 (Dynamic Type wrapping, VoiceOver
+elements incl. the release custom action, 44-point targets) extend to the
+recap sheet and both settings lists. Rollout: internal TestFlight first;
+the walker/product owner runs the LLM-readback QA pass (and a gentleness
+read of the release/welcome-back confirm strings) on that build, gating
+public TestFlight or App Store submission.

--- a/docs/superpowers/specs/2026-08-22-thought-threads-design.md
+++ b/docs/superpowers/specs/2026-08-22-thought-threads-design.md
@@ -1,7 +1,7 @@
 # Threads — Semantic Analysis of Walk Transcripts
 
-**Date:** 2026-08-22
-**Status:** Design approved, pending implementation planning
+**Date:** 2026-08-22 (Stage 3+4 addendum 2026-08-24)
+**Status:** Stages 1–2 shipped in v1.11.0 (PR #65). Field gate part 1 passed. Stage 3+4 design below, pending implementation planning.
 **Repos:** pilgrim-ios only (nothing leaves the device; worker/viewer untouched)
 
 ## Vision
@@ -327,8 +327,8 @@ or the schema.
 
 ## Out of scope (parked deliberately)
 
-- Moon-cycle / lunation recap (natural Stage 4; designed later, informed by
-  what threads actually look like in the field).
+- ~~Moon-cycle / lunation recap~~ — promoted into the Stage 3+4 addendum
+  below (2026-08-24), descriptive-only.
 - Any journal-page rendering of threads.
 - Foundation Models on-device generation (the clipboard-prompt flow already
   delegates generation to the walker's chosen AI; revisit only if that flow
@@ -364,5 +364,69 @@ clinical edge lives only in that hand-carried dossier.
   pack's composition at the field gate if dossier quality shows no lift.
 - Should the 30-day recurrence window adapt to walking cadence (a weekly
   walker's "recurring" is a daily walker's "fading")?
-- Per-theme forget control: should a walker be able to exclude a specific
-  thread (e.g. a person's name) from analysis, card, and dossier?
+- ~~Per-theme forget control~~ — resolved 2026-08-24: committed into Stage 3
+  as "Let this one go" (see addendum).
+
+## Stage 3+4 addendum (2026-08-24) — post-field-gate
+
+### Field gate outcomes
+
+- **Theme quality: PASSED** on real dogfood walks (v1.11.0 TestFlight) — the
+  walker judged surfaced themes recognizable and meaningful. Engine
+  thresholds stand as shipped (`minimumMentions = 2`, exact-lemma identity,
+  current suppression list).
+- **Chips: cleared to ship.** `ThreadIntentionSuggestions.pendingFieldGate`
+  flips to `false` in the Stage 3 release. Judge the section header copy
+  ("Recurring" vs. a softer variant) against real chip words during
+  implementation review.
+- **LLM-readback QA: PENDING — a RELEASE gate, not a build gate.** Before
+  the Stage 3 release (1.12.0) is submitted anywhere beyond internal
+  TestFlight: paste representative real dossiers (including elevated marker
+  profiles) into the major consumer LLMs and iterate the handling note until
+  no response contains clinical or diagnostic language.
+
+### Let this one go (committed — ships with the card)
+
+A walker can release a thread. Long-press a theme (on the card or in the
+thread view) → a gentle confirm ("Let 'my father' go? It will no longer be
+noticed.") → the lemma joins a persisted released set. Every surfacing path
+filters released lemmas — ThreadStore aggregation (which covers the card,
+thread view, dossier trajectories, and intention chips) plus the dossier's
+per-recording theme lines. Analysis and stored contexts are untouched, so
+release is reversible: a small "Released threads" list under the Thought
+Threads settings area lets the walker welcome one back. Releasing is
+wabi-sabi, not deletion — the words remain in their transcripts; the app
+simply stops noticing.
+
+### Return to where it began (committed — ships with the thread view)
+
+The thread view's oldest entry ("where it began") gains one quiet action:
+open the origin walk's map, focused on the recording's start coordinate.
+Viewing, not navigation — the walker sees the place a thread first found
+words. If the origin recording has no GPS, the action simply doesn't render.
+
+### The lunation recap (Stage 4, pulled forward — descriptive-only)
+
+When a lunation closes (existing `LunarPhase` boundaries), the first
+post-walk summary after the boundary shows one quiet invitation line —
+"The Sturgeon Moon has set — see what walked with you." — which opens the
+recap sheet (pulled, never pushed; the journal stays untouched; the
+invitation renders once per lunation and only when the closed moon held at
+least one analyzed walk).
+
+The recap holds: the moon's name and walk count; themes as plain counts
+("'the move' — walked with you in 6 of 9 walks"), each tappable to its
+thread view; *new this moon* firsts (backfill-gated, computed against full
+history like all origin claims); and one state-only texture line from the
+safe markers ("spoken slowly, with words of insight"). **No directional
+language** — the original Stage 4 sketch's rising/steady/faded labels are
+superseded by design principle 1; trajectory remains dossier-only. Released
+lemmas are filtered here too. Deterministic template copy; no generation.
+
+### Stage 3+4 release shape (v1.12.0)
+
+Card + thread view (as specified in Stage 3 above, unchanged) + Let this
+one go + Return to where it began + chips live + lunation recap. The
+accessibility requirements in Stage 3 (Dynamic Type wrapping, VoiceOver
+chip elements, 44-point targets) extend to the recap sheet and released
+list. LLM-readback QA gates external release.


### PR DESCRIPTION
*The themes the walker speaks now have somewhere to be seen — and a way to be released.*

## What's new

- **Threads card** on the post-walk summary: up to three recurring themes with ordinal status ("third walk now"), a texture line that opens into the exact transcript words that earned it, and a one-time caption introducing the release gesture. Only appears when there's something real to show.
- **Thread view**: tap a theme to see its history — every walk it appeared on, first-utterance excerpt, and "return to where it began" opening the origin on a map (resolved at tap time, never stale).
- **Let this one go**: long-press a theme to release it — "Let 'X' go? You can welcome it back anytime." Releases act on the whole lemma cohort, take effect everywhere instantly (card, prompts, suggestions, recap), and are reversible from Settings → Released threads.
- **Lunation recap**: when a moon cycle closes, an invitation appears on the card — "The Harvest Moon has set — see what walked with you." The recap is descriptive-only (counts and facts, never trajectories), honors releases with a quiet line, and past recaps live in Settings. Invitations render at most once per lunation and never as anyone's first exposure to threads.
- **Intention chips are live**: the field gate passed, so "walk with 'X'" suggestions now render under a "Recurring" header on the intention screen.

## Hardening (whole-branch review + 4 fix waves)

The final review surfaced real bugs the per-task gates couldn't see:

- **Edit-race closed at both layers**: editing a transcript inline on the summary now reloads the card on content (not count), and the card loader hash-checks stored contexts against passed transcripts, re-analyzing inline on mismatch — correct regardless of trigger timing.
- **UUID-cast production bug**: CoreStore stores the frozen `id` column as a string, so `row["id"] as? UUID` silently always failed — three query functions (`voiceRecordingWalkIndex`, `transcribedRecordingsSnapshot`, `voiceRecordingPaceIndex`) returned empty in production. All three fixed with direct tests. Never App-Store-shipped (entered after v1.10.0); on v1.11.0 TestFlight it made the historical backfill silently complete having analyzed nothing.
- **Backfill re-arm**: completion key versioned to V2 so those TestFlight devices re-run the (idempotent, battery-gated) sweep — origin claims and "new this moon" become true again.
- **Recap-state test seam**: `deleteAll` tests no longer wipe real recap state on a dogfood simulator.

## Evidence

- Suite: **1360 tests, 0 failures** (reconciled by test-case count; 105 new on this branch)
- SwiftLint: 401 baseline, 0 errors, zero new findings (the 401st is an adjudicated spec-pinned signature)
- Privacy greps: nothing thread-derived in Share or export beyond the sanctioned released-threads preferences carve-out
- String sweep: no directional/evaluative language on any walker-facing surface
- Every task passed a spec+quality review; whole-branch review on the most capable model: **Ready to merge**

## Release gates (not merge blockers)

- Internal TestFlight 1.12.0 first — manual smoke checklist at `.superpowers/sdd/task-9-release-checklist.md` (Recurring header rendering, chip tap-through, toggle end-to-end, demo-mode recurrence, VoiceOver release action, recap on a device clock)
- LLM-readback QA on real dossiers + confirm-string gentleness pass block **external** release

🤖 Generated with [Claude Code](https://claude.com/claude-code)