### PR TITLE
fix(threads): the gate speaks — questions cut, clouds humbled, days set free

### DIFF
--- a/Pilgrim/Models/Data/DataManager+VoiceRecording.swift
+++ b/Pilgrim/Models/Data/DataManager+VoiceRecording.swift
@@ -136,23 +136,15 @@ extension DataManager {
     /// never carries a bridged `UUID`/`NSUUID`, only the string CoreStore
     /// wrote. `rowUUID` undoes that encoding explicitly instead of relying
     /// on a cast that can only ever fail.
-    /// `range`, when supplied, bounds the fetch to recordings whose start
-    /// falls inside it — the senses' in-window transcript reads never pull
-    /// the whole table (spec: bounded fetch). `nil` preserves the original
-    /// all-recordings behavior for the existing backfill caller.
     @MainActor
-    public static func transcribedRecordingsSnapshot(
-        in range: ClosedRange<Date>? = nil
-    ) -> [(uuid: UUID, transcript: String)] {
-        var query = From<VoiceRecording>().select(
-            NSDictionary.self,
-            .attribute(\._uuid),
-            .attribute(\._transcription)
-        )
-        if let range {
-            query = query.where(\._startDate >= range.lowerBound && \._startDate <= range.upperBound)
-        }
-        guard let rows = try? dataStack.queryAttributes(query) else { return [] }
+    public static func transcribedRecordingsSnapshot() -> [(uuid: UUID, transcript: String)] {
+        guard let rows = try? dataStack.queryAttributes(
+            From<VoiceRecording>().select(
+                NSDictionary.self,
+                .attribute(\._uuid),
+                .attribute(\._transcription)
+            )
+        ) else { return [] }
         return rows.compactMap { row in
             guard let uuid = rowUUID(row["id"]),
                   let transcript = row["transcription"] as? String,

--- a/Pilgrim/Models/Threads/DossierSenses.swift
+++ b/Pilgrim/Models/Threads/DossierSenses.swift
@@ -192,10 +192,6 @@ extension DossierSenses {
         return "\(n) times"
     }
 
-    static func capitalizedCount(_ n: Int) -> String {
-        spelledSmall[n]?.capitalized ?? "\(n)"
-    }
-
     static func ordinalWord(_ n: Int) -> String {
         if let word = ordinalWords[n] { return word }
         if (11...13).contains(n % 100) { return "\(n)th" }

--- a/Pilgrim/Models/Threads/DossierSenses.swift
+++ b/Pilgrim/Models/Threads/DossierSenses.swift
@@ -22,9 +22,6 @@ enum DossierSenses {
     static let markerWindowRadius = 15
     static let markerMinWindowAbsolutist = 3
     static let markerMinDensityRatio = 2.0
-    static let questionMinCount = 3
-    static let questionMinHistoryWalks = 3
-    static let questionMedianRatio = 2.0
     static let speechShapeMinWordlessRemainder: TimeInterval = 30 * 60
     static let lineageMinWalks = 3
 
@@ -87,9 +84,7 @@ enum DossierSenses {
         let threads: [WalkThread]
         let backfillComplete: Bool
         let walkSnapshots: [WalkSnapshotRow]
-        let historyTranscripts: [(recordingUUID: UUID, transcript: String)]
         let recordingTimestamps: [UUID: Date]
-        let walkIndex: [UUID: (walkUUID: UUID, date: Date)]
         let fixes: [UUID: RouteFix]
         let moon: MoonInput?
     }
@@ -105,11 +100,14 @@ enum DossierSenses {
     }
 
     /// Declaration order IS the spec's binding priority order — reordering
-    /// cases reorders the block.
+    /// cases reorders the block. `questionDensity` was cut at the ship gate
+    /// (2026-08-25): real-device history fired it once, and the line was a
+    /// Whisper punctuation artifact ("151 of today's sentences were
+    /// questions"), not genuine question density — the spec's own
+    /// contingency was to cut at the gate, not patch.
     enum Sense: CaseIterable {
         case placeResonance, moonLine, markerColoring, intentionLineage,
-             climbAnchoring, weatherWeave, photoAdjacency, questionDensity,
-             speechShape
+             climbAnchoring, weatherWeave, photoAdjacency, speechShape
     }
 
     /// `evaluate` is a test seam (same style as ThreadsBackfill's
@@ -147,7 +145,6 @@ enum DossierSenses {
         case .climbAnchoring: return climbAnchoring(input: input, suppressed: suppressed)
         case .weatherWeave: return weatherWeave(input: input, suppressed: suppressed)
         case .photoAdjacency: return photoAdjacency(input: input, suppressed: suppressed)
-        case .questionDensity: return questionDensity(input: input, suppressed: suppressed)
         case .speechShape: return speechShape(input: input, suppressed: suppressed)
         }
     }

--- a/Pilgrim/Models/Threads/DossierSensesTracks.swift
+++ b/Pilgrim/Models/Threads/DossierSensesTracks.swift
@@ -162,37 +162,6 @@ extension DossierSenses {
     }
 }
 
-// MARK: - Track 4: question density (cross-walk)
-
-extension DossierSenses {
-
-    static func questionCount(in text: String) -> Int {
-        text.filter { $0 == "?" }.count
-    }
-
-    static func questionDensity(input: Input, suppressed: Set<String>) -> SenseLine? {
-        let todayCount = input.currentRecordings.reduce(0) { $0 + questionCount(in: $1.text) }
-        guard todayCount >= questionMinCount else { return nil }
-        let windowStart = input.walkStart.addingTimeInterval(-ThreadStore.recurrenceWindow)
-        var countsByWalk: [UUID: Int] = [:]
-        for entry in input.historyTranscripts {
-            guard let walk = input.walkIndex[entry.recordingUUID],
-                  walk.walkUUID != input.currentWalkUUID,
-                  let instant = input.recordingTimestamps[entry.recordingUUID],
-                  instant >= windowStart, instant <= input.walkEnd else { continue }
-            countsByWalk[walk.walkUUID, default: 0] += questionCount(in: entry.transcript)
-        }
-        guard countsByWalk.count >= questionMinHistoryWalks else { return nil }
-        let history = countsByWalk.values.sorted()
-        guard Double(todayCount) >= questionMedianRatio * median(history.map(Double.init)),
-              todayCount > history.last ?? 0 else { return nil }
-        return SenseLine(
-            text: "\(capitalizedCount(todayCount)) of today's sentences were questions — more than any walk in the last 30 days.",
-            lemma: nil
-        )
-    }
-}
-
 // MARK: - Track 4: theme-marker coloring (current walk)
 
 extension DossierSenses {
@@ -416,7 +385,7 @@ extension DossierSenses {
         case .rain: return "under rain"
         case .snow: return "under snow"
         case .clear: return "under clear skies"
-        case .cloud: return "under cloud"
+        case .cloud: return "under clouds"
         case .wind: return "in wind"
         case .fog: return "in fog"
         case .unknown: return nil
@@ -432,8 +401,14 @@ extension DossierSenses {
         }
         let known = buckets.values.filter { $0 != .unknown }
         guard !known.isEmpty else { return nil }
-        let majority = Dictionary(grouping: known, by: { $0 })
-            .first { Double($0.value.count) / Double(known.count) > 0.5 }?.key
+        // Ship gate (2026-08-25): the guard tightened from "majority" (>50%)
+        // to "mode" — 4/4 real-device firings were a plurality tautology
+        // ("under cloud" without any condition holding a true majority). The
+        // shared category now fires only when its count is strictly below
+        // the window's highest condition count; a tie with the mode counts
+        // as the mode and still suppresses (conservative).
+        let conditionCounts = Dictionary(grouping: known, by: { $0 }).mapValues(\.count)
+        let modeCount = conditionCounts.values.max() ?? 0
         for thread in activeThreads(in: input) where !suppressed.contains(thread.lemma) {
             let walkUUIDs = Set(
                 thread.appearances
@@ -445,7 +420,7 @@ extension DossierSenses {
             guard let shared = themeBuckets.first,
                   shared != .unknown,
                   themeBuckets.allSatisfy({ $0 == shared }),
-                  shared != majority,
+                  conditionCounts[shared, default: 0] < modeCount,
                   let phrase = skyPhrase(shared) else { continue }
             let head = walkUUIDs.count == 2 ? "Both walks" : "All \(walkUUIDs.count) walks"
             return SenseLine(text: "\(head) where '\(thread.displayTerm)' surfaced were \(phrase).",

--- a/Pilgrim/Models/Threads/ThreadsBackfill.swift
+++ b/Pilgrim/Models/Threads/ThreadsBackfill.swift
@@ -5,7 +5,7 @@ import Foundation
 /// once history is fully analyzed (spec: ThreadStore).
 enum ThreadsBackfill {
 
-    static let completedKey = "threadsBackfillCompletedV5"
+    static let completedKey = "threadsBackfillCompletedV6"
     /// v1.11.0 TestFlight devices could run the sweep, account for zero
     /// recordings under a snapshot bug (fixed alongside the V2 rename), and
     /// still set the old flag — stranding those devices on a never-swept
@@ -26,11 +26,17 @@ enum ThreadsBackfill {
     /// clause has real word-identity history to build a baseline from —
     /// unlike V3→V4, this rename touches no theme-extraction logic, so no
     /// moon-line re-arm accompanies it (`performLegacyHygiene` still only
-    /// watches the V3 key for that).
+    /// watches the V3 key for that). V6 (ship gate, 2026-08-25) adds `day`,
+    /// `days`, `area` to `SpokenStoplist.lightNouns` (schema v3→v4), a
+    /// narrower theme-extraction change than V2→V3's — like V4→V5, no
+    /// moon-line re-arm accompanies it; `performLegacyHygiene` still only
+    /// watches the V3 key.
     private static let legacyCompletedKeyV3 = "threadsBackfillCompletedV3"
     private static let legacyCompletedKeyV4 = "threadsBackfillCompletedV4"
+    private static let legacyCompletedKeyV5 = "threadsBackfillCompletedV5"
     private static let legacyCompletedKeys = [
-        "threadsBackfillCompleted", "threadsBackfillCompletedV2", legacyCompletedKeyV3, legacyCompletedKeyV4
+        "threadsBackfillCompleted", "threadsBackfillCompletedV2",
+        legacyCompletedKeyV3, legacyCompletedKeyV4, legacyCompletedKeyV5
     ]
     private static var isRunning = false
     private static var generation = 0

--- a/Pilgrim/Models/Threads/ThreadsDossierBuilder.swift
+++ b/Pilgrim/Models/Threads/ThreadsDossierBuilder.swift
@@ -11,7 +11,6 @@ struct DossierSensesFetchBundle {
     let elevationSeries: [DossierSenses.ElevationSample]
     let photos: [DossierSenses.PhotoPin]
     let walkSnapshots: [DossierSenses.WalkSnapshotRow]
-    let historyTranscripts: [(recordingUUID: UUID, transcript: String)]
     let recordingTimestamps: [UUID: Date]
     let closedLunation: Lunation
     let moonName: String
@@ -73,13 +72,6 @@ enum ThreadsDossierBuilder {
                 from: min(windowStart, lunation.start),
                 to: max(walk.endDate, lunation.end)
             ),
-            // Relabeled: `transcribedRecordingsSnapshot` returns `uuid:`,
-            // matching its other DataManager snapshot siblings; the senses
-            // bundle's tuple shape is `recordingUUID:`, matching
-            // `DossierSenses.Input` — the labels are structurally
-            // interchangeable but Swift does not convert them implicitly.
-            historyTranscripts: DataManager.transcribedRecordingsSnapshot(in: windowStart...walk.endDate)
-                .map { (recordingUUID: $0.uuid, transcript: $0.transcript) },
             recordingTimestamps: DataManager.voiceRecordingTimestampIndex(),
             closedLunation: lunation,
             moonName: LunationCalendar.moonName(for: lunation)
@@ -350,9 +342,7 @@ enum ThreadsDossierBuilder {
             threads: state.threads,
             backfillComplete: state.backfillComplete,
             walkSnapshots: senses.walkSnapshots,
-            historyTranscripts: senses.historyTranscripts,
             recordingTimestamps: senses.recordingTimestamps,
-            walkIndex: state.walkIndex,
             fixes: fixes,
             moon: moon
         )

--- a/Pilgrim/Models/Threads/TranscriptContext.swift
+++ b/Pilgrim/Models/Threads/TranscriptContext.swift
@@ -17,7 +17,12 @@ struct TranscriptContext: Codable, Equatable {
     /// stale-orphan sweep can still see it — but it carries no modal data,
     /// which would silently starve the modal-lean baseline of history; the
     /// bump forces those recordings to re-analyze.
-    static let currentSchemaVersion = 3
+    ///
+    /// v4 (ship gate, 2026-08-25): `SpokenStoplist.lightNouns` gained `day`,
+    /// `days`, `area` — a v3 file's stored themes may still carry one of
+    /// those as a generic noun rather than topical content, so the bump
+    /// forces re-analysis under `ThemeExtractor`'s tightened stoplist.
+    static let currentSchemaVersion = 4
 
     let schemaVersion: Int
     let recordingUUID: UUID

--- a/Pilgrim/Models/Threads/TranscriptNLP.swift
+++ b/Pilgrim/Models/Threads/TranscriptNLP.swift
@@ -139,10 +139,15 @@ enum TranscriptNLP {
 /// this gap between lexical class and topical content.
 enum SpokenStoplist {
 
-    /// Filler nouns filtered out of THEME extraction (nouns only).
+    /// Filler nouns filtered out of THEME extraction (nouns only). `day`,
+    /// `days`, and `area` joined at the ship gate (2026-08-25): real-device
+    /// history showed place resonance threading 'day' (17 mentions near the
+    /// same ground) and photo adjacency threading 'area' — the same
+    /// generic-noun class as `thing`/`way`, not topical content.
     static let lightNouns: Set<String> = [
         "thing", "things", "stuff", "kind", "sort", "lot", "bit", "way", "ways",
-        "one", "ones", "something", "anything", "everything", "nothing"
+        "one", "ones", "something", "anything", "everything", "nothing",
+        "day", "days", "area"
     ]
 
     /// Light/auxiliary/modal verbs plus the filler nouns above, filtered out

--- a/UnitTests/DossierSensesCrossWalkTests.swift
+++ b/UnitTests/DossierSensesCrossWalkTests.swift
@@ -17,9 +17,7 @@ final class DossierSensesCrossWalkTests: XCTestCase {
         threads: [WalkThread] = [],
         backfillComplete: Bool = true,
         walkSnapshots: [DossierSenses.WalkSnapshotRow] = [],
-        historyTranscripts: [(recordingUUID: UUID, transcript: String)] = [],
         recordingTimestamps: [UUID: Date] = [:],
-        walkIndex: [UUID: (walkUUID: UUID, date: Date)] = [:],
         fixes: [UUID: DossierSenses.RouteFix] = [:],
         moon: DossierSenses.MoonInput? = nil
     ) -> DossierSenses.Input {
@@ -28,8 +26,7 @@ final class DossierSensesCrossWalkTests: XCTestCase {
             totalAscent: totalAscent, elevationSeries: elevationSeries, photos: photos,
             currentRecordings: currentRecordings, threads: threads,
             backfillComplete: backfillComplete, walkSnapshots: walkSnapshots,
-            historyTranscripts: historyTranscripts, recordingTimestamps: recordingTimestamps,
-            walkIndex: walkIndex, fixes: fixes, moon: moon
+            recordingTimestamps: recordingTimestamps, fixes: fixes, moon: moon
         )
     }
 
@@ -139,13 +136,34 @@ final class DossierSensesCrossWalkTests: XCTestCase {
         XCTAssertNil(DossierSenses.weatherWeave(input: input, suppressed: []))
     }
 
-    func testWeatherWeave_pluralityWithoutMajority_doesNotSuppress() {
+    /// Ship gate (2026-08-25) tightened the climate guard from majority
+    /// (>50%) to mode: rain (2/5) ties clear (2/5, snow 1/5) for the
+    /// window's most common condition — no true majority exists, but the
+    /// tightened guard suppresses ties too (conservative). This deliberately
+    /// supersedes the prior design decision, which let this exact tie fire
+    /// (formerly `testWeatherWeave_pluralityWithoutMajority_doesNotSuppress`).
+    func testWeatherWeave_tiedForMode_suppresses() {
         let input = weaveInput(themeWalkWeather: ["lightRain", "heavyRain"],
                                otherWalkWeather: ["clear", "clear", "snow"])
+        XCTAssertNil(DossierSenses.weatherWeave(input: input, suppressed: []),
+                     "rain ties clear for the window's mode (2/5 each) — a tie suppresses under the tightened guard")
+    }
+
+    /// A genuine minority against a non-majority mode: cloud is the window's
+    /// most common condition (3/6) without holding a >50% majority — the old
+    /// guard would have missed this case entirely. Rain (2/6) is still
+    /// strictly rarer than the mode, so the tightened guard still fires.
+    func testWeatherWeave_minorityAgainstNonMajorityMode_fires() {
+        let input = weaveInput(themeWalkWeather: ["lightRain", "heavyRain"],
+                               otherWalkWeather: ["partlyCloudy", "overcast", "haze", "snow"])
         XCTAssertEqual(
             DossierSenses.weatherWeave(input: input, suppressed: []),
             DossierSenses.SenseLine(text: "Both walks where 'music' surfaced were under rain.", lemma: "music")
         )
+    }
+
+    func testSkyPhrase_cloud_pinnedText() {
+        XCTAssertEqual(DossierSenses.skyPhrase(.cloud), "under clouds")
     }
 
     // MARK: - Place-theme resonance
@@ -337,67 +355,6 @@ final class DossierSensesCrossWalkTests: XCTestCase {
             todayIntention: "walk with the river"
         )
         XCTAssertNil(DossierSenses.intentionLineage(input: input, suppressed: []))
-    }
-
-    // MARK: - Question density
-
-    private func questionInput(today: String, history: [String]) -> DossierSenses.Input {
-        let currentWalk = UUID()
-        let recUUID = UUID()
-        var walkIndex: [UUID: (walkUUID: UUID, date: Date)] = [:]
-        var timestamps: [UUID: Date] = [:]
-        var transcripts: [(recordingUUID: UUID, transcript: String)] = []
-        for (i, text) in history.enumerated() {
-            let historyRec = UUID()
-            let date = Self.walkStart.addingTimeInterval(Double(i + 1) * -3 * 86400)
-            walkIndex[historyRec] = (UUID(), date)
-            timestamps[historyRec] = date.addingTimeInterval(600)
-            transcripts.append((historyRec, text))
-        }
-        return makeInput(
-            currentWalkUUID: currentWalk,
-            currentRecordings: [DossierSenses.CurrentRecording(
-                uuid: recUUID, start: Self.walkStart, end: Self.walkStart.addingTimeInterval(300),
-                text: today, wordCount: TranscriptNLP.wordCount(in: today), themes: []
-            )],
-            historyTranscripts: transcripts,
-            recordingTimestamps: timestamps,
-            walkIndex: walkIndex
-        )
-    }
-
-    func testQuestionDensity_todayDoublesTheMedianAndTopsEveryWalk_fires() {
-        let input = questionInput(
-            today: "Who sits with him? What changes? Why now? What am I holding?",
-            history: ["A question? Another?", "One thing today?", "No questions today at all."]
-        )
-        XCTAssertEqual(
-            DossierSenses.questionDensity(input: input, suppressed: []),
-            DossierSenses.SenseLine(
-                text: "Four of today's sentences were questions — more than any walk in the last 30 days.",
-                lemma: nil
-            )
-        )
-    }
-
-    func testQuestionDensity_tiedWithAHistoryWalk_doesNotFire() {
-        let input = questionInput(
-            today: "Who? What? Why?",
-            history: ["One? Two? Three?", "Quiet.", "Still quiet."]
-        )
-        XCTAssertNil(DossierSenses.questionDensity(input: input, suppressed: []),
-                     "today must EXCEED every other in-window walk, not tie one")
-    }
-
-    func testQuestionDensity_underThreeQuestions_doesNotFire() {
-        let input = questionInput(today: "Why now? What next?", history: ["Quiet.", "Quiet.", "Quiet."])
-        XCTAssertNil(DossierSenses.questionDensity(input: input, suppressed: []))
-    }
-
-    func testQuestionDensity_underThreeHistoryWalks_doesNotFire() {
-        let input = questionInput(today: "Who? What? Why?", history: ["Quiet.", "Quiet."])
-        XCTAssertNil(DossierSenses.questionDensity(input: input, suppressed: []),
-                     "≥3 walks of history required before a median means anything")
     }
 }
 

--- a/UnitTests/DossierSensesTests.swift
+++ b/UnitTests/DossierSensesTests.swift
@@ -122,8 +122,6 @@ final class DossierSensesTests: XCTestCase {
         XCTAssertEqual(DossierSenses.timesPhrase(2), "twice")
         XCTAssertEqual(DossierSenses.timesPhrase(3), "three times")
         XCTAssertEqual(DossierSenses.timesPhrase(10), "10 times")
-        XCTAssertEqual(DossierSenses.capitalizedCount(4), "Four")
-        XCTAssertEqual(DossierSenses.capitalizedCount(11), "11")
         XCTAssertEqual(DossierSenses.ordinalWord(5), "Fifth")
         XCTAssertEqual(DossierSenses.ordinalWord(12), "Twelfth")
         XCTAssertEqual(DossierSenses.ordinalWord(13), "13th")

--- a/UnitTests/DossierSensesTests.swift
+++ b/UnitTests/DossierSensesTests.swift
@@ -19,9 +19,7 @@ final class DossierSensesTests: XCTestCase {
         threads: [WalkThread] = [],
         backfillComplete: Bool = true,
         walkSnapshots: [DossierSenses.WalkSnapshotRow] = [],
-        historyTranscripts: [(recordingUUID: UUID, transcript: String)] = [],
         recordingTimestamps: [UUID: Date] = [:],
-        walkIndex: [UUID: (walkUUID: UUID, date: Date)] = [:],
         fixes: [UUID: DossierSenses.RouteFix] = [:],
         moon: DossierSenses.MoonInput? = nil
     ) -> DossierSenses.Input {
@@ -30,8 +28,7 @@ final class DossierSensesTests: XCTestCase {
             totalAscent: totalAscent, elevationSeries: elevationSeries, photos: photos,
             currentRecordings: currentRecordings, threads: threads,
             backfillComplete: backfillComplete, walkSnapshots: walkSnapshots,
-            historyTranscripts: historyTranscripts, recordingTimestamps: recordingTimestamps,
-            walkIndex: walkIndex, fixes: fixes, moon: moon
+            recordingTimestamps: recordingTimestamps, fixes: fixes, moon: moon
         )
     }
 
@@ -54,12 +51,13 @@ final class DossierSensesTests: XCTestCase {
             .speechShape: .init(text: "speech", lemma: nil),
             .climbAnchoring: .init(text: "climb", lemma: "river"),
             .placeResonance: .init(text: "place", lemma: "move"),
-            .questionDensity: .init(text: "question", lemma: nil),
+            .photoAdjacency: .init(text: "photo", lemma: "trail"),
             .weatherWeave: .init(text: "weather", lemma: "music")
         ]
         let output = DossierSenses.lines(input: makeInput(), evaluate: stub(firing))
         XCTAssertEqual(output.lines, ["place", "climb", "weather"],
-                       "cap 3, spec priority order: place(1) > climb(5) > weather(6) > question(8) > speech(9)")
+                       "cap 3, spec priority order: place(1) > climb(5) > weather(6) > photo(7) > speech(8) " +
+                       "(questionDensity cut at the ship gate — the enum now has 8 cases, not 9)")
     }
 
     func testEngine_themeNamedAtRankOne_neverReappearsAtLowerRank() {

--- a/UnitTests/FieldGateReportTests.swift
+++ b/UnitTests/FieldGateReportTests.swift
@@ -76,7 +76,7 @@ final class FieldGateReportTests: XCTestCase {
                 DossierSenses.WalkSnapshotRow(walkUUID: $0.walkUUID, startDate: $0.date,
                                               intention: nil, weatherCondition: nil)
             },
-            historyTranscripts: [], recordingTimestamps: [:], walkIndex: walks,
+            recordingTimestamps: [:],
             fixes: [:], moon: nil
         )
         var report = "\n===== SENSES FIELD GATE REPORT (fixtures) =====\n"

--- a/UnitTests/ThemeExtractorTests.swift
+++ b/UnitTests/ThemeExtractorTests.swift
@@ -51,4 +51,22 @@ final class ThemeExtractorTests: XCTestCase {
         let themes = ThemeExtractor.themes(in: text, languageCode: "en")
         XCTAssertEqual(themes.map(\.lemma), ["music"])
     }
+
+    // MARK: - lightNouns gate (ship gate, 2026-08-25): day/days/area
+
+    /// Field-confirmed: place resonance threaded 'day' (17 mentions near the
+    /// same ground) and photo adjacency threaded 'area' — generic nouns, the
+    /// same class as the already-stoplisted `thing`/`way`.
+    func testDayAndArea_stoplisted_yieldNoThemes() {
+        let text = "It was a long day, every day feels like the last day, and this whole area " +
+            "of the area near the area keeps repeating on me, day after day in this area"
+        XCTAssertTrue(ThemeExtractor.themes(in: text, languageCode: "en").isEmpty)
+    }
+
+    func testNounAmongDayAndArea_isTheOnlyTheme() {
+        let text = "Another long day thinking about the harbor, the harbor sits at the edge of the " +
+            "area, and the day always brings me back to the harbor whatever the area looks like"
+        let themes = ThemeExtractor.themes(in: text, languageCode: "en")
+        XCTAssertEqual(themes.map(\.lemma), ["harbor"])
+    }
 }

--- a/UnitTests/ThreadsBackfillTests.swift
+++ b/UnitTests/ThreadsBackfillTests.swift
@@ -17,6 +17,7 @@ final class ThreadsBackfillTests: XCTestCase {
     private static let legacyCompletedKeyV2 = "threadsBackfillCompletedV2"
     private static let legacyCompletedKeyV3 = "threadsBackfillCompletedV3"
     private static let legacyCompletedKeyV4 = "threadsBackfillCompletedV4"
+    private static let legacyCompletedKeyV5 = "threadsBackfillCompletedV5"
 
     private var store: TranscriptContextStore!
     private var directory: URL!
@@ -25,6 +26,7 @@ final class ThreadsBackfillTests: XCTestCase {
     private var savedLegacyCompletedV2: Any?
     private var savedLegacyCompletedV3: Any?
     private var savedLegacyCompletedV4: Any?
+    private var savedLegacyCompletedV5: Any?
     private var savedMoonState: Any?
     private var savedToggle = true
 
@@ -35,6 +37,7 @@ final class ThreadsBackfillTests: XCTestCase {
         savedLegacyCompletedV2 = UserDefaults.standard.object(forKey: Self.legacyCompletedKeyV2)
         savedLegacyCompletedV3 = UserDefaults.standard.object(forKey: Self.legacyCompletedKeyV3)
         savedLegacyCompletedV4 = UserDefaults.standard.object(forKey: Self.legacyCompletedKeyV4)
+        savedLegacyCompletedV5 = UserDefaults.standard.object(forKey: Self.legacyCompletedKeyV5)
         savedMoonState = UserDefaults.standard.object(forKey: ThreadsDossierBuilder.moonLineDefaultsKey)
         savedToggle = UserPreferences.threadsAfterWalks.value
         UserDefaults.standard.set(false, forKey: ThreadsBackfill.completedKey)
@@ -42,6 +45,7 @@ final class ThreadsBackfillTests: XCTestCase {
         UserDefaults.standard.removeObject(forKey: Self.legacyCompletedKeyV2)
         UserDefaults.standard.removeObject(forKey: Self.legacyCompletedKeyV3)
         UserDefaults.standard.removeObject(forKey: Self.legacyCompletedKeyV4)
+        UserDefaults.standard.removeObject(forKey: Self.legacyCompletedKeyV5)
         UserPreferences.threadsAfterWalks.value = true
         directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("ThreadsBackfillTests-\(UUID().uuidString)")
@@ -73,6 +77,11 @@ final class ThreadsBackfillTests: XCTestCase {
             UserDefaults.standard.set(savedLegacyCompletedV4, forKey: Self.legacyCompletedKeyV4)
         } else {
             UserDefaults.standard.removeObject(forKey: Self.legacyCompletedKeyV4)
+        }
+        if let savedLegacyCompletedV5 {
+            UserDefaults.standard.set(savedLegacyCompletedV5, forKey: Self.legacyCompletedKeyV5)
+        } else {
+            UserDefaults.standard.removeObject(forKey: Self.legacyCompletedKeyV5)
         }
         if let savedMoonState {
             UserDefaults.standard.set(savedMoonState, forKey: ThreadsDossierBuilder.moonLineDefaultsKey)
@@ -140,6 +149,18 @@ final class ThreadsBackfillTests: XCTestCase {
 
         XCTAssertFalse(ThreadsBackfill.isComplete,
                        "a device that completed the pre-modal-lean V4 sweep must re-evaluate under the new key")
+    }
+
+    /// V5 devices completed a real sweep under schema v3, but `day`/`days`/
+    /// `area` were still admitted as theme nouns — the same generic-noun
+    /// class as the already-stoplisted `thing`/`way`. The V6 rename (schema
+    /// v4) re-arms them the same way every prior rename did: the new key is
+    /// absent regardless of what the V5 key holds.
+    func testIsComplete_legacyV5KeyTrue_reArmsUnderNewKey() {
+        UserDefaults.standard.set(true, forKey: Self.legacyCompletedKeyV5)
+
+        XCTAssertFalse(ThreadsBackfill.isComplete,
+                       "a device that completed the pre-lightNouns-gate V5 sweep must re-evaluate under the new key")
     }
 
     /// The where-clause skip (`!store.hasContext`) must become version-aware

--- a/UnitTests/ThreadsDossierSensesTests.swift
+++ b/UnitTests/ThreadsDossierSensesTests.swift
@@ -18,7 +18,7 @@ extension ThreadsDossierTests {
         return DossierSensesFetchBundle(
             walkStart: walkStart, walkEnd: walkEnd, totalAscent: 0,
             elevationSeries: [], photos: [], walkSnapshots: walkSnapshots,
-            historyTranscripts: [], recordingTimestamps: recordingTimestamps,
+            recordingTimestamps: recordingTimestamps,
             closedLunation: lunation, moonName: LunationCalendar.moonName(for: lunation)
         )
     }

--- a/UnitTests/VoiceRecordingPersistenceTests.swift
+++ b/UnitTests/VoiceRecordingPersistenceTests.swift
@@ -364,25 +364,6 @@ final class VoiceRecordingPersistenceTests: XCTestCase {
     }
 
     @MainActor
-    func test_transcribedRecordingsSnapshot_rangeBoundsTheFetch() throws {
-        let previousDataStack = DataManager.dataStack
-        DataManager.dataStack = stack
-        defer { DataManager.dataStack = previousDataStack }
-
-        let inside = UUID(), outside = UUID()
-        try seedRecording(uuid: inside, transcription: "inside the window",
-                          startDate: Date(timeIntervalSince1970: 1_700_000_000))
-        try seedRecording(uuid: outside, transcription: "outside the window",
-                          startDate: Date(timeIntervalSince1970: 1_600_000_000))
-
-        let range = Date(timeIntervalSince1970: 1_699_999_000)...Date(timeIntervalSince1970: 1_700_001_000)
-        let snapshot = DataManager.transcribedRecordingsSnapshot(in: range)
-        XCTAssertEqual(snapshot.map(\.uuid), [inside])
-        XCTAssertEqual(DataManager.transcribedRecordingsSnapshot().count, 2,
-                       "nil range preserves the existing all-recordings behavior")
-    }
-
-    @MainActor
     func test_routeFixNear_returnsNearestSampleWithinNinetySeconds() throws {
         let previousDataStack = DataManager.dataStack
         DataManager.dataStack = stack

--- a/docs/superpowers/specs/2026-08-22-thought-threads-design.md
+++ b/docs/superpowers/specs/2026-08-22-thought-threads-design.md
@@ -521,7 +521,11 @@ nouns ("thing", "way", "stuff", and similar) for theme extraction, and a
 separate scaffold-lemma set ("be", "have", "think", and similar) for the
 `AttentionDirectives` recurring-word directive, which shares the same
 spoken-filler exposure outside theme extraction entirely. That fix stands
-on its own, regardless of the surface question below.
+on its own, regardless of the surface question below. (Ship gate,
+2026-08-25: `day`, `days`, and `area` joined `lightNouns` after further
+real-device evidence — place resonance threaded 'day' from 17 mentions
+near the same ground, photo adjacency threaded 'area' — the same
+generic-noun class as `thing`/`way`.)
 
 The surface question did not survive contact. Once themes were correctly
 nouns-only and re-run against a real transcript, the walker's verdict was to

--- a/docs/superpowers/specs/2026-08-24-dossier-senses-2-design.md
+++ b/docs/superpowers/specs/2026-08-24-dossier-senses-2-design.md
@@ -10,7 +10,7 @@
 3. **Traceable**: every line derives from enumerable, deterministic inputs — no line the walker couldn't verify against their own recordings. Template counts and ordinals are always substituted from computed values, never hardcoded prose.
 4. **Pulled-never-pushed**: senses render only inside the AI-prompt dossier the walker opens. No notifications, no journal changes, no summary-screen changes.
 5. **Toggle sovereignty**: `threadsAfterWalks` off = none of this computes.
-6. **No schema migration.** All new state is UserDefaults or derived-at-build-time from existing CoreStore fields + `TranscriptContext` files. (Question density deliberately counts from stored transcripts at build time rather than adding a context field — see Track 4 — because the backfill cannot retrofit context-schema changes.)
+6. **No schema migration.** All new state is UserDefaults or derived-at-build-time from existing CoreStore fields + `TranscriptContext` files.
 7. **Prompt economy**: the dossier must not bloat. Each sense emits **at most one line**, and the whole Senses II block is capped at **3 lines per prompt** — roughly a quarter of a typical dossier's existing line budget, enough to add texture without competing with the theme section itself. A sense with nothing true to say emits nothing — silence is the default.
 8. **Module purity (binding)**: `DossierSenses.lines(...)` performs no DataManager, CoreStore, or singleton access itself. Every input is fetched by the caller (`ThreadsDossierBuilder`) and passed as an argument. A future sense that needs new data must widen the call signature — never reach out sideways. This is the enforcement mechanism for principle 3.
 9. **One theme, one line**: within a single build, once a sense has named a theme, lower-priority senses skip that theme (naming the same word twice in three lines reads as fixation, not noticing).
@@ -33,7 +33,6 @@
 |---|---|---|
 | Themes + mention offsets, markers, word counts | `TranscriptContext` file cache (per recording) | already loaded by dossier build |
 | Recording timestamps (per-recording `_startDate`) | CoreStore `VoiceRecording` | at build — NOTE: per-recording times, not the owning walk's `startDate`; Track 1 needs a recording-timestamp index distinct from the existing walk-level `walkIndex` |
-| Transcripts (for question counts) | CoreStore `VoiceRecording` transcription field | at build, in-window walks only (bounded fetch) |
 | Recording coordinates | walk `routeData` sample nearest recording timestamp | at build, per needed recording only, via a bounded timestamp-predicate query (`fetchLimit`, `rowUUID` discipline — UUID columns are stored as strings), never full-array materialization |
 | Elevation series, speeds | walk `routeData` | at build, current walk only |
 | Weather (condition, temperature) | `Walk._weatherCondition` / `_weatherTemperature` (PilgrimV7, existing) | at build |
@@ -92,7 +91,7 @@ Skip entirely when total ascent < 50 m (flat walks make the claim meaningless).
 
 ### Track 4 — Small signatures (current walk unless noted)
 
-*(Scope note: the approved track named photo adjacency + theme-marker coloring; question density, speech shape, and intention lineage were added during design elaboration and approved in the same session.)*
+*(Scope note: the approved tracks named photo adjacency, theme-marker coloring, speech shape, and intention lineage were added during design elaboration and approved in the same session. Question density was cut at the ship gate.)*
 
 **Theme-marker coloring**: absolutist-marker density inside ±15-word windows around a theme's mentions vs the transcript's overall absolutist density. Emit only when window density ≥ 2× overall AND ≥3 absolutist tokens in windows:
 
@@ -138,7 +137,7 @@ The implementation plan stages along the pure/cross-walk boundary: current-walk 
 
 ## Testing
 
-- Pure fixtures per sense (RED first): geometry fixtures for clustering incl. the specificity guard's baseline comparison (tight cluster + tight baseline → suppressed; tight cluster + wide baseline → fires); coordinate-hygiene fixtures (stale sample, poor accuracy → non-participation); elevation series fixtures; weather category fixtures incl. climate guard, unknown bucket, map-every-string drift test, and the any-excluded-walk-emits-nothing rule; marker-window fixtures incl. the dossier-present gate; photo place-tie fixtures (near+soon fires, near+late and far+soon don't); question/speech-shape fixtures; intention-lineage scaffold fixtures (the "want"-only pair must not cluster); moon-line state machine (emit once, not twice; current-walk-words gate; Delete All re-arms).
+- Pure fixtures per sense (RED first): geometry fixtures for clustering incl. the specificity guard's baseline comparison (tight cluster + tight baseline → suppressed; tight cluster + wide baseline → fires); coordinate-hygiene fixtures (stale sample, poor accuracy → non-participation); elevation series fixtures; weather category fixtures incl. climate guard, unknown bucket, map-every-string drift test, and the any-excluded-walk-emits-nothing rule; marker-window fixtures incl. the dossier-present gate; photo place-tie fixtures (near+soon fires, near+late and far+soon don't); speech-shape fixtures; intention-lineage scaffold fixtures (the "want"-only pair must not cluster); moon-line state machine (emit once, not twice; current-walk-words gate; Delete All re-arms).
 - Cap + priority + dedup tests: 5 senses firing → exactly 3 lines in priority order; a theme named at rank 1 never reappears at rank 5.
 - String-pinning tests for every template with substituted counts; descriptive-only sweep is part of review.
 - No UI tests (no UI).

--- a/docs/superpowers/specs/2026-08-24-dossier-senses-2-design.md
+++ b/docs/superpowers/specs/2026-08-24-dossier-senses-2-design.md
@@ -24,7 +24,7 @@
 5. **Climb anchoring** — embodied, current-walk, but only meaningful on hilly walks.
 6. **Weather weave** — evocative but weather is shared context, not personal signal.
 7. **Photo adjacency** — place-tied (below), but still a coincidence-class observation.
-8. **Question density** — interesting when true, generic in phrasing.
+8. ~~Question density~~ — **cut at the ship gate (2026-08-25)**: real-device history fired it once as a Whisper punctuation artifact ("151 of today's sentences were questions"), not genuine question density; removed entirely, per the contingency in its own Track 4 entry below.
 9. **Speech shape** — the most generic; cheap to compute, first to yield.
 
 ## Data sources (all existing)
@@ -87,7 +87,7 @@ Skip entirely when total ascent < 50 m (flat walks make the claim meaningless).
 
 > `All N walks where 'music' surfaced were under rain.` (N substituted; "Both" only when N is literally 2.)
 
-- **Climate guard (binding)**: skip when the shared category is also the walker's in-window *majority* condition (>50% of in-window walks with stored weather). In a place where it mostly rains, "both walks were under rain" is a tautology of geography, not a fact about the theme.
+- **Climate guard (binding)**: skip when the shared category is also the walker's in-window *majority* condition (>50% of in-window walks with stored weather). In a place where it mostly rains, "both walks were under rain" is a tautology of geography, not a fact about the theme. **Tightened at the ship gate (2026-08-25)**: majority proved insufficient — 4/4 real-device firings were a plurality tautology ("under cloud" without any condition holding a true majority) — so the guard now skips whenever the shared category is (or ties for) the window's most common known condition (mode), not only a strict majority.
 - Condition categories collapse WeatherKit strings to: rain, snow, clear, cloud, wind, fog, plus a named `unknown` bucket; a unit test asserts every WeatherKit condition string the app can store maps to some bucket (drift guard — WeatherKit's vocabulary has shifted before). Walks with unknown/missing conditions are excluded from the claim, and a theme with any excluded walk emits nothing — the claim must be total.
 
 ### Track 4 — Small signatures (current walk unless noted)
@@ -112,6 +112,7 @@ Skip entirely when total ascent < 50 m (flat walks make the claim meaningless).
 > `Four of today's sentences were questions — more than any walk in the last 30 days.`
 
 - **Known dependency**: Whisper's `?` placement is an ASR artifact, not prosody. The ship gate (below) measures real-transcript question-mark behavior before this sense ships; if punctuation proves unreliable, this sense is cut at the gate, not patched.
+- **Cut at the ship gate (2026-08-25)**: real-device history fired this sense exactly once, and the line read "151 of today's sentences were questions" — a Whisper punctuation artifact, exactly the contingency above. Cut entirely: the enum case, its track function and constants, its dispatch-table entry, its exclusive inputs (`historyTranscripts`, the in-window transcript fetch), and all of its tests.
 
 **Speech shape**: when all recordings fall in the first third of the walk's duration and the wordless remainder exceeds 30 minutes:
 


### PR DESCRIPTION
*The ship gate ran on real ground and three senses learned from it.*

## Gate 2 verdict, applied

The firing pass over 15 real walks (the binding ship gate) sanctioned three changes:

- **Question density is cut** — its one firing claimed "151 of today's sentences were questions": Whisper punctuation artifact, exactly the risk the spec pre-authorized cutting for. Gone entirely: sense, inputs (`historyTranscripts`, `walkIndex`), the in-window transcript fetch (also the main per-walk cost — median build was 0.312 s, dominated by this), and the snapshot's range parameter. Eight senses remain.
- **The climate guard is a mode now, not a majority** — all four weather firings were "under cloud" because cloud is Austin's plurality, not majority. The guard now suppresses the window's most-common condition (ties suppress); only genuinely minority weather speaks. Also: "under clouds."
- **'day', 'days', 'area' join the light-noun stoplist** — the guard-approved place and photo firings were carrying generic nouns. Extractor semantics changed ⇒ schema v4 + V6 re-arm, per the house doctrine (third one-constant bump in a row — the machinery holds).

## Evidence

Suite **1,388 / 0** (six removed with their subject, six added — mode-tie suppression, minority-fires arithmetic, day/area exclusions, V6 re-arm) · SwiftLint 398/0 · review: Approved — removal verified surgical by repo-wide grep, mode arithmetic hand-checked, no moon re-arm needed (field dossier proves the reported theme was 'music', unaffected).

Post-merge: confirmation firing pass on device, then 1.11.0 ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)