### PR TITLE
feat(threads): the leans get names — should is heard as obligation, can as the hollow

### DIFF
--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -224,6 +224,7 @@
 		4BCC1742561447DFBD59EF01 /* ThreadsDossierBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1060C3B913FD4DA88015D30D /* ThreadsDossierBuilder.swift */; };
 		366617D2E2404425A7BB8E0F /* ThreadsDossierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6AF4CB2CDC4F6DA1162CEA /* ThreadsDossierTests.swift */; };
 		6021C36CC44F486A8322CCF6 /* ThreadsDossierSensesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1892F0715213484FB4831780 /* ThreadsDossierSensesTests.swift */; };
+		39963097E78080FC16ED4DD9 /* ThreadsDossierModalLeanTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 166A1DAD8E9A1074A5502612 /* ThreadsDossierModalLeanTests.swift */; };
 		1777298B91F74F3BB7845E89 /* DossierSenses.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE45CFE80BF143578CE9AD0F /* DossierSenses.swift */; };
 		5A75182DEE57461AB02425A6 /* DossierSensesTracks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14EF62C0258F4A5E9B1CB669 /* DossierSensesTracks.swift */; };
 		DD4A23D5ECB4476E8D5D7137 /* DossierSensesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44C8743FE13846D2827B0B84 /* DossierSensesTests.swift */; };
@@ -872,6 +873,7 @@
 		1060C3B913FD4DA88015D30D /* ThreadsDossierBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsDossierBuilder.swift; sourceTree = "<group>"; };
 		3C6AF4CB2CDC4F6DA1162CEA /* ThreadsDossierTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsDossierTests.swift; sourceTree = "<group>"; };
 		1892F0715213484FB4831780 /* ThreadsDossierSensesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsDossierSensesTests.swift; sourceTree = "<group>"; };
+		166A1DAD8E9A1074A5502612 /* ThreadsDossierModalLeanTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ThreadsDossierModalLeanTests.swift; sourceTree = "<group>"; };
 		EE45CFE80BF143578CE9AD0F /* DossierSenses.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DossierSenses.swift; sourceTree = "<group>"; };
 		14EF62C0258F4A5E9B1CB669 /* DossierSensesTracks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DossierSensesTracks.swift; sourceTree = "<group>"; };
 		44C8743FE13846D2827B0B84 /* DossierSensesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DossierSensesTests.swift; sourceTree = "<group>"; };
@@ -1936,6 +1938,7 @@
 				25F8773000AC4CCC93F68DAF /* FieldGateReportTests.swift */,
 				3C6AF4CB2CDC4F6DA1162CEA /* ThreadsDossierTests.swift */,
 				1892F0715213484FB4831780 /* ThreadsDossierSensesTests.swift */,
+				166A1DAD8E9A1074A5502612 /* ThreadsDossierModalLeanTests.swift */,
 				44C8743FE13846D2827B0B84 /* DossierSensesTests.swift */,
 				81C820FEC4D64630A9C557BE /* DossierSensesMarkerPhotoTests.swift */,
 				4CEFDF8E058F4DDEB49054A4 /* DossierSensesCrossWalkTests.swift */,
@@ -3319,6 +3322,7 @@
 				AB27642252E24998A3ABFA3B /* FieldGateReportTests.swift in Sources */,
 				366617D2E2404425A7BB8E0F /* ThreadsDossierTests.swift in Sources */,
 				6021C36CC44F486A8322CCF6 /* ThreadsDossierSensesTests.swift in Sources */,
+				39963097E78080FC16ED4DD9 /* ThreadsDossierModalLeanTests.swift in Sources */,
 				DD4A23D5ECB4476E8D5D7137 /* DossierSensesTests.swift in Sources */,
 				45ADCF5FB26E4696BC6F1FB2 /* DossierSensesMarkerPhotoTests.swift in Sources */,
 				971D537B63FD4464A1BD7C08 /* DossierSensesCrossWalkTests.swift in Sources */,

--- a/Pilgrim/Models/Threads/MarkerAnalyzer.swift
+++ b/Pilgrim/Models/Threads/MarkerAnalyzer.swift
@@ -11,6 +11,49 @@ struct MarkerPack: Codable, Equatable {
     let futureCount: Int
     let pastCount: Int
     let sentiment: Double?
+    /// Per-surface-word modal occurrence counts (only words that occurred at
+    /// least once — absent, not zero). Word identity, not just family
+    /// totals, is what the dossier's modal-lean clause needs to name a
+    /// specific dominant word (e.g. "'should' ×31").
+    let modalCounts: [String: Int]
+
+    init(
+        wordCount: Int, absolutistCount: Int, firstPersonCount: Int, insightCount: Int,
+        causationCount: Int, discrepancyCount: Int, futureCount: Int, pastCount: Int,
+        sentiment: Double?, modalCounts: [String: Int]
+    ) {
+        self.wordCount = wordCount
+        self.absolutistCount = absolutistCount
+        self.firstPersonCount = firstPersonCount
+        self.insightCount = insightCount
+        self.causationCount = causationCount
+        self.discrepancyCount = discrepancyCount
+        self.futureCount = futureCount
+        self.pastCount = pastCount
+        self.sentiment = sentiment
+        self.modalCounts = modalCounts
+    }
+
+    /// `modalCounts` decodes leniently (missing key → empty) so a
+    /// schema-v2 file on disk, written before this field existed, still
+    /// decodes successfully. A hard decode failure would make it invisible
+    /// to `TranscriptContextStore.loadAllIncludingStaleVersions` — the
+    /// backfill's stale-orphan sweep would never see it to clean it up
+    /// (see docs/solutions/derived-cache-semantics-are-schema.md). The
+    /// schema-version filter, not a decode error, is what marks it stale.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        wordCount = try container.decode(Int.self, forKey: .wordCount)
+        absolutistCount = try container.decode(Int.self, forKey: .absolutistCount)
+        firstPersonCount = try container.decode(Int.self, forKey: .firstPersonCount)
+        insightCount = try container.decode(Int.self, forKey: .insightCount)
+        causationCount = try container.decode(Int.self, forKey: .causationCount)
+        discrepancyCount = try container.decode(Int.self, forKey: .discrepancyCount)
+        futureCount = try container.decode(Int.self, forKey: .futureCount)
+        pastCount = try container.decode(Int.self, forKey: .pastCount)
+        sentiment = try container.decodeIfPresent(Double.self, forKey: .sentiment)
+        modalCounts = try container.decodeIfPresent([String: Int].self, forKey: .modalCounts) ?? [:]
+    }
 
     /// Coarse heuristic, not a tagged linguistic feature — the dossier
     /// carries this caveat wherever the lean is reported.
@@ -33,6 +76,11 @@ enum MarkerAnalyzer {
             words.reduce(0) { $0 + (lexicon.contains($1) ? 1 : 0) }
         }
 
+        var modalCounts: [String: Int] = [:]
+        for word in words where MarkerLexicons.modalWords.contains(word) {
+            modalCounts[word, default: 0] += 1
+        }
+
         return MarkerPack(
             wordCount: words.count,
             absolutistCount: count(in: MarkerLexicons.absolutist),
@@ -42,14 +90,38 @@ enum MarkerAnalyzer {
             discrepancyCount: count(in: MarkerLexicons.discrepancy),
             futureCount: count(in: MarkerLexicons.futureMarkers),
             pastCount: count(in: MarkerLexicons.pastMarkers),
-            sentiment: sentimentScore(text)
+            sentiment: sentimentScore(text),
+            modalCounts: modalCounts
         )
     }
 
+    /// `NLTagger`'s sentiment model degrades to a near-constant score once
+    /// the tagged string passes roughly 150 words — confirmed by direct
+    /// measurement (happy/sad/neutral transcripts all converge on the same
+    /// value past that length), and reproduced in the field: three
+    /// wildly-different recordings all reported `-0.60`. Whole-transcript
+    /// `.paragraph` tagging doesn't dodge this either — spoken transcripts
+    /// rarely carry paragraph breaks, so `.paragraph` covers the same long
+    /// run as the raw string. Scoring each SENTENCE in isolation (a fresh
+    /// `.string` assignment per sentence, short enough to stay under the
+    /// degradation threshold) and averaging keeps the score genuinely
+    /// content-sensitive at any transcript length.
     static func sentimentScore(_ text: String) -> Double? {
         let tagger = NLTagger(tagSchemes: [.sentimentScore])
-        tagger.string = text
-        let (tag, _) = tagger.tag(at: text.startIndex, unit: .paragraph, scheme: .sentimentScore)
-        return tag.flatMap { Double($0.rawValue) }
+        let tokenizer = NLTokenizer(unit: .sentence)
+        tokenizer.string = text
+        var scores: [Double] = []
+        tokenizer.enumerateTokens(in: text.startIndex..<text.endIndex) { range, _ in
+            let sentence = String(text[range])
+            guard !sentence.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return true }
+            tagger.string = sentence
+            if let tag = tagger.tag(at: sentence.startIndex, unit: .paragraph, scheme: .sentimentScore).0,
+               let value = Double(tag.rawValue) {
+                scores.append(value)
+            }
+            return true
+        }
+        guard !scores.isEmpty else { return nil }
+        return scores.reduce(0, +) / Double(scores.count)
     }
 }

--- a/Pilgrim/Models/Threads/MarkerLexicons.swift
+++ b/Pilgrim/Models/Threads/MarkerLexicons.swift
@@ -40,4 +40,34 @@ enum MarkerLexicons {
         "was", "were", "did", "had", "ago", "yesterday", "remember",
         "remembered", "used", "back", "once", "before"
     ]
+
+    /// Modal verbs are a STATE signal (design decision, modal-lean spec):
+    /// they stay in this markers channel with per-word identity, and are
+    /// explicitly excluded from the recurring-word TOPIC directive
+    /// (`SpokenStoplist.scaffoldLemmas`) — a flat walk's "can ×57" is noise
+    /// there, not a theme. Six families, each an ordered array (not a Set)
+    /// so a dominant-word tie always resolves to the same word.
+    ///
+    /// "have to" (obligation) is a multi-word phrase and DEFERRED — this
+    /// lexicon is single-token only.
+    enum ModalFamily: String, CaseIterable {
+        case possibility, obligation, counterfactual, tentative, intention, desire
+    }
+
+    static let modalFamilies: [ModalFamily: [String]] = [
+        .possibility: ["can", "could"],
+        .obligation: ["should", "must", "ought"],
+        .counterfactual: ["would"],
+        .tentative: ["might", "may"],
+        .intention: ["will"],
+        .desire: ["want", "need", "wish"]
+    ]
+
+    static let modalWords: Set<String> = Set(modalFamilies.values.flatMap { $0 })
+
+    /// Every modal word belongs to exactly one family, so the search order
+    /// never affects the result.
+    static func modalFamily(of word: String) -> ModalFamily? {
+        modalFamilies.first { $0.value.contains(word) }?.key
+    }
 }

--- a/Pilgrim/Models/Threads/ThreadsBackfill.swift
+++ b/Pilgrim/Models/Threads/ThreadsBackfill.swift
@@ -5,7 +5,7 @@ import Foundation
 /// once history is fully analyzed (spec: ThreadStore).
 enum ThreadsBackfill {
 
-    static let completedKey = "threadsBackfillCompletedV4"
+    static let completedKey = "threadsBackfillCompletedV5"
     /// v1.11.0 TestFlight devices could run the sweep, account for zero
     /// recordings under a snapshot bug (fixed alongside the V2 rename), and
     /// still set the old flag — stranding those devices on a never-swept
@@ -21,10 +21,16 @@ enum ThreadsBackfill {
     /// Each rename re-arms by construction: the new key is absent, so
     /// `isComplete` reads false regardless of what any old key holds — V4
     /// additionally makes freshness itself schema-version-aware end to end
-    /// (see docs/solutions/derived-cache-semantics-are-schema.md).
+    /// (see docs/solutions/derived-cache-semantics-are-schema.md). V5 adds
+    /// `MarkerPack.modalCounts` (schema v2→v3) so the modal-lean dossier
+    /// clause has real word-identity history to build a baseline from —
+    /// unlike V3→V4, this rename touches no theme-extraction logic, so no
+    /// moon-line re-arm accompanies it (`performLegacyHygiene` still only
+    /// watches the V3 key for that).
     private static let legacyCompletedKeyV3 = "threadsBackfillCompletedV3"
+    private static let legacyCompletedKeyV4 = "threadsBackfillCompletedV4"
     private static let legacyCompletedKeys = [
-        "threadsBackfillCompleted", "threadsBackfillCompletedV2", legacyCompletedKeyV3
+        "threadsBackfillCompleted", "threadsBackfillCompletedV2", legacyCompletedKeyV3, legacyCompletedKeyV4
     ]
     private static var isRunning = false
     private static var generation = 0

--- a/Pilgrim/Models/Threads/ThreadsDossierBuilder.swift
+++ b/Pilgrim/Models/Threads/ThreadsDossierBuilder.swift
@@ -145,7 +145,8 @@ enum ThreadsDossierBuilder {
             allContexts: allContexts,
             threads: threads,
             currentWalkUUID: walkUUID,
-            backfillComplete: backfillComplete
+            backfillComplete: backfillComplete,
+            walkIndex: walkIndex.mapValues(\.walkUUID)
         )
 
         let postBuildMoonState = appendSensesBlock(

--- a/Pilgrim/Models/Threads/ThreadsDossierFormatter.swift
+++ b/Pilgrim/Models/Threads/ThreadsDossierFormatter.swift
@@ -8,6 +8,12 @@ enum ThreadsDossierFormatter {
     static let minimumAbsenceWalks = 2
     static let maxAbsenceLines = 2
     static let paceDifferenceThreshold = 0.15
+    /// Modal-lean baseline groups by WALK, not recording — a walker who
+    /// talks in three short bursts on one walk isn't three "prior" data
+    /// points for a per-walk state signal, unlike `baselineFloorRecordings`.
+    static let modalBaselineFloorWalks = 3
+    static let modalRemarkableMinCount = 10
+    static let modalRemarkableRateMultiple = 2.0
 
     static func markerLine(for context: TranscriptContext, baseline: (absolutist: Double, firstPerson: Double)?) -> String {
         guard let markers = context.markers else {
@@ -48,12 +54,129 @@ enum ThreadsDossierFormatter {
         )
     }
 
+    private struct ModalLeanSummary {
+        let family: MarkerLexicons.ModalFamily
+        let word: String
+        let count: Int
+        let familyCount: Int
+        let familyRate: Double
+    }
+
+    struct ModalBaselineEntry {
+        let rate: Double
+        let averagePerWalk: Double
+    }
+
+    /// Today's dominant modal family and its dominant surface word, summed
+    /// across the WALK's recordings (not one recording at a time — the
+    /// clause speaks once per walk). Deterministic ties: `ModalFamily
+    /// .allCases`/each family's word array are declaration-ordered, and only
+    /// a STRICTLY greater count replaces the running best.
+    private static func modalLeanSummary(for contexts: [TranscriptContext]) -> ModalLeanSummary? {
+        let totalWords = contexts.reduce(0) { $0 + $1.wordCount }
+        guard totalWords > 0 else { return nil }
+
+        var familyTotals: [MarkerLexicons.ModalFamily: Int] = [:]
+        var wordTotals: [String: Int] = [:]
+        for context in contexts {
+            guard let modalCounts = context.markers?.modalCounts else { continue }
+            for (word, count) in modalCounts {
+                wordTotals[word, default: 0] += count
+                if let family = MarkerLexicons.modalFamily(of: word) {
+                    familyTotals[family, default: 0] += count
+                }
+            }
+        }
+
+        var dominantFamily: (family: MarkerLexicons.ModalFamily, count: Int)?
+        for family in MarkerLexicons.ModalFamily.allCases {
+            let count = familyTotals[family] ?? 0
+            guard count > 0, dominantFamily == nil || count > dominantFamily!.count else { continue }
+            dominantFamily = (family, count)
+        }
+        guard let dominantFamily else { return nil }
+
+        var dominantWord: (word: String, count: Int)?
+        for word in MarkerLexicons.modalFamilies[dominantFamily.family] ?? [] {
+            let count = wordTotals[word] ?? 0
+            guard count > 0, dominantWord == nil || count > dominantWord!.count else { continue }
+            dominantWord = (word, count)
+        }
+        guard let dominantWord else { return nil }
+
+        return ModalLeanSummary(
+            family: dominantFamily.family, word: dominantWord.word, count: dominantWord.count,
+            familyCount: dominantFamily.count, familyRate: Double(dominantFamily.count) / Double(totalWords)
+        )
+    }
+
+    /// Per-family baseline, grouped by WALK (`modalBaselineFloorWalks`
+    /// prior, contexted walks required) rather than by recording — mirrors
+    /// `personalBaseline`'s density-floor qualification and its reuse of
+    /// already-persisted `MarkerPack` counts (never a fresh transcript
+    /// re-read), but the walk-grouping is this signal's own: a state lean is
+    /// a per-walk fact, not a per-recording one.
+    static func modalBaseline(
+        from contexts: [TranscriptContext],
+        walkIndex: [UUID: UUID],
+        excluding currentWalkUUID: UUID
+    ) -> [MarkerLexicons.ModalFamily: ModalBaselineEntry]? {
+        let qualifying = contexts.filter { context in
+            guard let markers = context.markers, markers.wordCount >= densityFloorWords,
+                  let walkUUID = walkIndex[context.recordingUUID], walkUUID != currentWalkUUID else { return false }
+            return true
+        }
+        let walksRepresented = Set(qualifying.compactMap { walkIndex[$0.recordingUUID] })
+        guard walksRepresented.count >= modalBaselineFloorWalks else { return nil }
+        let totalWords = qualifying.reduce(0) { $0 + $1.wordCount }
+        guard totalWords > 0 else { return nil }
+
+        var entries: [MarkerLexicons.ModalFamily: ModalBaselineEntry] = [:]
+        for family in MarkerLexicons.ModalFamily.allCases {
+            let words = MarkerLexicons.modalFamilies[family] ?? []
+            let total = qualifying.reduce(0) { sum, context in
+                sum + words.reduce(0) { $0 + (context.markers?.modalCounts[$1] ?? 0) }
+            }
+            entries[family] = ModalBaselineEntry(
+                rate: Double(total) / Double(totalWords),
+                averagePerWalk: Double(total) / Double(walksRepresented.count)
+            )
+        }
+        return entries
+    }
+
+    /// At most one clause, naming the dominant modal family and word — a
+    /// state signal, not a topic (design decision: modals live here with
+    /// word identity, never as a recurring-word theme). Silent by default:
+    /// fires only when the dominant family is both large on its own terms
+    /// (`modalRemarkableMinCount`) and elevated against the walker's own
+    /// per-walk baseline rate (`modalRemarkableRateMultiple`) — mirrors the
+    /// vs-baseline ratio shape `DossierSensesTracks.markerLine` already
+    /// uses (guard the baseline is nonzero before dividing by it). No
+    /// baseline at all means silence, not a fallback phrasing — first walks
+    /// never speak here, unlike the always-on absolutist line.
+    private static func modalLeanLine(
+        currentRecordings: [(context: TranscriptContext, wordsPerMinute: Double?)],
+        allContexts: [TranscriptContext],
+        walkIndex: [UUID: UUID],
+        currentWalkUUID: UUID
+    ) -> String? {
+        guard let summary = modalLeanSummary(for: currentRecordings.map(\.context)),
+              summary.familyCount >= modalRemarkableMinCount else { return nil }
+        guard let baseline = modalBaseline(from: allContexts, walkIndex: walkIndex, excluding: currentWalkUUID),
+              let entry = baseline[summary.family], entry.rate > 0,
+              summary.familyRate >= modalRemarkableRateMultiple * entry.rate else { return nil }
+        return "modal lean: \(summary.family.rawValue) — '\(summary.word)' ×\(summary.count)" +
+            " (your usual ~\(Int(entry.averagePerWalk.rounded())) per walk)"
+    }
+
     static func dossier(
         currentRecordings: [(context: TranscriptContext, wordsPerMinute: Double?)],
         allContexts: [TranscriptContext],
         threads: [WalkThread],
         currentWalkUUID: UUID,
-        backfillComplete: Bool
+        backfillComplete: Bool,
+        walkIndex: [UUID: UUID] = [:]
     ) -> String? {
         guard !currentRecordings.isEmpty else { return nil }
         let baseline = personalBaseline(from: allContexts)
@@ -61,6 +184,12 @@ enum ThreadsDossierFormatter {
         var section = "**Thought threads (on-device linguistic analysis):**"
         for (index, recording) in currentRecordings.enumerated() {
             section += "\nRecording \(index + 1): \(markerLine(for: recording.context, baseline: baseline))"
+        }
+        if let modalLine = modalLeanLine(
+            currentRecordings: currentRecordings, allContexts: allContexts,
+            walkIndex: walkIndex, currentWalkUUID: currentWalkUUID
+        ) {
+            section += "\n\(modalLine)"
         }
 
         let activeThreads = threads.filter { thread in

--- a/Pilgrim/Models/Threads/TranscriptContext.swift
+++ b/Pilgrim/Models/Threads/TranscriptContext.swift
@@ -10,7 +10,14 @@ struct TranscriptContext: Codable, Equatable {
     /// answers false for it, so every reader (threads/dossier/suggestions)
     /// and the backfill sweep treat a stale-derivation file as absent
     /// (see docs/solutions/derived-cache-semantics-are-schema.md).
-    static let currentSchemaVersion = 2
+    ///
+    /// v3: `MarkerPack.modalCounts` (per-surface-word modal-verb counts,
+    /// feeding the dossier's modal-lean clause). A v2 file still decodes —
+    /// `MarkerPack` decodes `modalCounts` leniently (missing → empty) so the
+    /// stale-orphan sweep can still see it — but it carries no modal data,
+    /// which would silently starve the modal-lean baseline of history; the
+    /// bump forces those recordings to re-analyze.
+    static let currentSchemaVersion = 3
 
     let schemaVersion: Int
     let recordingUUID: UUID

--- a/Pilgrim/Models/Threads/TranscriptNLP.swift
+++ b/Pilgrim/Models/Threads/TranscriptNLP.swift
@@ -148,9 +148,17 @@ enum SpokenStoplist {
     /// Light/auxiliary/modal verbs plus the filler nouns above, filtered out
     /// of the recurring-word attention directive — which still scans verbs,
     /// so it needs its own stoplist rather than the noun restriction above.
+    ///
+    /// Modal verbs (`can`, `could`, `should`, `would`, `must`, `might`,
+    /// `may`, `will`, `ought`, `wish` — `need`/`want` were already here) are
+    /// stoplisted by design: they're a STATE signal that belongs in the
+    /// markers channel with word identity (`MarkerLexicons.modalFamilies`),
+    /// never named as a recurring-word TOPIC — a flat walk's "can ×57" is
+    /// noise there, not a theme.
     static let scaffoldLemmas: Set<String> = [
         "be", "have", "do", "get", "go", "come", "make", "take", "know",
         "think", "say", "see", "want", "mean", "feel", "need", "let", "put",
-        "keep", "kind", "thing", "stuff", "way", "lot", "bit"
+        "keep", "kind", "thing", "stuff", "way", "lot", "bit",
+        "can", "could", "should", "would", "must", "might", "may", "will", "ought", "wish"
     ]
 }

--- a/UnitTests/AttentionDirectivesTests.swift
+++ b/UnitTests/AttentionDirectivesTests.swift
@@ -246,4 +246,18 @@ final class AttentionDirectivesTests: XCTestCase {
         )
         XCTAssertFalse(joined(context).contains("returns"))
     }
+
+    /// Design decision (modal-lean spec): modal verbs are a STATE signal
+    /// that belongs in the markers channel with word identity, never in the
+    /// recurring-word TOPIC channel — a flat walk's "can ×57" is noise
+    /// there, not a theme ("the verb of the hollow" made it work once; it
+    /// doesn't generalize). `SpokenStoplist.scaffoldLemmas` now excludes all
+    /// six modal families.
+    func testRecurringWord_modalVerb_doesNotFire() {
+        let context = ActivityContext.make(
+            recordings: [recording("I can do it. You can too. We can go now. It can work.")],
+            startDate: start
+        )
+        XCTAssertFalse(joined(context).contains("returns"))
+    }
 }

--- a/UnitTests/MarkerAnalyzerTests.swift
+++ b/UnitTests/MarkerAnalyzerTests.swift
@@ -42,4 +42,68 @@ final class MarkerAnalyzerTests: XCTestCase {
         let pack = MarkerAnalyzer.compute(text: "one two three, four — five!", languageCode: "en")
         XCTAssertEqual(pack?.wordCount, 5)
     }
+
+    /// Field bug: three real recordings with wildly different content all
+    /// reported `sentiment -0.60`. Root cause: `NLTagger`'s sentiment model
+    /// degrades to a near-constant score once the tagged string passes
+    /// roughly 150 words — confirmed by direct measurement, independent of
+    /// actual valence. These fixtures are long enough (220+ words) to land
+    /// past that threshold, so a regression back to whole-transcript tagging
+    /// collapses both to the same score.
+    func testSentiment_opposingValence_longTranscripts_produceDifferentScores() {
+        let happy = String(repeating: "I am so happy today. The sun is out and everything feels "
+            + "wonderful. I love this walk and feel grateful and joyful. ", count: 10)
+        let sad = String(repeating: "I am so sad today. Everything feels heavy and I am grieving. "
+            + "I hate how things turned out and feel hopeless. ", count: 10)
+
+        let happyPack = MarkerAnalyzer.compute(text: happy, languageCode: "en")
+        let sadPack = MarkerAnalyzer.compute(text: sad, languageCode: "en")
+
+        XCTAssertNotEqual(happyPack?.sentiment, sadPack?.sentiment,
+                          "two long transcripts with clearly opposite valence must not collapse to the same score")
+        XCTAssertGreaterThan(happyPack?.sentiment ?? -99, sadPack?.sentiment ?? 99,
+                             "the happier transcript's sentiment must score higher than the sadder one's")
+    }
+
+    // MARK: - Modal lean (word-identity, per surface word)
+
+    func testModalFamilies_sixFamiliesWithExactWords() {
+        XCTAssertEqual(MarkerLexicons.modalFamilies[.possibility], ["can", "could"])
+        XCTAssertEqual(MarkerLexicons.modalFamilies[.obligation], ["should", "must", "ought"])
+        XCTAssertEqual(MarkerLexicons.modalFamilies[.counterfactual], ["would"])
+        XCTAssertEqual(MarkerLexicons.modalFamilies[.tentative], ["might", "may"])
+        XCTAssertEqual(MarkerLexicons.modalFamilies[.intention], ["will"])
+        XCTAssertEqual(MarkerLexicons.modalFamilies[.desire], ["want", "need", "wish"])
+    }
+
+    func testModalCounts_perSurfaceWord() {
+        let pack = MarkerAnalyzer.compute(
+            text: "I should call her. I must decide. I should also apologize. Ought I go?",
+            languageCode: "en"
+        )
+        XCTAssertEqual(pack?.modalCounts["should"], 2)
+        XCTAssertEqual(pack?.modalCounts["must"], 1)
+        XCTAssertEqual(pack?.modalCounts["ought"], 1)
+        XCTAssertNil(pack?.modalCounts["would"], "a family member that never occurred is absent, not zero")
+    }
+
+    func testModalCounts_nonModalWords_notCounted() {
+        let pack = MarkerAnalyzer.compute(text: "The candle can hold canned goods too", languageCode: "en")
+        XCTAssertEqual(pack?.modalCounts["can"], 1, "only the standalone word 'can', not substrings inside other words")
+    }
+
+    /// A schema-v2 file on disk was written before `modalCounts` existed —
+    /// its JSON has no such key. It must still decode (as empty, not throw):
+    /// a decode failure would make `loadAllIncludingStaleVersions` silently
+    /// drop the file, so the backfill's stale-orphan sweep could never see
+    /// or clean it up (see docs/solutions/derived-cache-semantics-are-schema.md).
+    func testMarkerPack_decodesLeniently_whenModalCountsKeyMissing() throws {
+        let legacyJSON = """
+            {"wordCount": 10, "absolutistCount": 1, "firstPersonCount": 1, "insightCount": 0, \
+            "causationCount": 0, "discrepancyCount": 0, "futureCount": 0, "pastCount": 0, "sentiment": null}
+            """
+        let pack = try JSONDecoder().decode(MarkerPack.self, from: Data(legacyJSON.utf8))
+        XCTAssertEqual(pack.modalCounts, [:])
+        XCTAssertEqual(pack.wordCount, 10)
+    }
 }

--- a/UnitTests/ThreadsBackfillTests.swift
+++ b/UnitTests/ThreadsBackfillTests.swift
@@ -16,6 +16,7 @@ final class ThreadsBackfillTests: XCTestCase {
     private static let legacyCompletedKeyV1 = "threadsBackfillCompleted"
     private static let legacyCompletedKeyV2 = "threadsBackfillCompletedV2"
     private static let legacyCompletedKeyV3 = "threadsBackfillCompletedV3"
+    private static let legacyCompletedKeyV4 = "threadsBackfillCompletedV4"
 
     private var store: TranscriptContextStore!
     private var directory: URL!
@@ -23,6 +24,7 @@ final class ThreadsBackfillTests: XCTestCase {
     private var savedLegacyCompletedV1: Any?
     private var savedLegacyCompletedV2: Any?
     private var savedLegacyCompletedV3: Any?
+    private var savedLegacyCompletedV4: Any?
     private var savedMoonState: Any?
     private var savedToggle = true
 
@@ -32,12 +34,14 @@ final class ThreadsBackfillTests: XCTestCase {
         savedLegacyCompletedV1 = UserDefaults.standard.object(forKey: Self.legacyCompletedKeyV1)
         savedLegacyCompletedV2 = UserDefaults.standard.object(forKey: Self.legacyCompletedKeyV2)
         savedLegacyCompletedV3 = UserDefaults.standard.object(forKey: Self.legacyCompletedKeyV3)
+        savedLegacyCompletedV4 = UserDefaults.standard.object(forKey: Self.legacyCompletedKeyV4)
         savedMoonState = UserDefaults.standard.object(forKey: ThreadsDossierBuilder.moonLineDefaultsKey)
         savedToggle = UserPreferences.threadsAfterWalks.value
         UserDefaults.standard.set(false, forKey: ThreadsBackfill.completedKey)
         UserDefaults.standard.removeObject(forKey: Self.legacyCompletedKeyV1)
         UserDefaults.standard.removeObject(forKey: Self.legacyCompletedKeyV2)
         UserDefaults.standard.removeObject(forKey: Self.legacyCompletedKeyV3)
+        UserDefaults.standard.removeObject(forKey: Self.legacyCompletedKeyV4)
         UserPreferences.threadsAfterWalks.value = true
         directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("ThreadsBackfillTests-\(UUID().uuidString)")
@@ -64,6 +68,11 @@ final class ThreadsBackfillTests: XCTestCase {
             UserDefaults.standard.set(savedLegacyCompletedV3, forKey: Self.legacyCompletedKeyV3)
         } else {
             UserDefaults.standard.removeObject(forKey: Self.legacyCompletedKeyV3)
+        }
+        if let savedLegacyCompletedV4 {
+            UserDefaults.standard.set(savedLegacyCompletedV4, forKey: Self.legacyCompletedKeyV4)
+        } else {
+            UserDefaults.standard.removeObject(forKey: Self.legacyCompletedKeyV4)
         }
         if let savedMoonState {
             UserDefaults.standard.set(savedMoonState, forKey: ThreadsDossierBuilder.moonLineDefaultsKey)
@@ -117,6 +126,20 @@ final class ThreadsBackfillTests: XCTestCase {
 
         XCTAssertFalse(ThreadsBackfill.isComplete,
                        "a device that completed the stale-schema V3 sweep must re-evaluate under the new key")
+    }
+
+    /// V4 devices completed a real sweep under schema v2, but that schema
+    /// carries no modal-lean word counts (`MarkerPack.modalCounts` didn't
+    /// exist yet) — schema v3 adds them. The V5 rename (completedKey) re-arms
+    /// them the same way every prior rename did: the new key is absent
+    /// regardless of what the V4 key holds. Unlike V3→V4, this rename
+    /// touches no theme-extraction logic, so no moon-line re-arm accompanies
+    /// it (see `performLegacyHygiene`).
+    func testIsComplete_legacyV4KeyTrue_reArmsUnderNewKey() {
+        UserDefaults.standard.set(true, forKey: Self.legacyCompletedKeyV4)
+
+        XCTAssertFalse(ThreadsBackfill.isComplete,
+                       "a device that completed the pre-modal-lean V4 sweep must re-evaluate under the new key")
     }
 
     /// The where-clause skip (`!store.hasContext`) must become version-aware

--- a/UnitTests/ThreadsDossierModalLeanTests.swift
+++ b/UnitTests/ThreadsDossierModalLeanTests.swift
@@ -1,0 +1,164 @@
+import XCTest
+@testable import Pilgrim
+
+/// Modal-lean clause coverage — split from `ThreadsDossierTests` to keep
+/// both files under the file_length / type_body_length lint gates (same
+/// house rule as `ThreadsDossierSensesTests.swift`). Reuses the parent
+/// class's `markers`/`context` fixture builders.
+extension ThreadsDossierTests {
+
+    func testModalBaseline_needsThreeQualifyingWalks() {
+        let walkA = UUID(), walkB = UUID(), walkC = UUID(), currentWalk = UUID()
+        let ctxA = context(words: 200, absolutist: 2, modalCounts: ["should": 5])
+        let ctxB = context(words: 200, absolutist: 2, modalCounts: ["should": 5])
+        let twoWalkIndex: [UUID: UUID] = [ctxA.recordingUUID: walkA, ctxB.recordingUUID: walkB]
+        XCTAssertNil(ThreadsDossierFormatter.modalBaseline(
+            from: [ctxA, ctxB], walkIndex: twoWalkIndex, excluding: currentWalk
+        ), "two prior contexted walks is below the three-walk floor")
+
+        let ctxC = context(words: 200, absolutist: 2, modalCounts: ["should": 5])
+        let threeWalkIndex = twoWalkIndex.merging([ctxC.recordingUUID: walkC]) { a, _ in a }
+        XCTAssertNotNil(ThreadsDossierFormatter.modalBaseline(
+            from: [ctxA, ctxB, ctxC], walkIndex: threeWalkIndex, excluding: currentWalk
+        ), "three prior contexted walks meets the floor")
+    }
+
+    /// Exact-pin: the shipped clause format, mirroring the absolutist
+    /// baseline's own conventions (density-floor-qualified history, "your
+    /// usual" phrasing register) but per-walk rather than per-recording.
+    func testModalLean_dominantFamilyOverBaseline_firesExactPin() {
+        let currentWalk = UUID()
+        let walkA = UUID(), walkB = UUID(), walkC = UUID()
+        let priorA = context(words: 300, absolutist: 2, modalCounts: ["should": 8])
+        let priorB = context(words: 300, absolutist: 2, modalCounts: ["should": 8])
+        let priorC = context(words: 300, absolutist: 2, modalCounts: ["should": 8])
+        let today = context(words: 400, absolutist: 2, modalCounts: ["should": 31])
+
+        let walkIndex: [UUID: UUID] = [
+            priorA.recordingUUID: walkA, priorB.recordingUUID: walkB,
+            priorC.recordingUUID: walkC, today.recordingUUID: currentWalk
+        ]
+        let dossier = ThreadsDossierFormatter.dossier(
+            currentRecordings: [(today, nil)],
+            allContexts: [priorA, priorB, priorC, today],
+            threads: [], currentWalkUUID: currentWalk, backfillComplete: false,
+            walkIndex: walkIndex
+        )
+        XCTAssertTrue(
+            dossier!.contains("modal lean: obligation — 'should' ×31 (your usual ~8 per walk)"),
+            "actual: \(dossier ?? "nil")"
+        )
+    }
+
+    func testModalLean_silentWithoutBaseline_firstWalksNeverSpeak() {
+        let currentWalk = UUID()
+        let today = context(words: 400, absolutist: 2, modalCounts: ["should": 31])
+        let dossier = ThreadsDossierFormatter.dossier(
+            currentRecordings: [(today, nil)], allContexts: [today],
+            threads: [], currentWalkUUID: currentWalk, backfillComplete: false,
+            walkIndex: [today.recordingUUID: currentWalk]
+        )
+        XCTAssertFalse(dossier!.contains("modal lean"), "no baseline exists yet — the clause stays silent")
+    }
+
+    func testModalLean_silentWhenBelowMinimumCount() {
+        let currentWalk = UUID()
+        let walkA = UUID(), walkB = UUID(), walkC = UUID()
+        let priorA = context(words: 300, absolutist: 2, modalCounts: ["should": 1])
+        let priorB = context(words: 300, absolutist: 2, modalCounts: ["should": 1])
+        let priorC = context(words: 300, absolutist: 2, modalCounts: ["should": 1])
+        let today = context(words: 400, absolutist: 2, modalCounts: ["should": 9])  // below the count floor
+        let walkIndex: [UUID: UUID] = [
+            priorA.recordingUUID: walkA, priorB.recordingUUID: walkB,
+            priorC.recordingUUID: walkC, today.recordingUUID: currentWalk
+        ]
+        let dossier = ThreadsDossierFormatter.dossier(
+            currentRecordings: [(today, nil)],
+            allContexts: [priorA, priorB, priorC, today],
+            threads: [], currentWalkUUID: currentWalk, backfillComplete: false,
+            walkIndex: walkIndex
+        )
+        XCTAssertFalse(dossier!.contains("modal lean"), "a family count under 10 is never remarkable, whatever the ratio")
+    }
+
+    func testModalLean_silentWhenNotElevatedOverBaseline() {
+        let currentWalk = UUID()
+        let walkA = UUID(), walkB = UUID(), walkC = UUID()
+        let priorA = context(words: 100, absolutist: 2, modalCounts: ["should": 10])
+        let priorB = context(words: 100, absolutist: 2, modalCounts: ["should": 10])
+        let priorC = context(words: 100, absolutist: 2, modalCounts: ["should": 10])
+        // Today's rate (11/300 ≈ 3.7%) sits below the walker's own 10% baseline rate,
+        // let alone 2x it — the count floor (11 ≥ 10) alone must not be enough to fire.
+        let today = context(words: 300, absolutist: 2, modalCounts: ["should": 11])
+        let walkIndex: [UUID: UUID] = [
+            priorA.recordingUUID: walkA, priorB.recordingUUID: walkB,
+            priorC.recordingUUID: walkC, today.recordingUUID: currentWalk
+        ]
+        let dossier = ThreadsDossierFormatter.dossier(
+            currentRecordings: [(today, nil)],
+            allContexts: [priorA, priorB, priorC, today],
+            threads: [], currentWalkUUID: currentWalk, backfillComplete: false,
+            walkIndex: walkIndex
+        )
+        XCTAssertFalse(dossier!.contains("modal lean"), "a walker's usual rate this high is not news")
+    }
+
+    func testModalLean_silentWithNoModalWordsSpoken() {
+        let currentWalk = UUID()
+        let today = context(words: 400, absolutist: 2)
+        let dossier = ThreadsDossierFormatter.dossier(
+            currentRecordings: [(today, nil)], allContexts: [today],
+            threads: [], currentWalkUUID: currentWalk, backfillComplete: false,
+            walkIndex: [today.recordingUUID: currentWalk]
+        )
+        XCTAssertFalse(dossier!.contains("modal lean"))
+    }
+
+    /// End-to-end wiring check: `ThreadsDossierBuilder.build`'s own
+    /// `walkIndex: [UUID: (walkUUID: UUID, date: Date)]` must actually reach
+    /// the formatter's per-walk baseline grouping, not just the pure
+    /// formatter tests above.
+    func testBuilder_modalLean_wiredThroughToRealBuild() {
+        let saved = UserPreferences.threadsAfterWalks.value
+        defer { UserPreferences.threadsAfterWalks.value = saved }
+        UserPreferences.threadsAfterWalks.value = true
+
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("DossierBuilderTests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = TranscriptContextStore(directory: directory)
+
+        let walkA = UUID(), walkB = UUID(), walkC = UUID(), currentWalk = UUID()
+        func priorContext() -> TranscriptContext {
+            let ctx = TranscriptContext(
+                schemaVersion: TranscriptContext.currentSchemaVersion, recordingUUID: UUID(),
+                transcriptHash: "h-\(UUID())", languageCode: "en", wordCount: 300, themes: [],
+                markers: markers(words: 300, absolutist: 2, modalCounts: ["should": 8])
+            )
+            store.save(ctx)
+            return ctx
+        }
+        let priorA = priorContext(), priorB = priorContext(), priorC = priorContext()
+
+        let recordingUUID = UUID()
+        let text = String(repeating: "should ", count: 31) + String(repeating: "walking word ", count: 85)
+        let recording = RecordingContext(
+            text: text, timestamp: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            startCoordinate: nil, endCoordinate: nil, wordsPerMinute: nil, recordingUUID: recordingUUID
+        )
+        let walkIndex: [UUID: (walkUUID: UUID, date: Date)] = [
+            priorA.recordingUUID: (walkA, DateFactory.makeDate(2024, 6, 1, 9, 0, 0)),
+            priorB.recordingUUID: (walkB, DateFactory.makeDate(2024, 6, 3, 9, 0, 0)),
+            priorC.recordingUUID: (walkC, DateFactory.makeDate(2024, 6, 5, 9, 0, 0)),
+            recordingUUID: (currentWalk, DateFactory.makeDate(2024, 6, 15, 9, 0, 0))
+        ]
+
+        let dossier = ThreadsDossierBuilder.build(
+            walkUUID: currentWalk, recordings: [recording], walkIndex: walkIndex, store: store
+        )
+        XCTAssertTrue(
+            dossier!.contains("modal lean: obligation — 'should' ×31 (your usual ~8 per walk)"),
+            "actual: \(dossier ?? "nil")"
+        )
+    }
+}

--- a/UnitTests/ThreadsDossierTests.swift
+++ b/UnitTests/ThreadsDossierTests.swift
@@ -3,19 +3,23 @@ import XCTest
 
 final class ThreadsDossierTests: XCTestCase {
 
-    private func markers(words: Int, absolutist: Int) -> MarkerPack {
+    /// Not `private`: `ThreadsDossierModalLeanTests.swift` (an `extension
+    /// ThreadsDossierTests` split into its own file to stay under the
+    /// file_length / type_body_length lint gates — same house rule as
+    /// `ThreadsDossierSensesTests.swift`) reuses these fixture builders.
+    func markers(words: Int, absolutist: Int, modalCounts: [String: Int] = [:]) -> MarkerPack {
         MarkerPack(
             wordCount: words, absolutistCount: absolutist, firstPersonCount: 5,
             insightCount: 2, causationCount: 1, discrepancyCount: 1,
-            futureCount: 4, pastCount: 1, sentiment: -0.2
+            futureCount: 4, pastCount: 1, sentiment: -0.2, modalCounts: modalCounts
         )
     }
 
-    private func context(words: Int, absolutist: Int) -> TranscriptContext {
+    func context(words: Int, absolutist: Int, modalCounts: [String: Int] = [:]) -> TranscriptContext {
         TranscriptContext(
             schemaVersion: 1, recordingUUID: UUID(), transcriptHash: "h",
             languageCode: "en", wordCount: words, themes: [],
-            markers: markers(words: words, absolutist: absolutist)
+            markers: markers(words: words, absolutist: absolutist, modalCounts: modalCounts)
         )
     }
 
@@ -46,6 +50,10 @@ final class ThreadsDossierTests: XCTestCase {
         let line = ThreadsDossierFormatter.markerLine(for: today, baseline: baseline)
         XCTAssertTrue(line.contains("your usual"))
     }
+
+    // Modal-lean coverage lives in ThreadsDossierModalLeanTests.swift (an
+    // `extension ThreadsDossierTests` split into its own file to stay under
+    // the file_length / type_body_length lint gates).
 
     func testBuilder_toggleOffReturnsNil() {
         let saved = UserPreferences.threadsAfterWalks.value


### PR DESCRIPTION
*The dossier already counted the walker's shoulds; now it knows what they weigh.*

## What's new

- **Modal lean** — a new marker clause naming the dominant modal family with word identity: `modal lean: obligation — 'should' ×31 (your usual ~8 per walk)`. Six families (possibility, obligation, counterfactual, tentative, intention, desire — the NVC frame), one clause max, baseline-compared, silent by default and silent entirely until three walks of history. Rides the same handling note that just passed LLM-readback QA on real dossiers.
- **Topics are topics again** — modals join the recurring-word scaffold list, so "'can' returns 57 times" stops competing with 'river' for the attention slot; its signal now lives in the markers channel where the guardrail is.
- **Sentiment tells the truth** — root-caused the field mystery of three different recordings all reading −0.60: NLTagger's sentiment collapses toward a constant past ~150 words. Fixed with per-sentence tagging and averaging; opposite-valence transcripts now measurably differ (regression-pinned).
- **Schema v3 via the new machinery** — persisting modal counts is a derived-semantics change, so this PR is the first real exercise of `docs/solutions/derived-cache-semantics-are-schema.md`: version bump, V5 re-arm, version-aware freshness propagating through one constant, lenient decode keeping old files visible to the janitor while excluded from readers. The lesson held.

## Evidence

Suite **1,388 / 0** (14 new, all RED-first) · SwiftLint 398/0 byte-identical · review: Approved — sentiment mechanism, schema checklist, and both deviations independently verified; no moon re-arm needed (marker data never feeds the moon line, traced).

🤖 Generated with [Claude Code](https://claude.com/claude-code)