### PR TITLE
Prompt relevance fixes, and the Oblique design

### DIFF
--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -564,6 +564,7 @@
 		LR00000200000000LRACLT01 /* AudioConsumerLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRACLT01 /* AudioConsumerLifecycleTests.swift */; };
 		LR00000200000000LRASCT01 /* AudioSessionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRASCT01 /* AudioSessionCoordinatorTests.swift */; };
 		LR00000200000000LRATDR01 /* AttentionDirectivesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRATDR01 /* AttentionDirectivesTests.swift */; };
+		LR00000200000000LRATDR02 /* AttentionDirectivesFirstVersusLastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRATDR02 /* AttentionDirectivesFirstVersusLastTests.swift */; };
 		LR00000200000000LRBDCT01 /* BodyDataContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRBDCT01 /* BodyDataContextTests.swift */; };
 		LR00000200000000LRCRTT01 /* CairnTierTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRCRTT01 /* CairnTierTests.swift */; };
 		LR00000200000000LRDMRP01 /* DataManager+Replace.swift in Sources */ = {isa = PBXBuildFile; fileRef = LR00000100000000LRDMRP01 /* DataManager+Replace.swift */; };
@@ -1228,6 +1229,7 @@
 		LR00000100000000LRACLT01 /* AudioConsumerLifecycleTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioConsumerLifecycleTests.swift; sourceTree = "<group>"; };
 		LR00000100000000LRASCT01 /* AudioSessionCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AudioSessionCoordinatorTests.swift; sourceTree = "<group>"; };
 		LR00000100000000LRATDR01 /* AttentionDirectivesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AttentionDirectivesTests.swift; sourceTree = "<group>"; };
+		LR00000100000000LRATDR02 /* AttentionDirectivesFirstVersusLastTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AttentionDirectivesFirstVersusLastTests.swift; sourceTree = "<group>"; };
 		LR00000100000000LRBDCT01 /* BodyDataContextTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = BodyDataContextTests.swift; sourceTree = "<group>"; };
 		LR00000100000000LRCRTT01 /* CairnTierTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CairnTierTests.swift; sourceTree = "<group>"; };
 		LR00000100000000LRDMRP01 /* DataManager+Replace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DataManager+Replace.swift"; sourceTree = "<group>"; };
@@ -2017,6 +2019,7 @@
 				LR00000100000000LRTSMV01 /* TranscriptionServiceModelVariantTests.swift */,
 				LR00000100000000LRPRCT01 /* PromptResponseContractTests.swift */,
 				LR00000100000000LRATDR01 /* AttentionDirectivesTests.swift */,
+				LR00000100000000LRATDR02 /* AttentionDirectivesFirstVersusLastTests.swift */,
 				LR00000100000000LRWKCH01 /* WalkCharacterTests.swift */,
 				LR00000100000000LRPRLX01 /* PracticeLexiconTests.swift */,
 				LR00000100000000LRBDCT01 /* BodyDataContextTests.swift */,
@@ -3404,6 +3407,7 @@
 				LR00000200000000LRTSMV01 /* TranscriptionServiceModelVariantTests.swift in Sources */,
 				LR00000200000000LRPRCT01 /* PromptResponseContractTests.swift in Sources */,
 				LR00000200000000LRATDR01 /* AttentionDirectivesTests.swift in Sources */,
+				LR00000200000000LRATDR02 /* AttentionDirectivesFirstVersusLastTests.swift in Sources */,
 				LR00000200000000LRWKCH01 /* WalkCharacterTests.swift in Sources */,
 				LR00000200000000LRPRLX01 /* PracticeLexiconTests.swift in Sources */,
 				LR00000200000000LRBDCT01 /* BodyDataContextTests.swift in Sources */,

--- a/Pilgrim/Models/Prompt/AttentionDirectives.swift
+++ b/Pilgrim/Models/Prompt/AttentionDirectives.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NaturalLanguage
 
 /// Deterministic pattern detection over a walk's context. The assembler
 /// hands the downstream model a dossier; these directives tell it what is
@@ -9,8 +10,27 @@ enum AttentionDirectives {
     private static let movingThreshold = 0.3
     private static let maxDirectives = 4
     private static let paceShiftThreshold = 0.15
+    /// `wordsPerMinute` over a handful of words is noise, not a speaking
+    /// rate: a five-word note clears a 15% relative delta on the rounding of
+    /// its own start and end timestamps. At any plausible speaking rate this
+    /// floor means at least ten seconds of continuous speech on each side —
+    /// the pace branch's answer to the subject branch's lemma floor.
+    private static let minimumWordsToJudgePace = 25
     private static let subjectOverlapCeiling = 0.20
-    private static let minimumLemmasToJudgeSubject = 5
+    /// Content lemmas, after `SpokenStoplist.scaffoldLemmas` is removed. The
+    /// original floor of 5 sat far below where a lexical-overlap judgment
+    /// carries any information: a sign-off ("heading back down the hill,
+    /// tired but glad") clears 5 comfortably and shares nothing with a long
+    /// opening, so the overlap coefficient reads zero and the directive fires
+    /// on a walk that never changed subject. A genuinely divergent long pair
+    /// measures around 0.06, so there is ample headroom above this floor.
+    private static let minimumLemmasToJudgeSubject = 12
+    /// Two recordings are only comparable as subjects when both carry
+    /// comparable amounts of it. Past this ratio the smaller recording is a
+    /// thin sample of the walk rather than its second half, and its overlap
+    /// against a much longer transcript says more about its length than about
+    /// what the walker was talking about.
+    private static let subjectLengthRatioCeiling = 3.0
 
     /// `detectedLanguageCode` defaults to nil ("detect here") so direct
     /// callers stay unchanged; PromptGenerator.resolvedDerivations passes
@@ -153,41 +173,91 @@ enum AttentionDirectives {
     /// mean a fresh analyzer pass per recording. Pace is free
     /// (`wordsPerMinute` is already populated); subject costs exactly two
     /// lemma passes, never N.
+    ///
+    /// Both branches fail closed. Each carries a floor sized so the signal
+    /// it reads is measurable at all — words for a speaking rate, content
+    /// lemmas for a subject — and the subject branch additionally refuses
+    /// languages this OS cannot lemmatize. Silence hands the `maxDirectives`
+    /// budget to a detector with something to say.
     private static func firstVersusLast(_ context: ActivityContext) -> String? {
         guard let first = context.recordings.first,
               let last = context.recordings.last,
               context.recordings.count >= 2 else { return nil }
 
-        if let firstPace = first.wordsPerMinute, let lastPace = last.wordsPerMinute, firstPace > 0 {
-            let change = (lastPace - firstPace) / firstPace
-            if change >= paceShiftThreshold {
-                return "The walker spoke faster by the last recording than the first — attend to what moved between them."
-            }
-            if change <= -paceShiftThreshold {
-                return "The walker spoke more slowly by the last recording than the first — attend to what moved between them."
-            }
-        }
+        if let paceLine = speakingRateShift(first: first, last: last) { return paceLine }
+        return subjectShift(first: first, last: last)
+    }
 
-        let firstLemmas = Set(TranscriptNLP.contentLemmas(in: first.text))
-        let lastLemmas = Set(TranscriptNLP.contentLemmas(in: last.text))
-        guard firstLemmas.count >= minimumLemmasToJudgeSubject,
-              lastLemmas.count >= minimumLemmasToJudgeSubject else { return nil }
+    /// Speaking rate, not ground speed — `paceShift` above reads GPS.
+    private static func speakingRateShift(first: RecordingContext, last: RecordingContext) -> String? {
+        guard let firstPace = first.wordsPerMinute, let lastPace = last.wordsPerMinute, firstPace > 0,
+              TranscriptNLP.wordCount(in: first.text) >= minimumWordsToJudgePace,
+              TranscriptNLP.wordCount(in: last.text) >= minimumWordsToJudgePace else { return nil }
+
+        let change = (lastPace - firstPace) / firstPace
+        if change >= paceShiftThreshold {
+            return "The walker spoke faster by the last recording than the first — attend to what moved between them."
+        }
+        if change <= -paceShiftThreshold {
+            return "The walker spoke more slowly by the last recording than the first — attend to what moved between them."
+        }
+        return nil
+    }
+
+    /// Whether the walker's vocabulary moved between the two recordings.
+    ///
+    /// Both sides must be lemmatized by the SAME language model. Without a
+    /// lemma model `TranscriptNLP.contentLemmas` falls back to the lowercased
+    /// surface form, so an inflected language yields a distinct "lemma" per
+    /// inflection and depresses overlap systematically — every Camino walk in
+    /// Spanish, French, German, Italian, or Portuguese would read as total
+    /// divergence. A walker who switches languages mid-walk has not changed
+    /// subject either; the two sets are simply not comparable.
+    private static func subjectShift(first: RecordingContext, last: RecordingContext) -> String? {
+        guard let firstLanguage = lemmatizableLanguage(of: first.text),
+              let lastLanguage = lemmatizableLanguage(of: last.text),
+              firstLanguage == lastLanguage else { return nil }
+
+        let firstLemmas = subjectLemmas(in: first.text)
+        let lastLemmas = subjectLemmas(in: last.text)
+        let smallerCount = min(firstLemmas.count, lastLemmas.count)
+        let largerCount = max(firstLemmas.count, lastLemmas.count)
+        guard smallerCount >= minimumLemmasToJudgeSubject,
+              Double(largerCount) / Double(smallerCount) <= subjectLengthRatioCeiling else { return nil }
 
         // Overlap coefficient (intersection / smaller set), not Jaccard
         // (intersection / union). Jaccard collapses to |smaller| / |larger|
         // whenever one lemma set is a subset of the other — a long opening
         // reflection (~30+ unique lemmas) followed by a short closing note
-        // on the SAME subject (~6 lemmas, all repeats) can then cross the
-        // ceiling on length alone, firing "shares little vocabulary" on a
-        // walk that never left its subject. The overlap coefficient is 1.0
-        // for that same subset case (correctly silent) and still near 0 for
-        // genuinely divergent subjects, because it measures how much of the
-        // SMALLER recording is accounted for by the larger one rather than
+        // on the SAME subject (all repeats) can then cross the ceiling on
+        // length alone, firing "shares little vocabulary" on a walk that
+        // never left its subject. The overlap coefficient is 1.0 for that
+        // same subset case (correctly silent) and still near 0 for genuinely
+        // divergent subjects, because it measures how much of the SMALLER
+        // recording is accounted for by the larger one rather than
         // penalizing a short recording for being short.
-        let smallerCount = min(firstLemmas.count, lastLemmas.count)
         let overlap = Double(firstLemmas.intersection(lastLemmas).count) / Double(smallerCount)
         guard overlap <= subjectOverlapCeiling else { return nil }
 
         return "The walker's last recording shares little vocabulary with the first — attend to what moved between them."
+    }
+
+    /// The same `SpokenStoplist.scaffoldLemmas` filter `recurringWord`
+    /// applies: NLTagger tags "think", "know", "want", "keep" as content, but
+    /// a speaker reaches for them out of habit. Left in, a closing recording
+    /// made entirely of scaffolding clears the lemma floor on words that
+    /// carry no subject at all.
+    private static func subjectLemmas(in text: String) -> Set<String> {
+        Set(TranscriptNLP.contentLemmas(in: text)).subtracting(SpokenStoplist.scaffoldLemmas)
+    }
+
+    /// The transcript's language when this OS actually ships a lemma model
+    /// for it, nil otherwise — including when no language clears the
+    /// recognizer's confidence bar. Asked of the OS rather than hardcoded, so
+    /// the subject branch widens on its own as Apple adds lemma models.
+    static func lemmatizableLanguage(of text: String) -> String? {
+        guard let code = TranscriptNLP.detectLanguage(text) else { return nil }
+        return NLTagger.availableTagSchemes(for: .word, language: NLLanguage(rawValue: code))
+            .contains(.lemma) ? code : nil
     }
 }

--- a/Pilgrim/Models/Prompt/AttentionDirectives.swift
+++ b/Pilgrim/Models/Prompt/AttentionDirectives.swift
@@ -8,6 +8,9 @@ enum AttentionDirectives {
 
     private static let movingThreshold = 0.3
     private static let maxDirectives = 4
+    private static let paceShiftThreshold = 0.15
+    private static let subjectOverlapCeiling = 0.20
+    private static let minimumLemmasToJudgeSubject = 5
 
     /// `detectedLanguageCode` defaults to nil ("detect here") so direct
     /// callers stay unchanged; PromptGenerator.resolvedDerivations passes
@@ -139,8 +142,42 @@ enum AttentionDirectives {
         return "The word '\(display)' returns \(count) times across the recordings — it may be doing quiet work."
     }
 
+    /// Fires only when something measurably moved between the first
+    /// recording and the last. The previous version fired on every walk
+    /// with two recordings and presupposed its own conclusion — told to
+    /// measure what changed, the model finds change, including on walks
+    /// where nothing did (the `questionDensity` failure mode, quieter).
+    ///
+    /// Marker and sentiment deltas are deliberately NOT used: they are
+    /// unreachable from `ActivityContext`, and computing them here would
+    /// mean a fresh analyzer pass per recording. Pace is free
+    /// (`wordsPerMinute` is already populated); subject costs exactly two
+    /// lemma passes, never N.
     private static func firstVersusLast(_ context: ActivityContext) -> String? {
-        guard context.recordings.count >= 2 else { return nil }
-        return "Compare the first recording with the last — measure what changed in the walker between them."
+        guard let first = context.recordings.first,
+              let last = context.recordings.last,
+              context.recordings.count >= 2 else { return nil }
+
+        if let firstPace = first.wordsPerMinute, let lastPace = last.wordsPerMinute, firstPace > 0 {
+            let change = (lastPace - firstPace) / firstPace
+            if change >= paceShiftThreshold {
+                return "The walker spoke faster by the last recording than the first — attend to what moved between them."
+            }
+            if change <= -paceShiftThreshold {
+                return "The walker spoke more slowly by the last recording than the first — attend to what moved between them."
+            }
+        }
+
+        let firstLemmas = Set(TranscriptNLP.contentLemmas(in: first.text))
+        let lastLemmas = Set(TranscriptNLP.contentLemmas(in: last.text))
+        guard firstLemmas.count >= minimumLemmasToJudgeSubject,
+              lastLemmas.count >= minimumLemmasToJudgeSubject else { return nil }
+
+        let union = firstLemmas.union(lastLemmas).count
+        guard union > 0 else { return nil }
+        let jaccard = Double(firstLemmas.intersection(lastLemmas).count) / Double(union)
+        guard jaccard <= subjectOverlapCeiling else { return nil }
+
+        return "The walker's last recording shares little vocabulary with the first — attend to what moved between them."
     }
 }

--- a/Pilgrim/Models/Prompt/AttentionDirectives.swift
+++ b/Pilgrim/Models/Prompt/AttentionDirectives.swift
@@ -173,10 +173,20 @@ enum AttentionDirectives {
         guard firstLemmas.count >= minimumLemmasToJudgeSubject,
               lastLemmas.count >= minimumLemmasToJudgeSubject else { return nil }
 
-        let union = firstLemmas.union(lastLemmas).count
-        guard union > 0 else { return nil }
-        let jaccard = Double(firstLemmas.intersection(lastLemmas).count) / Double(union)
-        guard jaccard <= subjectOverlapCeiling else { return nil }
+        // Overlap coefficient (intersection / smaller set), not Jaccard
+        // (intersection / union). Jaccard collapses to |smaller| / |larger|
+        // whenever one lemma set is a subset of the other — a long opening
+        // reflection (~30+ unique lemmas) followed by a short closing note
+        // on the SAME subject (~6 lemmas, all repeats) can then cross the
+        // ceiling on length alone, firing "shares little vocabulary" on a
+        // walk that never left its subject. The overlap coefficient is 1.0
+        // for that same subset case (correctly silent) and still near 0 for
+        // genuinely divergent subjects, because it measures how much of the
+        // SMALLER recording is accounted for by the larger one rather than
+        // penalizing a short recording for being short.
+        let smallerCount = min(firstLemmas.count, lastLemmas.count)
+        let overlap = Double(firstLemmas.intersection(lastLemmas).count) / Double(smallerCount)
+        guard overlap <= subjectOverlapCeiling else { return nil }
 
         return "The walker's last recording shares little vocabulary with the first — attend to what moved between them."
     }

--- a/Pilgrim/Models/Prompt/PromptAssembler.swift
+++ b/Pilgrim/Models/Prompt/PromptAssembler.swift
@@ -182,6 +182,7 @@ enum PromptAssembler {
         }
         if hasThreadsDossier {
             lines.append("The thought-thread marker profiles are descriptive on-device linguistic signals, not assessments — interpret them gently, never produce clinical or diagnostic language, and never treat a single walk's numbers as meaningful on their own.")
+            lines.append("Read absolutist density as how fixed the walker's framing was, first-person density as how far they placed themselves at the centre of it, and the modal lean as the frame they were working inside — obligation means the frame constrained them, counterfactual means they were already replaying alternatives, possibility and tentative mean it was still open. None of these has a fixed meaning; read each through this walk's intention and practice.")
         }
         lines.append("Draw only on what this walk actually holds — never invent details, events, or memories that are not in the context above.")
         let bullets = lines.map { "- \($0)" }.joined(separator: "\n")

--- a/Pilgrim/Models/Prompt/PromptAssembler.swift
+++ b/Pilgrim/Models/Prompt/PromptAssembler.swift
@@ -182,7 +182,7 @@ enum PromptAssembler {
         }
         if hasThreadsDossier {
             lines.append("The thought-thread marker profiles are descriptive on-device linguistic signals, not assessments — interpret them gently, never produce clinical or diagnostic language, and never treat a single walk's numbers as meaningful on their own.")
-            lines.append("Read absolutist density as how fixed the walker's framing was, first-person density as how far they placed themselves at the centre of it, and the modal lean as the frame they were working inside — obligation means the frame constrained them, counterfactual means they were already replaying alternatives, possibility and tentative mean it was still open. None of these has a fixed meaning; read each through this walk's intention and practice.")
+            lines.append("Read the absolutist-word share as how fixed the walker's framing was, self-focus as how far they placed themselves at the centre of it, and the modal lean as the frame they were working inside — obligation means the frame constrained them, counterfactual means they were already replaying alternatives, possibility and tentative mean it was still open, intention means they had settled on a course, and desire means they were naming a want rather than a plan. None of these has a fixed meaning; read each through this walk's intention and practice.")
         }
         lines.append("Draw only on what this walk actually holds — never invent details, events, or memories that are not in the context above.")
         let bullets = lines.map { "- \($0)" }.joined(separator: "\n")

--- a/Pilgrim/Models/Prompt/PromptAssembler.swift
+++ b/Pilgrim/Models/Prompt/PromptAssembler.swift
@@ -42,7 +42,7 @@ enum PromptAssembler {
         }
 
         sections += "\n\n---\n\n\(fullInstruction)"
-        sections += "\n\n\(responseContract(voice: voice, hasSpeech: context.hasSpeech, hasThreadsDossier: context.threadsDossier != nil))"
+        sections += "\n\n\(responseContract(voice: voice, hasSpeech: context.hasSpeech, threadsDossier: context.threadsDossier))"
         return sections
     }
 
@@ -174,19 +174,52 @@ enum PromptAssembler {
     /// do (invent, flatten, switch language) plus the voice's own form
     /// constraints. This shapes the *reply's* quality — the part of the
     /// feature the walker actually experiences.
-    static func responseContract(voice: PromptVoice, hasSpeech: Bool, hasThreadsDossier: Bool) -> String {
+    static func responseContract(voice: PromptVoice, hasSpeech: Bool, threadsDossier: String?) -> String {
         var lines = voice.responseConstraints(hasSpeech: hasSpeech)
         if hasSpeech {
             lines.append("Respond in the language the walker speaks in the transcription.")
             lines.append("If more than one voice appears in the transcription, honor it as a conversation — attend to what happened between the speakers, and never guess at names.")
         }
-        if hasThreadsDossier {
+        if let threadsDossier {
             lines.append("The thought-thread marker profiles are descriptive on-device linguistic signals, not assessments — interpret them gently, never produce clinical or diagnostic language, and never treat a single walk's numbers as meaningful on their own.")
-            lines.append("Read the absolutist-word share as how fixed the walker's framing was, self-focus as how far they placed themselves at the centre of it, and the modal lean as the frame they were working inside — obligation means the frame constrained them, counterfactual means they were already replaying alternatives, possibility and tentative mean it was still open, intention means they had settled on a course, and desire means they were naming a want rather than a plan. None of these has a fixed meaning; read each through this walk's intention and practice.")
+            if let key = interpretiveKey(for: threadsDossier) {
+                lines.append(key)
+            }
         }
         lines.append("Draw only on what this walk actually holds — never invent details, events, or memories that are not in the context above.")
         let bullets = lines.map { "- \($0)" }.joined(separator: "\n")
         return "**How to respond:**\n\(bullets)"
+    }
+
+    /// How to read the marker signals — but only the ones this dossier
+    /// actually printed. `ThreadsDossierFormatter.markerLine` prints "Markers
+    /// unavailable" for a non-English recording and raw counts rather than
+    /// shares below `densityFloorWords`, and the modal-lean clause sits
+    /// behind three thresholds and is usually silent. Teaching a taxonomy the
+    /// dossier withheld hands the model vocabulary with no referent, and it
+    /// will find something to attach it to.
+    ///
+    /// The probes match the formatter's own phrasings. That coupling is the
+    /// point — it is pinned by
+    /// `testResponseContract_againstRealFormatterOutput_adaptsToWhatWasPrinted`,
+    /// which runs the real formatter, so a phrasing change fails a test
+    /// rather than silently suppressing the key on every walk.
+    ///
+    /// At most one line either way: the contract's accretion budget does not
+    /// grow to pay for this.
+    private static func interpretiveKey(for dossier: String) -> String? {
+        var clauses: [String] = []
+        if dossier.contains("absolutist words") {
+            clauses.append("Read the absolutist-word share as how fixed the walker's framing was, and self-focus as how far they placed themselves at the centre of it.")
+        } else if dossier.contains("raw counts only") {
+            clauses.append("Read the absolutist and self-focus counts as a bare tally of how fixed the walker's framing was and how far they placed themselves at the centre of it — too few words to read as a rate, so do not weigh them.")
+        }
+        if dossier.contains("modal lean:") {
+            clauses.append("Read the modal lean as the frame the walker was working inside — obligation means the frame constrained them, counterfactual means they were already replaying alternatives, possibility and tentative mean it was still open, intention means they had settled on a course, and desire means they were naming a want rather than a plan.")
+        }
+        guard !clauses.isEmpty else { return nil }
+        return (clauses + ["None of these has a fixed meaning; read each through this walk's intention and practice."])
+            .joined(separator: " ")
     }
 
     private static func formatPhotoSection(

--- a/Pilgrim/Models/Prompt/WalkPromptVoices.swift
+++ b/Pilgrim/Models/Prompt/WalkPromptVoices.swift
@@ -31,7 +31,12 @@ struct ReflectiveVoice: PromptVoice {
 
     func instruction(hasSpeech: Bool) -> String {
         hasSpeech
-            ? "Please analyze these walking reflections for patterns, recurring themes, and emotional undercurrents. Where the walk's own record supports it — the stated intention, a word that recurs, a shift in pace or marker profile — name what connects the moments; where it does not, say less rather than reaching. Note any genuine tension the record shows, and do not manufacture one. Offer observations that help me understand myself better."
+            // The marker profile is deliberately not named here. It reaches
+            // the prompt only when `UserPreferences.threadsAfterWalks` is on,
+            // and this instruction — unlike `PromptAssembler.responseContract`
+            // — has no way to know whether it did. Licensing evidence that may
+            // be switched off invites the model to reach for it anyway.
+            ? "Please analyze these walking reflections for patterns, recurring themes, and emotional undercurrents. Where the walk's own record supports it — the stated intention, a word that recurs, a shift in pace — name what connects the moments; where it does not, say less rather than reaching. Note any genuine tension the record shows, and do not manufacture one. Offer observations that help me understand myself better."
             : "Read the shape of this walk — its pace, its pauses, its waypoints — as you would read a text. Where the walk's own record supports it, name the patterns you find; where it does not, say less rather than reaching. What might the walker have been processing? What does the choice of silence itself suggest? Offer observations that help them understand themselves."
     }
 

--- a/Pilgrim/Models/Prompt/WalkPromptVoices.swift
+++ b/Pilgrim/Models/Prompt/WalkPromptVoices.swift
@@ -31,8 +31,8 @@ struct ReflectiveVoice: PromptVoice {
 
     func instruction(hasSpeech: Bool) -> String {
         hasSpeech
-            ? "Please analyze these walking reflections for patterns, recurring themes, and emotional undercurrents. What connections do you see between the different moments? What might I be processing or working through? What contradictions or tensions are present? Offer observations that help me understand myself better."
-            : "Read the shape of this walk — its pace, its pauses, its waypoints — as you would read a text. What patterns do you see? What might the walker have been processing? What does the choice of silence itself suggest? Offer observations that help them understand themselves."
+            ? "Please analyze these walking reflections for patterns, recurring themes, and emotional undercurrents. Where the walk's own record supports it — the stated intention, a word that recurs, a shift in pace or marker profile — name what connects the moments; where it does not, say less rather than reaching. Note any genuine tension the record shows, and do not manufacture one. Offer observations that help me understand myself better."
+            : "Read the shape of this walk — its pace, its pauses, its waypoints — as you would read a text. Where the walk's own record supports it, name the patterns you find; where it does not, say less rather than reaching. What might the walker have been processing? What does the choice of silence itself suggest? Offer observations that help them understand themselves."
     }
 
     func responseConstraints(hasSpeech: Bool) -> [String] {

--- a/UnitTests/AttentionDirectivesFirstVersusLastTests.swift
+++ b/UnitTests/AttentionDirectivesFirstVersusLastTests.swift
@@ -1,0 +1,267 @@
+import XCTest
+import NaturalLanguage
+@testable import Pilgrim
+
+/// Shared transcript fixtures for the `firstVersusLast` gate, which now
+/// carries floors on both branches: the pace branch needs
+/// `minimumWordsToJudgePace` words on each side, the subject branch
+/// `minimumLemmasToJudgeSubject` content lemmas. Short throwaway lines no
+/// longer reach either branch, so the fixtures have to be walk-sized.
+enum DirectiveFixtures {
+    static let heavyOpening = "Setting out heavy this morning, the pack digging into both shoulders, "
+        + "the road ahead grey and long, and my legs already complaining about the hill still ahead of me."
+    static let lighterClosing = "Coming home lighter now, the pack somehow easier, the same road under "
+        + "my feet but shorter, and the evening air cool against my face as the town appears."
+
+    /// ~17 content lemmas, zero overlap with `familyDebt`.
+    static let gardenWall = "The garden hedge grows beside the stone wall near the orchard gate, where "
+        + "old apple trees drop ripe fruit onto the wet grass beneath the crooked fence."
+    /// ~15 content lemmas, zero overlap with `gardenWall`.
+    static let familyDebt = "My brother telephoned about the mortgage payment, the lawyer's invoice, "
+        + "unpaid council tax, and a solicitor's letter concerning my late father's estate and the empty house."
+    /// Spoken scaffolding only — every lemma here is in
+    /// `SpokenStoplist.scaffoldLemmas`, so it carries no subject at all
+    /// despite clearing a raw-lemma count of eighteen.
+    static let scaffoldingOnly = "I think I know what you mean, and I want to go and see. Let me take it. "
+        + "I feel we should keep it. I could say it might be the kind of thing we would need."
+    /// Long enough to be detected as Spanish, short of nothing else.
+    static let spanishOpening = "Esta mañana caminé por el sendero del huerto, junto al muro de piedra, "
+        + "mirando los manzanos viejos y la hierba mojada bajo la valla torcida del jardín."
+}
+
+/// `firstVersusLast` used to fire on every walk with two recordings and
+/// presuppose its own conclusion — told to measure what changed, the model
+/// finds change, including on walks where nothing did. These tests pin the
+/// gated behaviour: it fires only on a pace shift (free from
+/// `wordsPerMinute`) or a subject that genuinely diverged (two bounded
+/// lemma passes, never one per recording).
+final class AttentionDirectivesFirstVersusLastTests: XCTestCase {
+
+    private static let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+
+    private func recording(_ text: String, wpm: Double?, minutesIn: Int) -> RecordingContext {
+        RecordingContext(
+            text: text,
+            timestamp: Self.start.addingTimeInterval(TimeInterval(minutesIn * 60)),
+            startCoordinate: nil,
+            endCoordinate: nil,
+            wordsPerMinute: wpm,
+            recordingUUID: UUID(),
+            endTimestamp: nil
+        )
+    }
+
+    private func directives(_ recordings: [RecordingContext]) -> [String] {
+        AttentionDirectives.detect(
+            context: .make(recordings: recordings, startDate: Self.start),
+            detectedLanguageCode: "en"
+        )
+    }
+
+    private func isFirstVersusLast(_ line: String) -> Bool {
+        line.contains("attend to what moved between them")
+    }
+
+    func testFirstVersusLast_sameSubjectSamePace_staysSilent() {
+        let lines = directives([
+            recording(DirectiveFixtures.gardenWall, wpm: 100, minutesIn: 0),
+            recording(DirectiveFixtures.gardenWall, wpm: 102, minutesIn: 20)
+        ])
+        XCTAssertFalse(lines.contains(where: isFirstVersusLast))
+    }
+
+    func testFirstVersusLast_paceShift_fires() {
+        let lines = directives([
+            recording(DirectiveFixtures.gardenWall, wpm: 100, minutesIn: 0),
+            recording(DirectiveFixtures.gardenWall, wpm: 140, minutesIn: 20)
+        ])
+        XCTAssertTrue(lines.contains { isFirstVersusLast($0) && $0.contains("faster") })
+    }
+
+    func testFirstVersusLast_paceSlowed_namesSlower() {
+        let lines = directives([
+            recording(DirectiveFixtures.gardenWall, wpm: 140, minutesIn: 0),
+            recording(DirectiveFixtures.gardenWall, wpm: 100, minutesIn: 20)
+        ])
+        XCTAssertTrue(lines.contains { isFirstVersusLast($0) && $0.contains("more slowly") })
+    }
+
+    /// A very short opening note makes `wordsPerMinute` meaningless — a
+    /// handful of words timed over a couple of seconds clears a 15% relative
+    /// delta on nothing but rounding. The pace branch carries its own word
+    /// floor for the same reason the subject branch carries a lemma floor.
+    func testFirstVersusLast_paceSwingOnTwoShortNotes_staysSilent() {
+        let lines = directives([
+            recording("Setting out heavy.", wpm: 100, minutesIn: 0),
+            recording("Coming home lighter.", wpm: 140, minutesIn: 20)
+        ])
+        XCTAssertFalse(lines.contains(where: isFirstVersusLast),
+                       "two three-word notes cannot carry a speaking-rate claim")
+    }
+
+    func testFirstVersusLast_subjectDiverged_fires() {
+        let lines = directives([
+            recording(DirectiveFixtures.gardenWall, wpm: 100, minutesIn: 0),
+            recording(DirectiveFixtures.familyDebt, wpm: 101, minutesIn: 20)
+        ])
+        XCTAssertTrue(lines.contains { isFirstVersusLast($0) && $0.contains("shares little vocabulary") })
+    }
+
+    func testFirstVersusLast_tooFewLemmasToJudge_staysSilent() {
+        let lines = directives([
+            recording("yes", wpm: 100, minutesIn: 0),
+            recording("no", wpm: 101, minutesIn: 20)
+        ])
+        XCTAssertFalse(lines.contains(where: isFirstVersusLast))
+    }
+
+    /// A sign-off is not a subject. It clears the old five-lemma floor
+    /// comfortably and shares nothing with a long opening, so the overlap
+    /// coefficient reads zero and the directive fired — telling the model to
+    /// find meaning in "heading back down the hill".
+    func testFirstVersusLast_shortSignOffAfterLongOpening_staysSilent() {
+        let lines = directives([
+            recording(DirectiveFixtures.gardenWall, wpm: nil, minutesIn: 0),
+            recording("Okay, that is everything for now — heading back down the hill, tired but glad.",
+                      wpm: nil, minutesIn: 40)
+        ])
+        XCTAssertFalse(lines.contains(where: isFirstVersusLast),
+                       "a closing sign-off carries too little subject to judge divergence against")
+    }
+
+    /// `recurringWord` already filters `SpokenStoplist.scaffoldLemmas`; the
+    /// subject branch did not, so a recording made entirely of spoken
+    /// scaffolding counted eighteen "lemmas" and cleared the floor on words
+    /// that carry no subject at all.
+    func testFirstVersusLast_scaffoldingOnlyClosing_staysSilent() {
+        let lines = directives([
+            recording(DirectiveFixtures.gardenWall, wpm: nil, minutesIn: 0),
+            recording(DirectiveFixtures.scaffoldingOnly, wpm: nil, minutesIn: 40)
+        ])
+        XCTAssertFalse(lines.contains(where: isFirstVersusLast),
+                       "spoken scaffolding is not vocabulary the subject can diverge from")
+    }
+
+    /// A walker who opens in one language and closes in another has not
+    /// changed subject — the lemma sets simply cannot be compared. Whichever
+    /// guard catches it first (no lemma model for the second language, or the
+    /// two detected codes differing), the directive must stay silent.
+    func testFirstVersusLast_bilingualWalk_staysSilent() {
+        let lines = directives([
+            recording(DirectiveFixtures.gardenWall, wpm: nil, minutesIn: 0),
+            recording(DirectiveFixtures.spanishOpening, wpm: nil, minutesIn: 40)
+        ])
+        XCTAssertFalse(lines.contains(where: isFirstVersusLast),
+                       "a language switch is not a subject shift")
+    }
+
+    /// The subject branch is only meaningful where NLTagger has a real lemma
+    /// model. Without one, `TranscriptNLP.contentLemmas` falls back to the
+    /// lowercased surface form, so every inflection of the same word counts
+    /// as a distinct lemma and overlap is depressed systematically — an
+    /// inflected language would read as permanent divergence.
+    func testLemmatizableLanguage_englishTranscript_resolves() {
+        XCTAssertEqual(AttentionDirectives.lemmatizableLanguage(of: DirectiveFixtures.gardenWall), "en")
+    }
+
+    func testLemmatizableLanguage_languageWithoutALemmaModel_returnsNil() throws {
+        let spanish = NLTagger.availableTagSchemes(for: .word, language: .spanish)
+        try XCTSkipUnless(!spanish.contains(.lemma),
+                          "this OS ships a Spanish lemma model, so Spanish is a legitimate subject language here")
+        XCTAssertNil(AttentionDirectives.lemmatizableLanguage(of: DirectiveFixtures.spanishOpening))
+    }
+
+    func testLemmatizableLanguage_unrecognizableText_returnsNil() {
+        XCTAssertNil(AttentionDirectives.lemmatizableLanguage(of: "..."))
+    }
+
+    func testFirstVersusLast_missingPaceAndSameSubject_staysSilent() {
+        let lines = directives([
+            recording(DirectiveFixtures.gardenWall, wpm: nil, minutesIn: 0),
+            recording(DirectiveFixtures.gardenWall, wpm: nil, minutesIn: 20)
+        ])
+        XCTAssertFalse(lines.contains(where: isFirstVersusLast))
+    }
+
+    func testFirstVersusLast_singleRecording_staysSilent() {
+        let lines = directives([
+            recording(DirectiveFixtures.gardenWall, wpm: 100, minutesIn: 0)
+        ])
+        XCTAssertFalse(lines.contains(where: isFirstVersusLast))
+    }
+
+    /// Regression for the Jaccard length-asymmetry bug: when the last
+    /// recording's vocabulary is a strict subset of the first's — a short
+    /// closing note that only repeats words already spoken at length — the
+    /// subject has not diverged at all, but Jaccard (`intersection / union`)
+    /// collapses to `|smaller| / |larger|` and can cross the ceiling anyway.
+    /// Here the first recording carries ~32 unique content lemmas and the
+    /// closing note's ~14 are all drawn from that set: Jaccard would be
+    /// 14/32 ≈ 0.44 — but on the original 6-lemma note it read 6/32 ≈ 0.19,
+    /// under the 0.20 ceiling, so the old computation fired "shares little
+    /// vocabulary" on a walk that never left its subject. The closing note is
+    /// sized to clear `minimumLemmasToJudgeSubject` so this still exercises
+    /// the overlap computation rather than passing on the floor. The overlap
+    /// coefficient (`intersection / min(|first|, |last|)`) is 1.0 here,
+    /// correctly silent.
+    func testFirstVersusLast_lastRecordingSubsetOfFirst_staysSilent() {
+        let openingReflection = """
+        I started down the garden path early this morning, past the stone \
+        wall and under the old oak trees, thinking about my mother and the \
+        letters she used to write, the garden she tended for thirty years, \
+        the roses along the fence, the smell of rain on the hedges, and how \
+        the light falls differently now that autumn is coming, the leaves \
+        turning gold and copper along the orchard gate near the pond.
+        """
+        let closingNote = "The garden path, the stone wall, the orchard gate, the old oak trees, "
+            + "my mother's letters, the roses, the hedges, the pond again."
+        let lines = directives([
+            recording(openingReflection, wpm: nil, minutesIn: 0),
+            recording(closingNote, wpm: nil, minutesIn: 45)
+        ])
+        XCTAssertFalse(lines.contains(where: isFirstVersusLast),
+                       "a closing note that only repeats the opening's own vocabulary is the same subject, not a divergent one")
+    }
+
+    // MARK: - Guard paths (firstPace == 0, asymmetric nil wordsPerMinute)
+
+    /// `firstPace > 0` guards the pace branch's division. Without it,
+    /// `firstPace == 0` would divide by zero (`(lastPace - 0) / 0`), which
+    /// in Swift's floating-point arithmetic produces `.infinity` rather than
+    /// trapping — `abs(change) >= paceShiftThreshold` would then be
+    /// trivially true and fire a bogus pace claim on every walk with a
+    /// zero-wpm first recording. Must fall through to the subject branch
+    /// instead, which — using the same divergent-subject fixture as
+    /// `testFirstVersusLast_subjectDiverged_fires` — genuinely fires here.
+    func testFirstVersusLast_firstPaceZero_fallsThroughToSubjectBranch() {
+        let lines = directives([
+            recording(DirectiveFixtures.gardenWall, wpm: 0, minutesIn: 0),
+            recording(DirectiveFixtures.familyDebt, wpm: 101, minutesIn: 20)
+        ])
+        XCTAssertTrue(lines.contains { isFirstVersusLast($0) && $0.contains("shares little vocabulary") },
+                      "firstPace == 0 must not fire a pace claim from a divide-by-zero; it must fall through to subject")
+    }
+
+    /// `wordsPerMinute` is persisted asynchronously and is nil on the
+    /// walk-recovery path, so an asymmetric nil (one recording has a value,
+    /// the other doesn't) is a live production shape, not an edge case.
+    /// `if let firstPace = ..., let lastPace = ...` must fail closed on
+    /// either side and fall through to the subject branch.
+    func testFirstVersusLast_lastPaceMissing_fallsThroughToSubjectBranch() {
+        let lines = directives([
+            recording(DirectiveFixtures.gardenWall, wpm: 100, minutesIn: 0),
+            recording(DirectiveFixtures.familyDebt, wpm: nil, minutesIn: 20)
+        ])
+        XCTAssertTrue(lines.contains { isFirstVersusLast($0) && $0.contains("shares little vocabulary") },
+                      "a missing last-recording pace must fall through to subject, not crash or stay silent")
+    }
+
+    func testFirstVersusLast_firstPaceMissing_fallsThroughToSubjectBranch() {
+        let lines = directives([
+            recording(DirectiveFixtures.gardenWall, wpm: nil, minutesIn: 0),
+            recording(DirectiveFixtures.familyDebt, wpm: 100, minutesIn: 20)
+        ])
+        XCTAssertTrue(lines.contains { isFirstVersusLast($0) && $0.contains("shares little vocabulary") },
+                      "a missing first-recording pace must fall through to subject, not crash or stay silent")
+    }
+}

--- a/UnitTests/AttentionDirectivesTests.swift
+++ b/UnitTests/AttentionDirectivesTests.swift
@@ -367,4 +367,81 @@ final class AttentionDirectivesFirstVersusLastTests: XCTestCase {
         ])
         XCTAssertFalse(lines.contains(where: isFirstVersusLast))
     }
+
+    /// Regression for the Jaccard length-asymmetry bug: when the last
+    /// recording's vocabulary is a strict subset of the first's — a short
+    /// closing note that only repeats words already spoken at length — the
+    /// subject has not diverged at all, but Jaccard (`intersection / union`)
+    /// collapses to `|smaller| / |larger|` and can cross the ceiling anyway.
+    /// Here the first recording carries 32 unique content lemmas and the
+    /// closing note's 6 are all drawn from that set: Jaccard would be
+    /// 6/32 ≈ 0.19 — under the 0.20 ceiling, so the old computation fired
+    /// "shares little vocabulary" on a walk that never left its subject. The
+    /// overlap coefficient (`intersection / min(|first|, |last|)`) is 1.0
+    /// here, correctly silent.
+    func testFirstVersusLast_lastRecordingSubsetOfFirst_staysSilent() {
+        let openingReflection = """
+        I started down the garden path early this morning, past the stone \
+        wall and under the old oak trees, thinking about my mother and the \
+        letters she used to write, the garden she tended for thirty years, \
+        the roses along the fence, the smell of rain on the hedges, and how \
+        the light falls differently now that autumn is coming, the leaves \
+        turning gold and copper along the orchard gate near the pond.
+        """
+        let closingNote = "The garden path, the stone wall, the orchard gate again."
+        let lines = directives([
+            recording(openingReflection, wpm: nil, minutesIn: 0),
+            recording(closingNote, wpm: nil, minutesIn: 45)
+        ])
+        XCTAssertFalse(lines.contains(where: isFirstVersusLast),
+                       "a closing note that only repeats the opening's own vocabulary is the same subject, not a divergent one")
+    }
+
+    // MARK: - Guard paths (firstPace == 0, asymmetric nil wordsPerMinute)
+
+    /// `firstPace > 0` guards the pace branch's division. Without it,
+    /// `firstPace == 0` would divide by zero (`(lastPace - 0) / 0`), which
+    /// in Swift's floating-point arithmetic produces `.infinity` rather than
+    /// trapping — `abs(change) >= paceShiftThreshold` would then be
+    /// trivially true and fire a bogus pace claim on every walk with a
+    /// zero-wpm first recording. Must fall through to the subject branch
+    /// instead, which — using the same divergent-subject fixture as
+    /// `testFirstVersusLast_subjectDiverged_fires` — genuinely fires here.
+    func testFirstVersusLast_firstPaceZero_fallsThroughToSubjectBranch() {
+        let lines = directives([
+            recording("the garden hedge grows beside the stone wall near the orchard gate",
+                      wpm: 0, minutesIn: 0),
+            recording("my brother telephoned about the mortgage payment and the lawyer's invoice",
+                      wpm: 101, minutesIn: 20)
+        ])
+        XCTAssertTrue(lines.contains { isFirstVersusLast($0) && $0.contains("shares little vocabulary") },
+                      "firstPace == 0 must not fire a pace claim from a divide-by-zero; it must fall through to subject")
+    }
+
+    /// `wordsPerMinute` is persisted asynchronously and is nil on the
+    /// walk-recovery path, so an asymmetric nil (one recording has a value,
+    /// the other doesn't) is a live production shape, not an edge case.
+    /// `if let firstPace = ..., let lastPace = ...` must fail closed on
+    /// either side and fall through to the subject branch.
+    func testFirstVersusLast_lastPaceMissing_fallsThroughToSubjectBranch() {
+        let lines = directives([
+            recording("the garden hedge grows beside the stone wall near the orchard gate",
+                      wpm: 100, minutesIn: 0),
+            recording("my brother telephoned about the mortgage payment and the lawyer's invoice",
+                      wpm: nil, minutesIn: 20)
+        ])
+        XCTAssertTrue(lines.contains { isFirstVersusLast($0) && $0.contains("shares little vocabulary") },
+                      "a missing last-recording pace must fall through to subject, not crash or stay silent")
+    }
+
+    func testFirstVersusLast_firstPaceMissing_fallsThroughToSubjectBranch() {
+        let lines = directives([
+            recording("the garden hedge grows beside the stone wall near the orchard gate",
+                      wpm: nil, minutesIn: 0),
+            recording("my brother telephoned about the mortgage payment and the lawyer's invoice",
+                      wpm: 100, minutesIn: 20)
+        ])
+        XCTAssertTrue(lines.contains { isFirstVersusLast($0) && $0.contains("shares little vocabulary") },
+                      "a missing first-recording pace must fall through to subject, not crash or stay silent")
+    }
 }

--- a/UnitTests/AttentionDirectivesTests.swift
+++ b/UnitTests/AttentionDirectivesTests.swift
@@ -158,8 +158,8 @@ final class AttentionDirectivesTests: XCTestCase {
     func testFirstVersusLast_paceShiftBetweenRecordings_fires() {
         let context = ActivityContext.make(
             recordings: [
-                recording("Setting out heavy", wpm: 100),
-                recording("Coming home lighter", offset: 3000, wpm: 140)
+                recording(DirectiveFixtures.heavyOpening, wpm: 100),
+                recording(DirectiveFixtures.lighterClosing, offset: 3000, wpm: 140)
             ],
             startDate: start
         )
@@ -182,9 +182,14 @@ final class AttentionDirectivesTests: XCTestCase {
             + Array(repeating: 0.8, count: 30)
         let context = ActivityContext.make(
             recordings: [
-                recording("Release the river from its banks", wpm: 100),
-                recording("The river again, release again", offset: 900),
-                recording("Still the river", offset: 1500, wpm: 150)
+                recording("Release the river from its banks and let the water find its own way down "
+                          + "through the meadow, past the willows, toward the bridge I crossed yesterday.",
+                          wpm: 100),
+                recording("The river again, release again, the same water moving under the same bridge.",
+                          offset: 900),
+                recording("Still the river, still the release, and the meadow going gold in the late "
+                          + "light while the willows lean over the water and the bridge waits quietly ahead.",
+                          offset: 1500, wpm: 150)
             ],
             duration: 3600,
             startDate: start,
@@ -203,7 +208,10 @@ final class AttentionDirectivesTests: XCTestCase {
         XCTAssertFalse(quietPrompt.text.contains("**Attend to:**"))
 
         let telling = ActivityContext.make(
-            recordings: [recording("Setting out", wpm: 100), recording("Returning", offset: 3000, wpm: 140)],
+            recordings: [
+                recording(DirectiveFixtures.heavyOpening, wpm: 100),
+                recording(DirectiveFixtures.lighterClosing, offset: 3000, wpm: 140)
+            ],
             startDate: start
         )
         let tellingPrompt = PromptGenerator.generate(style: .reflective, context: telling)
@@ -271,177 +279,5 @@ final class AttentionDirectivesTests: XCTestCase {
             startDate: start
         )
         XCTAssertFalse(joined(context).contains("returns"))
-    }
-}
-
-/// `firstVersusLast` used to fire on every walk with two recordings and
-/// presuppose its own conclusion — told to measure what changed, the model
-/// finds change, including on walks where nothing did. These tests pin the
-/// gated behaviour: it fires only on a pace shift (free from
-/// `wordsPerMinute`) or a subject that genuinely diverged (two bounded
-/// lemma passes, never one per recording).
-final class AttentionDirectivesFirstVersusLastTests: XCTestCase {
-
-    private static let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
-
-    private func recording(_ text: String, wpm: Double?, minutesIn: Int) -> RecordingContext {
-        RecordingContext(
-            text: text,
-            timestamp: Self.start.addingTimeInterval(TimeInterval(minutesIn * 60)),
-            startCoordinate: nil,
-            endCoordinate: nil,
-            wordsPerMinute: wpm,
-            recordingUUID: UUID(),
-            endTimestamp: nil
-        )
-    }
-
-    private func directives(_ recordings: [RecordingContext]) -> [String] {
-        AttentionDirectives.detect(
-            context: .make(recordings: recordings, startDate: Self.start),
-            detectedLanguageCode: "en"
-        )
-    }
-
-    private func isFirstVersusLast(_ line: String) -> Bool {
-        line.contains("attend to what moved between them")
-    }
-
-    func testFirstVersusLast_sameSubjectSamePace_staysSilent() {
-        let text = "the garden hedge grows beside the stone wall near the orchard gate"
-        let lines = directives([
-            recording(text, wpm: 100, minutesIn: 0),
-            recording(text, wpm: 102, minutesIn: 20)
-        ])
-        XCTAssertFalse(lines.contains(where: isFirstVersusLast))
-    }
-
-    func testFirstVersusLast_paceShift_fires() {
-        let text = "the garden hedge grows beside the stone wall near the orchard gate"
-        let lines = directives([
-            recording(text, wpm: 100, minutesIn: 0),
-            recording(text, wpm: 140, minutesIn: 20)
-        ])
-        XCTAssertTrue(lines.contains { isFirstVersusLast($0) && $0.contains("faster") })
-    }
-
-    func testFirstVersusLast_paceSlowed_namesSlower() {
-        let text = "the garden hedge grows beside the stone wall near the orchard gate"
-        let lines = directives([
-            recording(text, wpm: 140, minutesIn: 0),
-            recording(text, wpm: 100, minutesIn: 20)
-        ])
-        XCTAssertTrue(lines.contains { isFirstVersusLast($0) && $0.contains("more slowly") })
-    }
-
-    func testFirstVersusLast_subjectDiverged_fires() {
-        let lines = directives([
-            recording("the garden hedge grows beside the stone wall near the orchard gate",
-                      wpm: 100, minutesIn: 0),
-            recording("my brother telephoned about the mortgage payment and the lawyer's invoice",
-                      wpm: 101, minutesIn: 20)
-        ])
-        XCTAssertTrue(lines.contains { isFirstVersusLast($0) && $0.contains("shares little vocabulary") })
-    }
-
-    func testFirstVersusLast_tooFewLemmasToJudge_staysSilent() {
-        let lines = directives([
-            recording("yes", wpm: 100, minutesIn: 0),
-            recording("no", wpm: 101, minutesIn: 20)
-        ])
-        XCTAssertFalse(lines.contains(where: isFirstVersusLast))
-    }
-
-    func testFirstVersusLast_missingPaceAndSameSubject_staysSilent() {
-        let text = "the garden hedge grows beside the stone wall near the orchard gate"
-        let lines = directives([
-            recording(text, wpm: nil, minutesIn: 0),
-            recording(text, wpm: nil, minutesIn: 20)
-        ])
-        XCTAssertFalse(lines.contains(where: isFirstVersusLast))
-    }
-
-    func testFirstVersusLast_singleRecording_staysSilent() {
-        let lines = directives([
-            recording("the garden hedge grows beside the stone wall", wpm: 100, minutesIn: 0)
-        ])
-        XCTAssertFalse(lines.contains(where: isFirstVersusLast))
-    }
-
-    /// Regression for the Jaccard length-asymmetry bug: when the last
-    /// recording's vocabulary is a strict subset of the first's — a short
-    /// closing note that only repeats words already spoken at length — the
-    /// subject has not diverged at all, but Jaccard (`intersection / union`)
-    /// collapses to `|smaller| / |larger|` and can cross the ceiling anyway.
-    /// Here the first recording carries 32 unique content lemmas and the
-    /// closing note's 6 are all drawn from that set: Jaccard would be
-    /// 6/32 ≈ 0.19 — under the 0.20 ceiling, so the old computation fired
-    /// "shares little vocabulary" on a walk that never left its subject. The
-    /// overlap coefficient (`intersection / min(|first|, |last|)`) is 1.0
-    /// here, correctly silent.
-    func testFirstVersusLast_lastRecordingSubsetOfFirst_staysSilent() {
-        let openingReflection = """
-        I started down the garden path early this morning, past the stone \
-        wall and under the old oak trees, thinking about my mother and the \
-        letters she used to write, the garden she tended for thirty years, \
-        the roses along the fence, the smell of rain on the hedges, and how \
-        the light falls differently now that autumn is coming, the leaves \
-        turning gold and copper along the orchard gate near the pond.
-        """
-        let closingNote = "The garden path, the stone wall, the orchard gate again."
-        let lines = directives([
-            recording(openingReflection, wpm: nil, minutesIn: 0),
-            recording(closingNote, wpm: nil, minutesIn: 45)
-        ])
-        XCTAssertFalse(lines.contains(where: isFirstVersusLast),
-                       "a closing note that only repeats the opening's own vocabulary is the same subject, not a divergent one")
-    }
-
-    // MARK: - Guard paths (firstPace == 0, asymmetric nil wordsPerMinute)
-
-    /// `firstPace > 0` guards the pace branch's division. Without it,
-    /// `firstPace == 0` would divide by zero (`(lastPace - 0) / 0`), which
-    /// in Swift's floating-point arithmetic produces `.infinity` rather than
-    /// trapping — `abs(change) >= paceShiftThreshold` would then be
-    /// trivially true and fire a bogus pace claim on every walk with a
-    /// zero-wpm first recording. Must fall through to the subject branch
-    /// instead, which — using the same divergent-subject fixture as
-    /// `testFirstVersusLast_subjectDiverged_fires` — genuinely fires here.
-    func testFirstVersusLast_firstPaceZero_fallsThroughToSubjectBranch() {
-        let lines = directives([
-            recording("the garden hedge grows beside the stone wall near the orchard gate",
-                      wpm: 0, minutesIn: 0),
-            recording("my brother telephoned about the mortgage payment and the lawyer's invoice",
-                      wpm: 101, minutesIn: 20)
-        ])
-        XCTAssertTrue(lines.contains { isFirstVersusLast($0) && $0.contains("shares little vocabulary") },
-                      "firstPace == 0 must not fire a pace claim from a divide-by-zero; it must fall through to subject")
-    }
-
-    /// `wordsPerMinute` is persisted asynchronously and is nil on the
-    /// walk-recovery path, so an asymmetric nil (one recording has a value,
-    /// the other doesn't) is a live production shape, not an edge case.
-    /// `if let firstPace = ..., let lastPace = ...` must fail closed on
-    /// either side and fall through to the subject branch.
-    func testFirstVersusLast_lastPaceMissing_fallsThroughToSubjectBranch() {
-        let lines = directives([
-            recording("the garden hedge grows beside the stone wall near the orchard gate",
-                      wpm: 100, minutesIn: 0),
-            recording("my brother telephoned about the mortgage payment and the lawyer's invoice",
-                      wpm: nil, minutesIn: 20)
-        ])
-        XCTAssertTrue(lines.contains { isFirstVersusLast($0) && $0.contains("shares little vocabulary") },
-                      "a missing last-recording pace must fall through to subject, not crash or stay silent")
-    }
-
-    func testFirstVersusLast_firstPaceMissing_fallsThroughToSubjectBranch() {
-        let lines = directives([
-            recording("the garden hedge grows beside the stone wall near the orchard gate",
-                      wpm: nil, minutesIn: 0),
-            recording("my brother telephoned about the mortgage payment and the lawyer's invoice",
-                      wpm: 100, minutesIn: 20)
-        ])
-        XCTAssertTrue(lines.contains { isFirstVersusLast($0) && $0.contains("shares little vocabulary") },
-                      "a missing first-recording pace must fall through to subject, not crash or stay silent")
     }
 }

--- a/UnitTests/AttentionDirectivesTests.swift
+++ b/UnitTests/AttentionDirectivesTests.swift
@@ -10,13 +10,13 @@ final class AttentionDirectivesTests: XCTestCase {
 
     private let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
 
-    private func recording(_ text: String, offset: TimeInterval = 300) -> RecordingContext {
+    private func recording(_ text: String, offset: TimeInterval = 300, wpm: Double? = nil) -> RecordingContext {
         RecordingContext(
             text: text,
             timestamp: start.addingTimeInterval(offset),
             startCoordinate: nil,
             endCoordinate: nil,
-            wordsPerMinute: nil
+            wordsPerMinute: wpm
         )
     }
 
@@ -148,13 +148,22 @@ final class AttentionDirectivesTests: XCTestCase {
     }
 
     // MARK: - First vs last recording
+    //
+    // Full behavioural coverage (pace shift, subject divergence, and the
+    // silent cases) lives in AttentionDirectivesFirstVersusLastTests below —
+    // gated per PR (task 3 of the oblique-voice plan): the directive used to
+    // fire unconditionally on any walk with two recordings, presupposing
+    // its own conclusion. These two just confirm the assembler wiring.
 
-    func testFirstVersusLast_twoRecordings_fires() {
+    func testFirstVersusLast_paceShiftBetweenRecordings_fires() {
         let context = ActivityContext.make(
-            recordings: [recording("Setting out heavy"), recording("Coming home lighter", offset: 3000)],
+            recordings: [
+                recording("Setting out heavy", wpm: 100),
+                recording("Coming home lighter", offset: 3000, wpm: 140)
+            ],
             startDate: start
         )
-        XCTAssertTrue(joined(context).contains("first recording"))
+        XCTAssertTrue(joined(context).contains("attend to what moved between them"))
     }
 
     func testFirstVersusLast_singleRecording_doesNotFire() {
@@ -162,7 +171,7 @@ final class AttentionDirectivesTests: XCTestCase {
             recordings: [recording("Just one thought today")],
             startDate: start
         )
-        XCTAssertFalse(joined(context).contains("first recording"))
+        XCTAssertFalse(joined(context).contains("attend to what moved between them"))
     }
 
     // MARK: - Cap and assembly
@@ -173,15 +182,18 @@ final class AttentionDirectivesTests: XCTestCase {
             + Array(repeating: 0.8, count: 30)
         let context = ActivityContext.make(
             recordings: [
-                recording("Release the river from its banks"),
+                recording("Release the river from its banks", wpm: 100),
                 recording("The river again, release again", offset: 900),
-                recording("Still the river", offset: 1500)
+                recording("Still the river", offset: 1500, wpm: 150)
             ],
             duration: 3600,
             startDate: start,
             routeSpeeds: speeds,
             intention: "Release what I cannot carry"
         )
+        // Five detectors have something to fire here (stillness, pace shift,
+        // intention echo, recurring word, and first-vs-last via the 50% wpm
+        // change) — the cap must still hold at four.
         XCTAssertLessThanOrEqual(AttentionDirectives.detect(context: context).count, 4)
     }
 
@@ -191,7 +203,7 @@ final class AttentionDirectivesTests: XCTestCase {
         XCTAssertFalse(quietPrompt.text.contains("**Attend to:**"))
 
         let telling = ActivityContext.make(
-            recordings: [recording("Setting out"), recording("Returning", offset: 3000)],
+            recordings: [recording("Setting out", wpm: 100), recording("Returning", offset: 3000, wpm: 140)],
             startDate: start
         )
         let tellingPrompt = PromptGenerator.generate(style: .reflective, context: telling)
@@ -259,5 +271,100 @@ final class AttentionDirectivesTests: XCTestCase {
             startDate: start
         )
         XCTAssertFalse(joined(context).contains("returns"))
+    }
+}
+
+/// `firstVersusLast` used to fire on every walk with two recordings and
+/// presuppose its own conclusion — told to measure what changed, the model
+/// finds change, including on walks where nothing did. These tests pin the
+/// gated behaviour: it fires only on a pace shift (free from
+/// `wordsPerMinute`) or a subject that genuinely diverged (two bounded
+/// lemma passes, never one per recording).
+final class AttentionDirectivesFirstVersusLastTests: XCTestCase {
+
+    private static let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+
+    private func recording(_ text: String, wpm: Double?, minutesIn: Int) -> RecordingContext {
+        RecordingContext(
+            text: text,
+            timestamp: Self.start.addingTimeInterval(TimeInterval(minutesIn * 60)),
+            startCoordinate: nil,
+            endCoordinate: nil,
+            wordsPerMinute: wpm,
+            recordingUUID: UUID(),
+            endTimestamp: nil
+        )
+    }
+
+    private func directives(_ recordings: [RecordingContext]) -> [String] {
+        AttentionDirectives.detect(
+            context: .make(recordings: recordings, startDate: Self.start),
+            detectedLanguageCode: "en"
+        )
+    }
+
+    private func isFirstVersusLast(_ line: String) -> Bool {
+        line.contains("attend to what moved between them")
+    }
+
+    func testFirstVersusLast_sameSubjectSamePace_staysSilent() {
+        let text = "the garden hedge grows beside the stone wall near the orchard gate"
+        let lines = directives([
+            recording(text, wpm: 100, minutesIn: 0),
+            recording(text, wpm: 102, minutesIn: 20)
+        ])
+        XCTAssertFalse(lines.contains(where: isFirstVersusLast))
+    }
+
+    func testFirstVersusLast_paceShift_fires() {
+        let text = "the garden hedge grows beside the stone wall near the orchard gate"
+        let lines = directives([
+            recording(text, wpm: 100, minutesIn: 0),
+            recording(text, wpm: 140, minutesIn: 20)
+        ])
+        XCTAssertTrue(lines.contains { isFirstVersusLast($0) && $0.contains("faster") })
+    }
+
+    func testFirstVersusLast_paceSlowed_namesSlower() {
+        let text = "the garden hedge grows beside the stone wall near the orchard gate"
+        let lines = directives([
+            recording(text, wpm: 140, minutesIn: 0),
+            recording(text, wpm: 100, minutesIn: 20)
+        ])
+        XCTAssertTrue(lines.contains { isFirstVersusLast($0) && $0.contains("more slowly") })
+    }
+
+    func testFirstVersusLast_subjectDiverged_fires() {
+        let lines = directives([
+            recording("the garden hedge grows beside the stone wall near the orchard gate",
+                      wpm: 100, minutesIn: 0),
+            recording("my brother telephoned about the mortgage payment and the lawyer's invoice",
+                      wpm: 101, minutesIn: 20)
+        ])
+        XCTAssertTrue(lines.contains { isFirstVersusLast($0) && $0.contains("shares little vocabulary") })
+    }
+
+    func testFirstVersusLast_tooFewLemmasToJudge_staysSilent() {
+        let lines = directives([
+            recording("yes", wpm: 100, minutesIn: 0),
+            recording("no", wpm: 101, minutesIn: 20)
+        ])
+        XCTAssertFalse(lines.contains(where: isFirstVersusLast))
+    }
+
+    func testFirstVersusLast_missingPaceAndSameSubject_staysSilent() {
+        let text = "the garden hedge grows beside the stone wall near the orchard gate"
+        let lines = directives([
+            recording(text, wpm: nil, minutesIn: 0),
+            recording(text, wpm: nil, minutesIn: 20)
+        ])
+        XCTAssertFalse(lines.contains(where: isFirstVersusLast))
+    }
+
+    func testFirstVersusLast_singleRecording_staysSilent() {
+        let lines = directives([
+            recording("the garden hedge grows beside the stone wall", wpm: 100, minutesIn: 0)
+        ])
+        XCTAssertFalse(lines.contains(where: isFirstVersusLast))
     }
 }

--- a/UnitTests/PromptGeneratorTests.swift
+++ b/UnitTests/PromptGeneratorTests.swift
@@ -419,4 +419,24 @@ final class PromptGeneratorTests: XCTestCase {
         XCTAssertNil(prompt.style)
         XCTAssertEqual(prompt.customStyle?.title, "Letter")
     }
+
+    // MARK: - Task 2: Reflective Voice Bound to the Walk's Own Evidence
+
+    func testReflectiveVoice_spoken_bindsConnectionsToTheRecord() {
+        let instruction = ReflectiveVoice().instruction(hasSpeech: true)
+        XCTAssertTrue(instruction.contains("Where the walk's own record supports it"))
+        XCTAssertTrue(instruction.contains("say less rather than reaching"))
+        XCTAssertTrue(instruction.contains("do not manufacture one"))
+    }
+
+    func testReflectiveVoice_silent_bindsPatternsToTheRecord() {
+        let instruction = ReflectiveVoice().instruction(hasSpeech: false)
+        XCTAssertTrue(instruction.contains("Where the walk's own record supports it"))
+        XCTAssertTrue(instruction.contains("say less rather than reaching"))
+    }
+
+    func testReflectiveVoice_bothModes_keepSelfUnderstandingGoal() {
+        XCTAssertTrue(ReflectiveVoice().instruction(hasSpeech: true).contains("understand"))
+        XCTAssertTrue(ReflectiveVoice().instruction(hasSpeech: false).contains("understand"))
+    }
 }

--- a/UnitTests/PromptGeneratorTests.swift
+++ b/UnitTests/PromptGeneratorTests.swift
@@ -422,11 +422,19 @@ final class PromptGeneratorTests: XCTestCase {
 
     // MARK: - Task 2: Reflective Voice Bound to the Walk's Own Evidence
 
+    /// The instruction enumerates the evidence the model may lean on, and
+    /// every item in that enumeration must be evidence a spoken walk
+    /// actually carries. The marker profile is not: it reaches the prompt
+    /// only when `UserPreferences.threadsAfterWalks` is on, and
+    /// `instruction(hasSpeech:)` — unlike `PromptAssembler.responseContract`
+    /// — has no way to know whether it did.
     func testReflectiveVoice_spoken_bindsConnectionsToTheRecord() {
         let instruction = ReflectiveVoice().instruction(hasSpeech: true)
         XCTAssertTrue(instruction.contains("Where the walk's own record supports it"))
         XCTAssertTrue(instruction.contains("say less rather than reaching"))
         XCTAssertTrue(instruction.contains("do not manufacture one"))
+        XCTAssertTrue(instruction.contains("a shift in pace"))
+        XCTAssertFalse(instruction.contains("marker profile"), "the dossier is behind a preference")
     }
 
     func testReflectiveVoice_silent_bindsPatternsToTheRecord() {

--- a/UnitTests/PromptResponseContractTests.swift
+++ b/UnitTests/PromptResponseContractTests.swift
@@ -87,11 +87,28 @@ final class PromptResponseContractTests: XCTestCase {
         let contract = PromptAssembler.responseContract(
             voice: ReflectiveVoice(), hasSpeech: true, hasThreadsDossier: true
         )
-        XCTAssertTrue(contract.contains("absolutist density"))
-        XCTAssertTrue(contract.contains("first-person density"))
+        XCTAssertTrue(contract.contains("absolutist-word share"))
+        XCTAssertTrue(contract.contains("self-focus"))
         XCTAssertTrue(contract.contains("modal lean"))
         XCTAssertTrue(contract.contains("obligation"))
         XCTAssertTrue(contract.contains("counterfactual"))
+    }
+
+    /// The interpretive key must name every modal family the model can
+    /// encounter in a dossier — a family named in the enum but not here
+    /// invites the model to back-fit an unnamed family onto the nearest
+    /// named one. Reading straight from `ModalFamily.allCases` means a
+    /// future family added without updating the contract line fails this
+    /// test automatically, rather than relying on someone remembering to
+    /// keep a hardcoded list in sync.
+    func testResponseContract_withThreadsDossier_namesEveryModalFamily() {
+        let contract = PromptAssembler.responseContract(
+            voice: ReflectiveVoice(), hasSpeech: true, hasThreadsDossier: true
+        )
+        for family in MarkerLexicons.ModalFamily.allCases {
+            XCTAssertTrue(contract.contains(family.rawValue),
+                          "interpretive key omits modal family '\(family.rawValue)'")
+        }
     }
 
     func testResponseContract_withThreadsDossier_retainsClinicalGuard() {
@@ -105,7 +122,7 @@ final class PromptResponseContractTests: XCTestCase {
         let contract = PromptAssembler.responseContract(
             voice: ReflectiveVoice(), hasSpeech: true, hasThreadsDossier: false
         )
-        XCTAssertFalse(contract.contains("absolutist density"))
+        XCTAssertFalse(contract.contains("absolutist-word share"))
     }
 
     func testResponseContract_withThreadsDossier_addsExactlyOneLine() {

--- a/UnitTests/PromptResponseContractTests.swift
+++ b/UnitTests/PromptResponseContractTests.swift
@@ -83,9 +83,42 @@ final class PromptResponseContractTests: XCTestCase {
         XCTAssertTrue(prompt.text.contains("never invent"))
     }
 
+    // MARK: - Interpretive key
+    //
+    // The key is only honest about signals the dossier actually printed. A
+    // non-English recording prints "Markers unavailable"; a recording under
+    // `densityFloorWords` prints raw counts, not shares; and the modal-lean
+    // clause is silent unless it clears three thresholds. Teaching a
+    // taxonomy the dossier withheld invites the model to back-fill it.
+
+    /// The richest shape: shares over the density floor plus a modal lean.
+    private func fullDossier() -> String {
+        "**Thought threads (on-device linguistic analysis):**"
+            + "\nRecording 1: absolutist words 2.4% over 320 words; self-focus 6.1%; "
+            + "insight 4, causation 2, discrepancy 1; temporal lean: past (coarse heuristic)"
+            + "\nmodal lean: obligation — 'should' ×14 (your usual ~5 per walk)"
+    }
+
+    private func sharesOnlyDossier() -> String {
+        "**Thought threads (on-device linguistic analysis):**"
+            + "\nRecording 1: absolutist words 2.4% over 320 words; self-focus 6.1%; "
+            + "insight 4, causation 2, discrepancy 1; temporal lean: past (coarse heuristic)"
+    }
+
+    private func nonEnglishDossier() -> String {
+        "**Thought threads (on-device linguistic analysis):**"
+            + "\nRecording 1: Markers unavailable (non-English recording)."
+    }
+
+    private func smallSampleDossier() -> String {
+        "**Thought threads (on-device linguistic analysis):**"
+            + "\nRecording 1: 40 words — small sample, raw counts only: 2 absolutist, 5 self-focus; "
+            + "insight 1, causation 0, discrepancy 0; temporal lean: present (coarse heuristic)"
+    }
+
     func testResponseContract_withThreadsDossier_carriesInterpretiveKey() {
         let contract = PromptAssembler.responseContract(
-            voice: ReflectiveVoice(), hasSpeech: true, hasThreadsDossier: true
+            voice: ReflectiveVoice(), hasSpeech: true, threadsDossier: fullDossier()
         )
         XCTAssertTrue(contract.contains("absolutist-word share"))
         XCTAssertTrue(contract.contains("self-focus"))
@@ -100,40 +133,141 @@ final class PromptResponseContractTests: XCTestCase {
     /// named one. Reading straight from `ModalFamily.allCases` means a
     /// future family added without updating the contract line fails this
     /// test automatically, rather than relying on someone remembering to
-    /// keep a hardcoded list in sync.
+    /// keep a hardcoded list in sync. Naming is not enough on its own,
+    /// though: a scrambled term-to-definition mapping would still name all
+    /// six, so each pair is asserted as a unit.
     func testResponseContract_withThreadsDossier_namesEveryModalFamily() {
         let contract = PromptAssembler.responseContract(
-            voice: ReflectiveVoice(), hasSpeech: true, hasThreadsDossier: true
+            voice: ReflectiveVoice(), hasSpeech: true, threadsDossier: fullDossier()
         )
         for family in MarkerLexicons.ModalFamily.allCases {
             XCTAssertTrue(contract.contains(family.rawValue),
                           "interpretive key omits modal family '\(family.rawValue)'")
         }
+        for pair in [
+            "obligation means the frame constrained them",
+            "counterfactual means they were already replaying alternatives",
+            "possibility and tentative mean it was still open",
+            "intention means they had settled on a course",
+            "desire means they were naming a want rather than a plan"
+        ] {
+            XCTAssertTrue(contract.contains(pair),
+                          "interpretive key does not bind '\(pair)' as a unit")
+        }
     }
 
     func testResponseContract_withThreadsDossier_retainsClinicalGuard() {
-        let contract = PromptAssembler.responseContract(
-            voice: ReflectiveVoice(), hasSpeech: true, hasThreadsDossier: true
-        )
-        XCTAssertTrue(contract.contains("never produce clinical or diagnostic language"))
+        for dossier in [fullDossier(), nonEnglishDossier(), smallSampleDossier()] {
+            let contract = PromptAssembler.responseContract(
+                voice: ReflectiveVoice(), hasSpeech: true, threadsDossier: dossier
+            )
+            XCTAssertTrue(contract.contains("never produce clinical or diagnostic language"),
+                          "the safety line is unconditional on the dossier's presence")
+        }
     }
 
     func testResponseContract_withoutThreadsDossier_hasNoInterpretiveKey() {
         let contract = PromptAssembler.responseContract(
-            voice: ReflectiveVoice(), hasSpeech: true, hasThreadsDossier: false
+            voice: ReflectiveVoice(), hasSpeech: true, threadsDossier: nil
         )
         XCTAssertFalse(contract.contains("absolutist-word share"))
     }
 
-    func testResponseContract_withThreadsDossier_addsExactlyTwoLines() {
-        let with = PromptAssembler.responseContract(
-            voice: ReflectiveVoice(), hasSpeech: true, hasThreadsDossier: true
+    func testResponseContract_nonEnglishDossier_teachesNoTaxonomyAtAll() {
+        let contract = PromptAssembler.responseContract(
+            voice: ReflectiveVoice(), hasSpeech: true, threadsDossier: nonEnglishDossier()
         )
+        XCTAssertFalse(contract.contains("absolutist-word share"),
+                       "the dossier printed no markers, so there is no share to read")
+        XCTAssertFalse(contract.contains("modal lean"),
+                       "the dossier printed no modal lean, so there is no frame to read")
+    }
+
+    func testResponseContract_smallSampleDossier_readsCountsNotShares() {
+        let contract = PromptAssembler.responseContract(
+            voice: ReflectiveVoice(), hasSpeech: true, threadsDossier: smallSampleDossier()
+        )
+        XCTAssertFalse(contract.contains("absolutist-word share"),
+                       "under the density floor the dossier prints raw counts, never a share")
+        XCTAssertTrue(contract.contains("too few words to read as a rate"))
+    }
+
+    func testResponseContract_dossierWithoutModalLean_omitsTheModalTaxonomy() {
+        let contract = PromptAssembler.responseContract(
+            voice: ReflectiveVoice(), hasSpeech: true, threadsDossier: sharesOnlyDossier()
+        )
+        XCTAssertTrue(contract.contains("absolutist-word share"))
+        XCTAssertFalse(contract.contains("modal lean"),
+                       "the modal clause is silent behind three thresholds; the key must follow it")
+    }
+
+    /// The key's probes read `ThreadsDossierFormatter`'s own output, so this
+    /// runs the real formatter rather than a hand-written fixture — if the
+    /// formatter's phrasing moves, this fails rather than silently
+    /// suppressing the key on every walk.
+    func testResponseContract_againstRealFormatterOutput_adaptsToWhatWasPrinted() {
+        let markers = MarkerPack(
+            wordCount: 320, absolutistCount: 8, firstPersonCount: 20,
+            insightCount: 2, causationCount: 1, discrepancyCount: 1,
+            futureCount: 4, pastCount: 1, sentiment: -0.2, modalCounts: [:]
+        )
+        let dense = TranscriptContext(
+            schemaVersion: TranscriptContext.currentSchemaVersion, recordingUUID: UUID(),
+            transcriptHash: "h", languageCode: "en", wordCount: 320, themes: [], markers: markers
+        )
+        let denseLine = ThreadsDossierFormatter.markerLine(for: dense, baseline: nil)
+        XCTAssertTrue(
+            PromptAssembler.responseContract(
+                voice: ReflectiveVoice(), hasSpeech: true, threadsDossier: denseLine
+            ).contains("absolutist-word share")
+        )
+
+        let sparse = TranscriptContext(
+            schemaVersion: TranscriptContext.currentSchemaVersion, recordingUUID: UUID(),
+            transcriptHash: "h", languageCode: "en", wordCount: 40, themes: [],
+            markers: MarkerPack(
+                wordCount: 40, absolutistCount: 2, firstPersonCount: 5,
+                insightCount: 1, causationCount: 0, discrepancyCount: 0,
+                futureCount: 1, pastCount: 0, sentiment: nil, modalCounts: [:]
+            )
+        )
+        let sparseContract = PromptAssembler.responseContract(
+            voice: ReflectiveVoice(), hasSpeech: true,
+            threadsDossier: ThreadsDossierFormatter.markerLine(for: sparse, baseline: nil)
+        )
+        XCTAssertFalse(sparseContract.contains("absolutist-word share"))
+        XCTAssertTrue(sparseContract.contains("too few words to read as a rate"))
+
+        let absent = TranscriptContext(
+            schemaVersion: TranscriptContext.currentSchemaVersion, recordingUUID: UUID(),
+            transcriptHash: "h", languageCode: "es", wordCount: 320, themes: [], markers: nil
+        )
+        let absentContract = PromptAssembler.responseContract(
+            voice: ReflectiveVoice(), hasSpeech: true,
+            threadsDossier: ThreadsDossierFormatter.markerLine(for: absent, baseline: nil)
+        )
+        XCTAssertFalse(absentContract.contains("absolutist-word share"))
+        XCTAssertFalse(absentContract.contains("too few words to read as a rate"))
+    }
+
+    /// The accretion budget: a dossier may add the clinical guard plus at
+    /// most one interpretive line, never more. When the dossier withheld
+    /// every referent the key shrinks to the guard alone.
+    func testResponseContract_withThreadsDossier_neverAddsMoreThanTwoLines() {
         let without = PromptAssembler.responseContract(
-            voice: ReflectiveVoice(), hasSpeech: true, hasThreadsDossier: false
+            voice: ReflectiveVoice(), hasSpeech: true, threadsDossier: nil
         )
-        let withLines = with.components(separatedBy: "\n- ").count
-        let withoutLines = without.components(separatedBy: "\n- ").count
-        XCTAssertEqual(withLines - withoutLines, 2, "clinical guard + interpretive key, no more")
+        let baseline = without.components(separatedBy: "\n- ").count
+
+        for (dossier, expected) in [
+            (fullDossier(), 2), (sharesOnlyDossier(), 2),
+            (smallSampleDossier(), 2), (nonEnglishDossier(), 1)
+        ] {
+            let with = PromptAssembler.responseContract(
+                voice: ReflectiveVoice(), hasSpeech: true, threadsDossier: dossier
+            )
+            XCTAssertEqual(with.components(separatedBy: "\n- ").count - baseline, expected,
+                           "clinical guard + at most one interpretive line")
+        }
     }
 }

--- a/UnitTests/PromptResponseContractTests.swift
+++ b/UnitTests/PromptResponseContractTests.swift
@@ -125,7 +125,7 @@ final class PromptResponseContractTests: XCTestCase {
         XCTAssertFalse(contract.contains("absolutist-word share"))
     }
 
-    func testResponseContract_withThreadsDossier_addsExactlyOneLine() {
+    func testResponseContract_withThreadsDossier_addsExactlyTwoLines() {
         let with = PromptAssembler.responseContract(
             voice: ReflectiveVoice(), hasSpeech: true, hasThreadsDossier: true
         )

--- a/UnitTests/PromptResponseContractTests.swift
+++ b/UnitTests/PromptResponseContractTests.swift
@@ -82,4 +82,41 @@ final class PromptResponseContractTests: XCTestCase {
         XCTAssertTrue(prompt.text.contains("**How to respond:**"))
         XCTAssertTrue(prompt.text.contains("never invent"))
     }
+
+    func testResponseContract_withThreadsDossier_carriesInterpretiveKey() {
+        let contract = PromptAssembler.responseContract(
+            voice: ReflectiveVoice(), hasSpeech: true, hasThreadsDossier: true
+        )
+        XCTAssertTrue(contract.contains("absolutist density"))
+        XCTAssertTrue(contract.contains("first-person density"))
+        XCTAssertTrue(contract.contains("modal lean"))
+        XCTAssertTrue(contract.contains("obligation"))
+        XCTAssertTrue(contract.contains("counterfactual"))
+    }
+
+    func testResponseContract_withThreadsDossier_retainsClinicalGuard() {
+        let contract = PromptAssembler.responseContract(
+            voice: ReflectiveVoice(), hasSpeech: true, hasThreadsDossier: true
+        )
+        XCTAssertTrue(contract.contains("never produce clinical or diagnostic language"))
+    }
+
+    func testResponseContract_withoutThreadsDossier_hasNoInterpretiveKey() {
+        let contract = PromptAssembler.responseContract(
+            voice: ReflectiveVoice(), hasSpeech: true, hasThreadsDossier: false
+        )
+        XCTAssertFalse(contract.contains("absolutist density"))
+    }
+
+    func testResponseContract_withThreadsDossier_addsExactlyOneLine() {
+        let with = PromptAssembler.responseContract(
+            voice: ReflectiveVoice(), hasSpeech: true, hasThreadsDossier: true
+        )
+        let without = PromptAssembler.responseContract(
+            voice: ReflectiveVoice(), hasSpeech: true, hasThreadsDossier: false
+        )
+        let withLines = with.components(separatedBy: "\n- ").count
+        let withoutLines = without.components(separatedBy: "\n- ").count
+        XCTAssertEqual(withLines - withoutLines, 2, "clinical guard + interpretive key, no more")
+    }
 }

--- a/docs/superpowers/plans/2026-08-27-oblique-voice.md
+++ b/docs/superpowers/plans/2026-08-27-oblique-voice.md
@@ -1,0 +1,2007 @@
+# Oblique Voice Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** A seventh prompt voice that reads what has **not** moved across a walker's history and names the frame they have been looking through rather than at.
+
+**Architecture:** Two layers. Layer 1 is a pure, deterministic on-device engine (`DossierSensesInvariance`) that computes what is actually invariant across the walker's threads — this is relevance realization, and the model cannot do it because it has no access to history. Layer 2 is the model, which interprets those invariants — aspectualization, which the device cannot do. The engine emits an `**Unchanged:**` block that enters the prompt as context; the model's response is what the walker reads.
+
+**Tech Stack:** Swift 5, SwiftUI, XCTest. Build via `Pilgrim.xcworkspace`, scheme `Pilgrim`.
+
+**Spec:** `docs/superpowers/specs/2026-08-27-oblique-and-prompt-relevance-design.md` (Workstreams 1 and 5)
+
+**Depends on:** nothing. Can land before, after, or alongside `2026-08-27-prompt-relevance-fixes.md`.
+
+## Global Constraints
+
+- **Binding purity contract.** `DossierSensesInvariance` must not reference `DataManager`, `CoreStore`, any singleton, or `Date()`. Every input arrives as an argument. Time arrives as data. This mirrors `DossierSenses` and is what makes every emitted line traceable to enumerable, deterministic inputs.
+- **Single-pass property.** `PromptGenerator.generateAll` maps one `ActivityContext` across `PromptStyle.allCases`, and `resolvedDerivations` computes language detection and directives once. The `unchangedBlock` is built **once** with the rest of the dossier and merely *emitted* per voice at assembly time. Never build a per-voice dossier.
+- **No new fetches.** `historicalContexts` is wired from the fetch `ThreadsDossierBuilder` already performs for `ThreadsDossierFormatter.dossier(allContexts:)`. If you find yourself adding a `fetchAll`, stop — the plan is wrong, not the constraint.
+- Do **not** bump `TranscriptContext.currentSchemaVersion` (currently `4`). Nothing here changes how context is derived, so no stored file becomes stale. Bumping it would force a needless full re-analysis sweep.
+- Line cap is **3**, matching `DossierSenses.lineCap` and the working-memory bound.
+- All thresholds are **starting values** subject to the field gate, following the `ThemeExtractor.minimumMentions` and `questionDensity` precedents. Never loosen a threshold to make a test pass — fix the fixture.
+- Typography: any UI text uses `Constants.Typography.*`. Never `.system()` fonts.
+- Run the full suite before each commit. Baseline 1388; expect growth, never reduction.
+- Never use `--no-verify`.
+
+**Build:**
+```bash
+xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build
+```
+
+**Test:**
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+```
+
+> **Note on test counts:** `xcodebuild` summary lines are unreliable under the macos-26 simulator flake. Count `Test Case '-[...]' started` lines instead.
+
+---
+
+## Task 1: Widen `DossierSenses.Input` with `historicalContexts`
+
+**Why:** Signals 2 and 3 need historical marker data (`markers.modalCounts`, absolutist rate, sentiment) keyed by `recordingUUID`. `Input` currently carries only `currentRecordings`. The builder already fetches `allContexts` for `ThreadsDossierFormatter.dossier` — this is a widened hand-off, not a new query.
+
+**Files:**
+- Modify: `Pilgrim/Models/Threads/DossierSenses.swift` (the `Input` struct)
+- Modify: `Pilgrim/Models/Threads/ThreadsDossierBuilder.swift` (`makeSensesInput`)
+- Modify: `UnitTests/DossierSensesTests.swift` (`makeInput` helper)
+- Modify: `UnitTests/DossierSensesCrossWalkTests.swift` (its `Input` construction)
+- Modify: `UnitTests/FieldGateReportTests.swift` (its `Input` construction)
+
+**Interfaces:**
+- Produces: `DossierSenses.Input.historicalContexts: [TranscriptContext]` — every `TranscriptContext` the builder loaded, including the current walk's. Consumers filter by `recordingUUID`.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `UnitTests/DossierSensesTests.swift`:
+
+```swift
+func testInput_carriesHistoricalContexts() {
+    let uuid = UUID()
+    let context = TranscriptContext(
+        schemaVersion: TranscriptContext.currentSchemaVersion,
+        recordingUUID: uuid,
+        transcriptHash: "hash",
+        languageCode: "en",
+        wordCount: 200,
+        themes: [],
+        markers: nil
+    )
+    let input = makeInput(historicalContexts: [context])
+    XCTAssertEqual(input.historicalContexts.count, 1)
+    XCTAssertEqual(input.historicalContexts.first?.recordingUUID, uuid)
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:UnitTests/DossierSensesTests
+```
+
+Expected: COMPILE FAILURE — `makeInput` has no parameter `historicalContexts`.
+
+- [ ] **Step 3: Add the field and update all four construction sites**
+
+In `Pilgrim/Models/Threads/DossierSenses.swift`, add to `Input` after `currentRecordings`:
+
+```swift
+        /// Every TranscriptContext the builder loaded, current walk
+        /// included, so invariance signals can reach historical marker and
+        /// modal data by `recordingUUID`. Wired from the fetch the builder
+        /// already performs for ThreadsDossierFormatter — never a new query.
+        let historicalContexts: [TranscriptContext]
+```
+
+In `ThreadsDossierBuilder.makeSensesInput`, pass the contexts the builder already holds. `state.contextsByUUID` is the loaded map, so:
+
+```swift
+            historicalContexts: Array(state.contextsByUUID.values),
+```
+
+Place it in the `DossierSenses.Input(...)` call immediately after `currentRecordings:`.
+
+In each of the three test files, add the parameter to the local helper with a default so existing call sites stay unchanged. In `UnitTests/DossierSensesTests.swift`:
+
+```swift
+        historicalContexts: [TranscriptContext] = [],
+```
+
+as a `makeInput` parameter, and `historicalContexts: historicalContexts,` in the `Input(...)` body. Apply the identical change to `UnitTests/DossierSensesCrossWalkTests.swift` and `UnitTests/FieldGateReportTests.swift`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+```
+
+Expected: the new test PASSES and the whole suite is green. This task changes no behaviour — if any existing test fails, the wiring is wrong.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Models/Threads/DossierSenses.swift Pilgrim/Models/Threads/ThreadsDossierBuilder.swift UnitTests/
+git commit -m "refactor(threads): widen the senses Input to carry historical contexts
+
+Invariance signals need marker and modal data from past recordings, keyed
+by recordingUUID. The builder already loads every TranscriptContext to feed
+ThreadsDossierFormatter, so this widens an existing hand-off rather than
+adding a query. No behaviour change.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: The invariance engine — cap, priority, dedup
+
+**Why:** The engine shell must exist before any signal, and it must be testable independently via a stub, exactly as `DossierSenses.lines` is.
+
+**Files:**
+- Create: `Pilgrim/Models/Threads/DossierSensesInvariance.swift`
+- Create: `UnitTests/DossierSensesInvarianceTests.swift`
+
+**Interfaces:**
+- Produces:
+  - `DossierSenses.Invariant` — `CaseIterable` enum, declaration order IS priority order
+  - `DossierSenses.invarianceLines(input:evaluate:) -> [String]`
+  - `DossierSenses.evaluateInvariant(_:input:suppressed:) -> SenseLine?`
+  - `DossierSensesInvariance.pendingFieldGate: Bool`
+  - `DossierSensesInvariance.minimumInvariantWalks: Int`
+- Consumes: `DossierSenses.SenseLine` (existing), `DossierSenses.Input` (widened in Task 1)
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `UnitTests/DossierSensesInvarianceTests.swift`:
+
+```swift
+import XCTest
+@testable import Pilgrim
+
+final class DossierSensesInvarianceTests: XCTestCase {
+
+    private func emptyInput() -> DossierSenses.Input {
+        DossierSenses.Input(
+            currentWalkUUID: UUID(),
+            walkStart: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            walkEnd: DateFactory.makeDate(2024, 6, 15, 10, 30, 0),
+            totalAscent: 0, elevationSeries: [], photos: [],
+            currentRecordings: [], historicalContexts: [], threads: [],
+            backfillComplete: true, walkSnapshots: [], recordingTimestamps: [:],
+            fixes: [:], moon: nil
+        )
+    }
+
+    private func stub(_ firing: [DossierSenses.Invariant: DossierSenses.SenseLine])
+        -> (DossierSenses.Invariant, DossierSenses.Input, Set<String>) -> DossierSenses.SenseLine? {
+        { invariant, _, _ in firing[invariant] }
+    }
+
+    func testEngine_allFiring_capsAtThreeInPriorityOrder() {
+        let lines = DossierSenses.invarianceLines(
+            input: emptyInput(),
+            evaluate: stub([
+                .fusedThemes: .init(text: "fused", lemma: "father"),
+                .unmovedReturn: .init(text: "unmoved", lemma: "work"),
+                .frameConstancy: .init(text: "frame", lemma: "money"),
+                .placeFrameLock: .init(text: "place", lemma: "river")
+            ])
+        )
+        XCTAssertEqual(lines, ["fused", "unmoved", "frame"])
+    }
+
+    func testEngine_lemmaClaimedByHigherRank_suppressesLowerRank() {
+        let lines = DossierSenses.invarianceLines(
+            input: emptyInput(),
+            evaluate: stub([
+                .fusedThemes: .init(text: "fused", lemma: "work"),
+                .unmovedReturn: .init(text: "unmoved", lemma: "work"),
+                .frameConstancy: .init(text: "frame", lemma: "money")
+            ])
+        )
+        XCTAssertEqual(lines, ["fused", "frame"])
+    }
+
+    func testEngine_nilLemmaNeverSuppresses() {
+        let lines = DossierSenses.invarianceLines(
+            input: emptyInput(),
+            evaluate: stub([
+                .fusedThemes: .init(text: "a", lemma: nil),
+                .unmovedReturn: .init(text: "b", lemma: nil)
+            ])
+        )
+        XCTAssertEqual(lines, ["a", "b"])
+    }
+
+    func testEngine_noneFiring_returnsEmpty() {
+        XCTAssertTrue(DossierSenses.invarianceLines(input: emptyInput(), evaluate: stub([:])).isEmpty)
+    }
+
+    func testInvariantOrder_isTheSpecPriorityOrder() {
+        XCTAssertEqual(
+            DossierSenses.Invariant.allCases,
+            [.fusedThemes, .unmovedReturn, .frameConstancy, .placeFrameLock, .unarrivedIntention]
+        )
+    }
+
+    func testUnarrivedIntention_isDarkByDefault() {
+        XCTAssertTrue(DossierSensesInvariance.pendingFieldGate)
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:UnitTests/DossierSensesInvarianceTests
+```
+
+Expected: COMPILE FAILURE — no `Invariant`, no `invarianceLines`, no `DossierSensesInvariance`.
+
+- [ ] **Step 3: Create the engine**
+
+Create `Pilgrim/Models/Threads/DossierSensesInvariance.swift`:
+
+```swift
+import Foundation
+import CoreLocation
+
+/// Invariance track for the dossier's `Unchanged:` block — the mirror of
+/// `Noticed:`. Where the senses report what was distinctive about THIS
+/// walk, these report what has never moved across all of them.
+///
+/// Binding purity contract, identical to `DossierSenses`: no DataManager,
+/// no CoreStore, no singleton access, and `Date()` is never called here —
+/// time arrives as data. Every line stays traceable to enumerable,
+/// deterministic inputs.
+///
+/// Why invariance at all: escaping a bad problem framing means noticing
+/// what stayed the same across your failed attempts and changing THAT
+/// (Kaplan & Simon 1990). Nobody keeps that record about themselves.
+/// Thought Threads is that record.
+enum DossierSensesInvariance {
+
+    /// Signal 5 (unarrived intention) ships dark. It is the most
+    /// confronting line the app can produce — it says, in effect, that the
+    /// walker deliberately tried and nothing moved. Engine and tests ship;
+    /// the flag flips only after the field gate judges it on real history.
+    /// Mirrors `ThreadIntentionSuggestions.pendingFieldGate`.
+    static let pendingFieldGate = true
+
+    /// Every invariant needs at least this many walks before it may speak.
+    /// Below it, a "pattern" is noise wearing a pattern's clothes.
+    static let minimumInvariantWalks = 3
+
+    /// Coefficient-of-variation ceiling for calling a marker profile flat.
+    static let markerFlatnessCeiling = 0.20
+
+    /// NLTagger sentiment spans -1...1, so a theme whose mean sits near
+    /// zero would make raw CV explode. Shift into 0...2 before dividing.
+    static let sentimentShift = 1.0
+}
+
+extension DossierSenses {
+
+    /// Declaration order IS the spec's binding priority order — reordering
+    /// cases reorders the block, exactly as with `Sense`.
+    enum Invariant: CaseIterable {
+        case fusedThemes, unmovedReturn, frameConstancy, placeFrameLock, unarrivedIntention
+    }
+
+    /// `evaluate` is a test seam, same style as `lines(input:evaluate:)`.
+    static func invarianceLines(
+        input: Input,
+        evaluate: (Invariant, Input, Set<String>) -> SenseLine? = {
+            DossierSenses.evaluateInvariant($0, input: $1, suppressed: $2)
+        }
+    ) -> [String] {
+        var used = Set<String>()
+        var lines: [String] = []
+        for invariant in Invariant.allCases {
+            guard lines.count < lineCap else { break }
+            guard let line = evaluate(invariant, input, used) else { continue }
+            if let lemma = line.lemma {
+                guard !used.contains(lemma) else { continue }
+                used.insert(lemma)
+            }
+            lines.append(line.text)
+        }
+        return lines
+    }
+
+    static func evaluateInvariant(
+        _ invariant: Invariant, input: Input, suppressed: Set<String>
+    ) -> SenseLine? {
+        switch invariant {
+        case .fusedThemes: return nil
+        case .unmovedReturn: return nil
+        case .frameConstancy: return nil
+        case .placeFrameLock: return nil
+        case .unarrivedIntention: return nil
+        }
+    }
+}
+```
+
+Each `case` returns `nil` for now; Tasks 3–7 fill them in one at a time.
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:UnitTests/DossierSensesInvarianceTests
+```
+
+Expected: all six PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Models/Threads/DossierSensesInvariance.swift UnitTests/DossierSensesInvarianceTests.swift
+git commit -m "feat(threads): the invariance engine — cap, priority, dedup
+
+The mirror of Noticed:. Where the senses report what was distinctive about
+this walk, these report what has never moved across all of them. Same
+purity contract, same three-line cap, same lemma suppression so a theme
+named at a higher rank never speaks twice.
+
+Signal 5 ships dark from the first commit — the flag exists before the
+signal does, so it can never accidentally ship live.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Signal 1 — fused themes
+
+**Why:** Two themes whose walk-sets are identical or nested are a **structural** invariant the walker cannot see, because it is a grouping they performed pre-categorically. Cheapest signal and the most arresting: *"you have not spoken about your father without also speaking about money."*
+
+**Files:**
+- Modify: `Pilgrim/Models/Threads/DossierSensesInvariance.swift`
+- Modify: `UnitTests/DossierSensesInvarianceTests.swift`
+
+**Interfaces:**
+- Produces: `DossierSensesInvariance.fusedThemes(input:suppressed:) -> DossierSenses.SenseLine?`
+- Consumes: `WalkThread.appearances` → `ThreadAppearance.walkUUID`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `UnitTests/DossierSensesInvarianceTests.swift`:
+
+```swift
+    private func thread(_ lemma: String, walks: [UUID], salience: Double = 0.5) -> WalkThread {
+        WalkThread(
+            lemma: lemma,
+            displayTerm: lemma,
+            appearances: walks.map {
+                ThreadAppearance(
+                    recordingUUID: UUID(), walkUUID: $0,
+                    date: DateFactory.makeDate(2024, 6, 1, 9, 0, 0),
+                    mentionCount: 3, salience: salience
+                )
+            }
+        )
+    }
+
+    private func inputWith(threads: [WalkThread]) -> DossierSenses.Input {
+        DossierSenses.Input(
+            currentWalkUUID: threads.first?.appearances.first?.walkUUID ?? UUID(),
+            walkStart: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            walkEnd: DateFactory.makeDate(2024, 6, 15, 10, 30, 0),
+            totalAscent: 0, elevationSeries: [], photos: [],
+            currentRecordings: [], historicalContexts: [], threads: threads,
+            backfillComplete: true, walkSnapshots: [], recordingTimestamps: [:],
+            fixes: [:], moon: nil
+        )
+    }
+
+    func testFusedThemes_identicalWalkSets_fires() {
+        let walks = [UUID(), UUID(), UUID()]
+        let input = inputWith(threads: [
+            thread("father", walks: walks),
+            thread("money", walks: walks)
+        ])
+        let line = DossierSensesInvariance.fusedThemes(input: input, suppressed: [])
+        XCTAssertNotNil(line)
+        XCTAssertTrue(line!.text.contains("father"))
+        XCTAssertTrue(line!.text.contains("money"))
+        XCTAssertTrue(line!.text.contains("3 of 3"))
+    }
+
+    func testFusedThemes_nestedWalkSet_fires() {
+        let walks = [UUID(), UUID(), UUID(), UUID()]
+        let input = inputWith(threads: [
+            thread("father", walks: Array(walks.prefix(3))),
+            thread("money", walks: walks)
+        ])
+        XCTAssertNotNil(DossierSensesInvariance.fusedThemes(input: input, suppressed: []))
+    }
+
+    func testFusedThemes_belowMinimumWalks_staysSilent() {
+        let walks = [UUID(), UUID()]
+        let input = inputWith(threads: [
+            thread("father", walks: walks),
+            thread("money", walks: walks)
+        ])
+        XCTAssertNil(DossierSensesInvariance.fusedThemes(input: input, suppressed: []))
+    }
+
+    func testFusedThemes_partialOverlap_staysSilent() {
+        let a = UUID(), b = UUID(), c = UUID(), d = UUID()
+        let input = inputWith(threads: [
+            thread("father", walks: [a, b, c]),
+            thread("money", walks: [b, c, d])
+        ])
+        XCTAssertNil(DossierSensesInvariance.fusedThemes(input: input, suppressed: []))
+    }
+
+    func testFusedThemes_suppressedLemma_staysSilent() {
+        let walks = [UUID(), UUID(), UUID()]
+        let input = inputWith(threads: [
+            thread("father", walks: walks),
+            thread("money", walks: walks)
+        ])
+        XCTAssertNil(DossierSensesInvariance.fusedThemes(input: input, suppressed: ["father"]))
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:UnitTests/DossierSensesInvarianceTests
+```
+
+Expected: COMPILE FAILURE — no `fusedThemes`.
+
+- [ ] **Step 3: Implement**
+
+Add to `DossierSensesInvariance` in `Pilgrim/Models/Threads/DossierSensesInvariance.swift`:
+
+```swift
+extension DossierSensesInvariance {
+
+    /// Two themes whose walk-sets are identical, or where one nests wholly
+    /// inside the other, across at least `minimumInvariantWalks` walks.
+    ///
+    /// This is a grouping the walker performed pre-categorically — they
+    /// gathered two things together without ever deciding to, which is
+    /// exactly the move that precedes forming a category. Partial overlap
+    /// is NOT fusion: two themes sharing some walks is ordinary, and
+    /// reporting it would be the Goodman error (everything resembles
+    /// everything if you pick the properties afterwards).
+    ///
+    /// Deterministic: threads arrive lemma-sorted from `ThreadStore.build`,
+    /// and only a STRICTLY larger shared-walk count replaces the best pair.
+    static func fusedThemes(
+        input: DossierSenses.Input, suppressed: Set<String>
+    ) -> DossierSenses.SenseLine? {
+        let candidates = input.threads
+            .filter { !suppressed.contains($0.lemma) }
+            .map { (thread: $0, walks: Set($0.appearances.map(\.walkUUID))) }
+            .filter { $0.walks.count >= minimumInvariantWalks }
+
+        guard candidates.count >= 2 else { return nil }
+
+        var best: (a: WalkThread, b: WalkThread, shared: Int, outer: Int)?
+        for i in candidates.indices {
+            for j in candidates.indices where j > i {
+                let (first, second) = (candidates[i], candidates[j])
+                let isNested = first.walks.isSubset(of: second.walks)
+                    || second.walks.isSubset(of: first.walks)
+                guard isNested else { continue }
+                let shared = first.walks.intersection(second.walks).count
+                let outer = max(first.walks.count, second.walks.count)
+                guard best == nil || shared > best!.shared else { continue }
+                best = (first.thread, second.thread, shared, outer)
+            }
+        }
+
+        guard let best else { return nil }
+        return DossierSenses.SenseLine(
+            text: "'\(best.a.displayTerm)' and '\(best.b.displayTerm)' have appeared in "
+                + "\(best.shared) of \(best.outer) walks together, never apart.",
+            lemma: best.a.lemma
+        )
+    }
+}
+```
+
+Then wire the case in `evaluateInvariant`:
+
+```swift
+        case .fusedThemes:
+            return DossierSensesInvariance.fusedThemes(input: input, suppressed: suppressed)
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:UnitTests/DossierSensesInvarianceTests
+```
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Models/Threads/DossierSensesInvariance.swift UnitTests/DossierSensesInvarianceTests.swift
+git commit -m "feat(threads): fused themes — the two that never travel apart
+
+Two themes whose walk-sets nest are a grouping the walker made without
+deciding to, which is the move that comes before forming a category at all.
+They cannot see it, because it is the shape of their looking.
+
+Partial overlap deliberately does not count. Two themes sharing some walks
+is ordinary, and calling that fusion would be picking the properties after
+the fact - which is how you end up proving a lawn mower resembles a plum.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Signal 2 — the unmoved return
+
+**Why:** A theme that recurs with steady salience *and* a flat marker profile is the invariant across the walker's returns. `ThreadStore.salienceDirection` already computes `.steady` and `ThreadsDossierFormatter` already prints it as a throwaway clause — this gives it the weight it deserves.
+
+**Files:**
+- Modify: `Pilgrim/Models/Threads/DossierSensesInvariance.swift`
+- Modify: `UnitTests/DossierSensesInvarianceTests.swift`
+
+**Interfaces:**
+- Produces: `DossierSensesInvariance.unmovedReturn(input:suppressed:) -> DossierSenses.SenseLine?`
+- Consumes: `ThreadStore.salienceDirection(of:)`, `TranscriptContext.markers`, `ThreadsDossierFormatter.densityFloorWords`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `UnitTests/DossierSensesInvarianceTests.swift`:
+
+```swift
+    private func markerContext(
+        _ uuid: UUID, absolutist: Int, firstPerson: Int, sentiment: Double, words: Int = 200
+    ) -> TranscriptContext {
+        TranscriptContext(
+            schemaVersion: TranscriptContext.currentSchemaVersion,
+            recordingUUID: uuid, transcriptHash: "h", languageCode: "en",
+            wordCount: words, themes: [],
+            markers: MarkerPack(
+                wordCount: words, absolutistCount: absolutist, firstPersonCount: firstPerson,
+                insightCount: 2, causationCount: 2, discrepancyCount: 1,
+                futureCount: 3, pastCount: 3, sentiment: sentiment, modalCounts: [:]
+            )
+        )
+    }
+
+    private func steadyThread(_ lemma: String, recordings: [UUID], walks: [UUID]) -> WalkThread {
+        WalkThread(
+            lemma: lemma, displayTerm: lemma,
+            appearances: zip(recordings, walks).map { rec, walk in
+                ThreadAppearance(
+                    recordingUUID: rec, walkUUID: walk,
+                    date: DateFactory.makeDate(2024, 6, 1, 9, 0, 0),
+                    mentionCount: 3, salience: 0.5
+                )
+            }
+        )
+    }
+
+    func testUnmovedReturn_steadySalienceFlatMarkers_fires() {
+        let recs = [UUID(), UUID(), UUID()]
+        let input = DossierSenses.Input(
+            currentWalkUUID: UUID(),
+            walkStart: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            walkEnd: DateFactory.makeDate(2024, 6, 15, 10, 30, 0),
+            totalAscent: 0, elevationSeries: [], photos: [], currentRecordings: [],
+            historicalContexts: [
+                markerContext(recs[0], absolutist: 10, firstPerson: 20, sentiment: -0.2),
+                markerContext(recs[1], absolutist: 10, firstPerson: 21, sentiment: -0.2),
+                markerContext(recs[2], absolutist: 11, firstPerson: 20, sentiment: -0.21)
+            ],
+            threads: [steadyThread("work", recordings: recs, walks: [UUID(), UUID(), UUID()])],
+            backfillComplete: true, walkSnapshots: [], recordingTimestamps: [:],
+            fixes: [:], moon: nil
+        )
+        let line = DossierSensesInvariance.unmovedReturn(input: input, suppressed: [])
+        XCTAssertNotNil(line)
+        XCTAssertTrue(line!.text.contains("work"))
+        XCTAssertTrue(line!.text.contains("3 walks"))
+    }
+
+    func testUnmovedReturn_markersVary_staysSilent() {
+        let recs = [UUID(), UUID(), UUID()]
+        let input = DossierSenses.Input(
+            currentWalkUUID: UUID(),
+            walkStart: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            walkEnd: DateFactory.makeDate(2024, 6, 15, 10, 30, 0),
+            totalAscent: 0, elevationSeries: [], photos: [], currentRecordings: [],
+            historicalContexts: [
+                markerContext(recs[0], absolutist: 2, firstPerson: 5, sentiment: -0.8),
+                markerContext(recs[1], absolutist: 20, firstPerson: 40, sentiment: 0.7),
+                markerContext(recs[2], absolutist: 11, firstPerson: 20, sentiment: 0.0)
+            ],
+            threads: [steadyThread("work", recordings: recs, walks: [UUID(), UUID(), UUID()])],
+            backfillComplete: true, walkSnapshots: [], recordingTimestamps: [:],
+            fixes: [:], moon: nil
+        )
+        XCTAssertNil(DossierSensesInvariance.unmovedReturn(input: input, suppressed: []))
+    }
+
+    func testUnmovedReturn_belowDensityFloor_staysSilent() {
+        let recs = [UUID(), UUID(), UUID()]
+        let input = DossierSenses.Input(
+            currentWalkUUID: UUID(),
+            walkStart: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            walkEnd: DateFactory.makeDate(2024, 6, 15, 10, 30, 0),
+            totalAscent: 0, elevationSeries: [], photos: [], currentRecordings: [],
+            historicalContexts: recs.map {
+                markerContext($0, absolutist: 1, firstPerson: 2, sentiment: -0.2, words: 40)
+            },
+            threads: [steadyThread("work", recordings: recs, walks: [UUID(), UUID(), UUID()])],
+            backfillComplete: true, walkSnapshots: [], recordingTimestamps: [:],
+            fixes: [:], moon: nil
+        )
+        XCTAssertNil(DossierSensesInvariance.unmovedReturn(input: input, suppressed: []))
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: COMPILE FAILURE — no `unmovedReturn`.
+
+- [ ] **Step 3: Implement**
+
+Add to `DossierSensesInvariance`:
+
+```swift
+extension DossierSensesInvariance {
+
+    /// A theme that recurs with steady salience AND a flat marker profile:
+    /// it has come back, and every time it sounds the same. That sameness
+    /// across returns is the invariant — the thing that did not budge while
+    /// the walker kept working at it.
+    ///
+    /// Appearances below `densityFloorWords` are EXCLUDED, never counted as
+    /// flat: a short recording is not evidence of sameness, it is absence
+    /// of evidence. At least `minimumInvariantWalks` must clear the floor.
+    static func unmovedReturn(
+        input: DossierSenses.Input, suppressed: Set<String>
+    ) -> DossierSenses.SenseLine? {
+        let byRecording = Dictionary(
+            input.historicalContexts.map { ($0.recordingUUID, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        for thread in input.threads.sorted(by: { $0.lemma < $1.lemma })
+        where !suppressed.contains(thread.lemma) {
+            guard ThreadStore.salienceDirection(of: thread) == .steady else { continue }
+
+            let packs = thread.appearances.compactMap { appearance -> MarkerPack? in
+                guard let markers = byRecording[appearance.recordingUUID]?.markers,
+                      markers.wordCount >= ThreadsDossierFormatter.densityFloorWords else { return nil }
+                return markers
+            }
+            guard packs.count >= minimumInvariantWalks else { continue }
+
+            let absolutist = packs.map { Double($0.absolutistCount) / Double($0.wordCount) }
+            let firstPerson = packs.map { Double($0.firstPersonCount) / Double($0.wordCount) }
+            let sentiment = packs.compactMap { $0.sentiment }.map { $0 + sentimentShift }
+            guard sentiment.count == packs.count else { continue }
+
+            guard isFlat(absolutist), isFlat(firstPerson), isFlat(sentiment) else { continue }
+
+            let walks = Set(thread.appearances.map(\.walkUUID)).count
+            return DossierSenses.SenseLine(
+                text: "'\(thread.displayTerm)' has returned across \(walks) walks; "
+                    + "it sounds the same each time.",
+                lemma: thread.lemma
+            )
+        }
+        return nil
+    }
+
+    /// Coefficient of variation at or under the flatness ceiling. A zero or
+    /// negative mean cannot be judged this way, so it is treated as not
+    /// flat rather than dividing by it.
+    static func isFlat(_ values: [Double]) -> Bool {
+        guard values.count >= 2 else { return false }
+        let mean = values.reduce(0, +) / Double(values.count)
+        guard mean > 0 else { return false }
+        let variance = values.reduce(0) { $0 + ($1 - mean) * ($1 - mean) } / Double(values.count)
+        return (variance.squareRoot() / mean) <= markerFlatnessCeiling
+    }
+}
+```
+
+Wire the case:
+
+```swift
+        case .unmovedReturn:
+            return DossierSensesInvariance.unmovedReturn(input: input, suppressed: suppressed)
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Models/Threads/DossierSensesInvariance.swift UnitTests/DossierSensesInvarianceTests.swift
+git commit -m "feat(threads): the unmoved return — it came back sounding the same
+
+salienceDirection has been computing .steady since Threads shipped and the
+dossier printed it as a trailing clause nobody could use. Steady salience
+plus a flat marker profile is not a footnote: it is the thing that did not
+budge while the walker kept working at it.
+
+Recordings under the density floor are excluded rather than counted flat.
+A short recording is absence of evidence, not evidence of sameness.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 5: Signal 3 — frame constancy
+
+**Why:** If every walk where a theme appears is dominated by the same modal family, the walker has been thinking about it inside one fixed frame. Obligation means the frame constrained them; counterfactual means they were already replaying alternatives.
+
+**Files:**
+- Modify: `Pilgrim/Models/Threads/DossierSensesInvariance.swift`
+- Modify: `UnitTests/DossierSensesInvarianceTests.swift`
+
+**Interfaces:**
+- Produces: `DossierSensesInvariance.frameConstancy(input:suppressed:) -> DossierSenses.SenseLine?`
+- Consumes: `MarkerPack.modalCounts`, `MarkerLexicons.modalFamily(of:)`, `MarkerLexicons.ModalFamily`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+    private func modalContext(_ uuid: UUID, modals: [String: Int], words: Int = 200) -> TranscriptContext {
+        TranscriptContext(
+            schemaVersion: TranscriptContext.currentSchemaVersion,
+            recordingUUID: uuid, transcriptHash: "h", languageCode: "en",
+            wordCount: words, themes: [],
+            markers: MarkerPack(
+                wordCount: words, absolutistCount: 5, firstPersonCount: 10,
+                insightCount: 2, causationCount: 2, discrepancyCount: 1,
+                futureCount: 3, pastCount: 3, sentiment: -0.1, modalCounts: modals
+            )
+        )
+    }
+
+    private func modalInput(_ contexts: [TranscriptContext], _ thread: WalkThread) -> DossierSenses.Input {
+        DossierSenses.Input(
+            currentWalkUUID: UUID(),
+            walkStart: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            walkEnd: DateFactory.makeDate(2024, 6, 15, 10, 30, 0),
+            totalAscent: 0, elevationSeries: [], photos: [], currentRecordings: [],
+            historicalContexts: contexts, threads: [thread],
+            backfillComplete: true, walkSnapshots: [], recordingTimestamps: [:],
+            fixes: [:], moon: nil
+        )
+    }
+
+    func testFrameConstancy_sameFamilyEveryWalk_fires() {
+        let recs = [UUID(), UUID(), UUID()]
+        let input = modalInput(
+            [
+                modalContext(recs[0], modals: ["should": 12, "can": 2]),
+                modalContext(recs[1], modals: ["should": 9, "might": 1]),
+                modalContext(recs[2], modals: ["must": 7, "could": 2])
+            ],
+            steadyThread("money", recordings: recs, walks: [UUID(), UUID(), UUID()])
+        )
+        let line = DossierSensesInvariance.frameConstancy(input: input, suppressed: [])
+        XCTAssertNotNil(line)
+        XCTAssertTrue(line!.text.contains("money"))
+        XCTAssertTrue(line!.text.contains("obligation"))
+    }
+
+    func testFrameConstancy_familyVaries_staysSilent() {
+        let recs = [UUID(), UUID(), UUID()]
+        let input = modalInput(
+            [
+                modalContext(recs[0], modals: ["should": 12]),
+                modalContext(recs[1], modals: ["could": 11]),
+                modalContext(recs[2], modals: ["would": 9])
+            ],
+            steadyThread("money", recordings: recs, walks: [UUID(), UUID(), UUID()])
+        )
+        XCTAssertNil(DossierSensesInvariance.frameConstancy(input: input, suppressed: []))
+    }
+
+    func testFrameConstancy_noModalsAtAll_staysSilent() {
+        let recs = [UUID(), UUID(), UUID()]
+        let input = modalInput(
+            recs.map { modalContext($0, modals: [:]) },
+            steadyThread("money", recordings: recs, walks: [UUID(), UUID(), UUID()])
+        )
+        XCTAssertNil(DossierSensesInvariance.frameConstancy(input: input, suppressed: []))
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: COMPILE FAILURE — no `frameConstancy`.
+
+- [ ] **Step 3: Implement**
+
+```swift
+extension DossierSensesInvariance {
+
+    /// One modal family dominant in EVERY walk where the theme appears.
+    /// Modals name the shape of the frame the walker was thinking inside —
+    /// obligation constrains, counterfactual replays alternatives,
+    /// possibility and tentative stay open. The same family every time is
+    /// a frame that never varied.
+    ///
+    /// Per-appearance dominance is a MODE, not a majority — the same fix
+    /// PR #71 applied to weatherWeave to kill the cloud tautologies. A
+    /// family can dominate with 40% of the modals as long as nothing beats
+    /// it. Deterministic ties: `ModalFamily.allCases` is declaration-ordered
+    /// and only a STRICTLY greater count replaces the running best.
+    static func frameConstancy(
+        input: DossierSenses.Input, suppressed: Set<String>
+    ) -> DossierSenses.SenseLine? {
+        let byRecording = Dictionary(
+            input.historicalContexts.map { ($0.recordingUUID, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+
+        for thread in input.threads.sorted(by: { $0.lemma < $1.lemma })
+        where !suppressed.contains(thread.lemma) {
+            let families = thread.appearances.compactMap { appearance -> MarkerLexicons.ModalFamily? in
+                guard let modals = byRecording[appearance.recordingUUID]?.markers?.modalCounts,
+                      !modals.isEmpty else { return nil }
+                var totals: [MarkerLexicons.ModalFamily: Int] = [:]
+                for (word, count) in modals {
+                    guard let family = MarkerLexicons.modalFamily(of: word) else { continue }
+                    totals[family, default: 0] += count
+                }
+                var best: (family: MarkerLexicons.ModalFamily, count: Int)?
+                for family in MarkerLexicons.ModalFamily.allCases {
+                    let count = totals[family] ?? 0
+                    guard count > 0, best == nil || count > best!.count else { continue }
+                    best = (family, count)
+                }
+                return best?.family
+            }
+
+            guard families.count >= minimumInvariantWalks,
+                  let first = families.first,
+                  families.allSatisfy({ $0 == first }) else { continue }
+
+            return DossierSenses.SenseLine(
+                text: "Every walk where '\(thread.displayTerm)' appears is "
+                    + "\(first.rawValue)-dominant.",
+                lemma: thread.lemma
+            )
+        }
+        return nil
+    }
+}
+```
+
+Wire the case:
+
+```swift
+        case .frameConstancy:
+            return DossierSensesInvariance.frameConstancy(input: input, suppressed: suppressed)
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Models/Threads/DossierSensesInvariance.swift UnitTests/DossierSensesInvarianceTests.swift
+git commit -m "feat(threads): frame constancy — it always arrives the same way
+
+Modal families name the shape of the frame the walker was thinking inside.
+Obligation constrains, counterfactual replays alternatives, possibility
+stays open. The same family in every single walk where a theme appears is a
+frame that never once varied.
+
+Dominance is a mode, not a majority - the fix PR #71 made to weatherWeave
+after majority-voting produced cloud tautologies.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 6: Signal 4 — place-frame lock
+
+**Why:** The same theme spoken within the same 150m cluster every time is an invariant tied to ground, not language. `placeResonance` already proves the clustering machinery works over `fixes`.
+
+**Files:**
+- Modify: `Pilgrim/Models/Threads/DossierSensesInvariance.swift`
+- Modify: `UnitTests/DossierSensesInvarianceTests.swift`
+
+**Interfaces:**
+- Produces: `DossierSensesInvariance.placeFrameLock(input:suppressed:) -> DossierSenses.SenseLine?`
+- Consumes: `DossierSenses.Input.fixes`, `DossierSenses.qualifies(_:)`, `DossierSenses.distance(_:_:)`, `DossierSenses.placeClusterRadius`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+    func testPlaceFrameLock_sameCluster_fires() {
+        let recs = [UUID(), UUID(), UUID()]
+        var fixes: [UUID: DossierSenses.RouteFix] = [:]
+        for (offset, rec) in recs.enumerated() {
+            fixes[rec] = DossierSenses.RouteFix(
+                coordinate: .init(latitude: 51.5 + Double(offset) * 0.0001, longitude: -0.12),
+                horizontalAccuracy: 10, gapSeconds: 5
+            )
+        }
+        var input = modalInput([], steadyThread("river", recordings: recs, walks: [UUID(), UUID(), UUID()]))
+        input = DossierSenses.Input(
+            currentWalkUUID: input.currentWalkUUID, walkStart: input.walkStart, walkEnd: input.walkEnd,
+            totalAscent: 0, elevationSeries: [], photos: [], currentRecordings: [],
+            historicalContexts: [], threads: input.threads, backfillComplete: true,
+            walkSnapshots: [], recordingTimestamps: [:], fixes: fixes, moon: nil
+        )
+        let line = DossierSensesInvariance.placeFrameLock(input: input, suppressed: [])
+        XCTAssertNotNil(line)
+        XCTAssertTrue(line!.text.contains("river"))
+    }
+
+    func testPlaceFrameLock_scatteredFixes_staysSilent() {
+        let recs = [UUID(), UUID(), UUID()]
+        var fixes: [UUID: DossierSenses.RouteFix] = [:]
+        for (offset, rec) in recs.enumerated() {
+            fixes[rec] = DossierSenses.RouteFix(
+                coordinate: .init(latitude: 51.5 + Double(offset) * 0.5, longitude: -0.12),
+                horizontalAccuracy: 10, gapSeconds: 5
+            )
+        }
+        let thread = steadyThread("river", recordings: recs, walks: [UUID(), UUID(), UUID()])
+        let input = DossierSenses.Input(
+            currentWalkUUID: UUID(),
+            walkStart: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            walkEnd: DateFactory.makeDate(2024, 6, 15, 10, 30, 0),
+            totalAscent: 0, elevationSeries: [], photos: [], currentRecordings: [],
+            historicalContexts: [], threads: [thread], backfillComplete: true,
+            walkSnapshots: [], recordingTimestamps: [:], fixes: fixes, moon: nil
+        )
+        XCTAssertNil(DossierSensesInvariance.placeFrameLock(input: input, suppressed: []))
+    }
+
+    func testPlaceFrameLock_poorAccuracyFixesExcluded_staysSilent() {
+        let recs = [UUID(), UUID(), UUID()]
+        var fixes: [UUID: DossierSenses.RouteFix] = [:]
+        for rec in recs {
+            fixes[rec] = DossierSenses.RouteFix(
+                coordinate: .init(latitude: 51.5, longitude: -0.12),
+                horizontalAccuracy: 500, gapSeconds: 5
+            )
+        }
+        let thread = steadyThread("river", recordings: recs, walks: [UUID(), UUID(), UUID()])
+        let input = DossierSenses.Input(
+            currentWalkUUID: UUID(),
+            walkStart: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            walkEnd: DateFactory.makeDate(2024, 6, 15, 10, 30, 0),
+            totalAscent: 0, elevationSeries: [], photos: [], currentRecordings: [],
+            historicalContexts: [], threads: [thread], backfillComplete: true,
+            walkSnapshots: [], recordingTimestamps: [:], fixes: fixes, moon: nil
+        )
+        XCTAssertNil(DossierSensesInvariance.placeFrameLock(input: input, suppressed: []))
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: COMPILE FAILURE — no `placeFrameLock`.
+
+- [ ] **Step 3: Implement**
+
+```swift
+extension DossierSensesInvariance {
+
+    /// The same theme spoken inside the same `placeClusterRadius` cluster
+    /// every time. An invariant tied to ground rather than to language.
+    ///
+    /// Reuses `DossierSenses.qualifies` so poor-accuracy and long-gap fixes
+    /// are excluded on the same terms as `placeResonance` — a 500m-accuracy
+    /// fix would make any two points look like the same place.
+    static func placeFrameLock(
+        input: DossierSenses.Input, suppressed: Set<String>
+    ) -> DossierSenses.SenseLine? {
+        for thread in input.threads.sorted(by: { $0.lemma < $1.lemma })
+        where !suppressed.contains(thread.lemma) {
+            let coordinates = thread.appearances.compactMap { appearance -> DossierSenses.Coordinate? in
+                guard let fix = input.fixes[appearance.recordingUUID],
+                      DossierSenses.qualifies(fix) else { return nil }
+                return fix.coordinate
+            }
+            guard coordinates.count >= minimumInvariantWalks else { continue }
+
+            guard let anchor = coordinates.first else { continue }
+            let clustered = coordinates.allSatisfy {
+                DossierSenses.distance(anchor, $0) <= DossierSenses.placeClusterRadius
+            }
+            guard clustered else { continue }
+
+            let walks = Set(thread.appearances.map(\.walkUUID)).count
+            return DossierSenses.SenseLine(
+                text: "'\(thread.displayTerm)' has been spoken in the same place "
+                    + "on all \(walks) walks it appears in.",
+                lemma: thread.lemma
+            )
+        }
+        return nil
+    }
+}
+```
+
+Wire the case:
+
+```swift
+        case .placeFrameLock:
+            return DossierSensesInvariance.placeFrameLock(input: input, suppressed: suppressed)
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Expected: all PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Models/Threads/DossierSensesInvariance.swift UnitTests/DossierSensesInvarianceTests.swift
+git commit -m "feat(threads): place-frame lock — the same thought at the same bend
+
+An invariant tied to ground rather than language: the walker says this in
+this place, every time, and has never noticed. Reuses the placeResonance
+hygiene gate so a 500m-accuracy fix cannot make two points look like one.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 7: Signal 5 — unarrived intention, shipped dark
+
+**Why:** The walker deliberately set out carrying a word, repeatedly, and the language never moved. This is Vervaeke's *"keep good track of your failures"* made literal — and the most confronting line the app could produce, which is why it ships behind a flag.
+
+**Files:**
+- Modify: `Pilgrim/Models/Threads/DossierSensesInvariance.swift`
+- Modify: `UnitTests/DossierSensesInvarianceTests.swift`
+
+**Interfaces:**
+- Produces: `DossierSensesInvariance.unarrivedIntention(input:suppressed:) -> DossierSenses.SenseLine?`
+- Consumes: `DossierSenses.WalkSnapshotRow.intention`, `TranscriptNLP.contentLemmas(in:)`, `ThreadStore.salienceDirection(of:)`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+    func testUnarrivedIntention_engineFires_whenCalledDirectly() {
+        let walks = [UUID(), UUID(), UUID()]
+        let recs = [UUID(), UUID(), UUID()]
+        let snapshots = walks.map {
+            DossierSenses.WalkSnapshotRow(
+                walkUUID: $0, startDate: DateFactory.makeDate(2024, 6, 1, 9, 0, 0),
+                intention: "walk with patience", weatherCondition: nil
+            )
+        }
+        let thread = WalkThread(
+            lemma: "patience", displayTerm: "patience",
+            appearances: zip(recs, walks).map { rec, walk in
+                ThreadAppearance(
+                    recordingUUID: rec, walkUUID: walk,
+                    date: DateFactory.makeDate(2024, 6, 1, 9, 0, 0),
+                    mentionCount: 3, salience: 0.5
+                )
+            }
+        )
+        let input = DossierSenses.Input(
+            currentWalkUUID: walks[0],
+            walkStart: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            walkEnd: DateFactory.makeDate(2024, 6, 15, 10, 30, 0),
+            totalAscent: 0, elevationSeries: [], photos: [], currentRecordings: [],
+            historicalContexts: [], threads: [thread], backfillComplete: true,
+            walkSnapshots: snapshots, recordingTimestamps: [:], fixes: [:], moon: nil
+        )
+        let line = DossierSensesInvariance.unarrivedIntention(input: input, suppressed: [])
+        XCTAssertNotNil(line)
+        XCTAssertTrue(line!.text.contains("patience"))
+    }
+
+    func testUnarrivedIntention_isSuppressedFromEngineOutputByTheFlag() {
+        let walks = [UUID(), UUID(), UUID()]
+        let recs = [UUID(), UUID(), UUID()]
+        let snapshots = walks.map {
+            DossierSenses.WalkSnapshotRow(
+                walkUUID: $0, startDate: DateFactory.makeDate(2024, 6, 1, 9, 0, 0),
+                intention: "walk with patience", weatherCondition: nil
+            )
+        }
+        let thread = WalkThread(
+            lemma: "patience", displayTerm: "patience",
+            appearances: zip(recs, walks).map { rec, walk in
+                ThreadAppearance(
+                    recordingUUID: rec, walkUUID: walk,
+                    date: DateFactory.makeDate(2024, 6, 1, 9, 0, 0),
+                    mentionCount: 3, salience: 0.5
+                )
+            }
+        )
+        let input = DossierSenses.Input(
+            currentWalkUUID: walks[0],
+            walkStart: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            walkEnd: DateFactory.makeDate(2024, 6, 15, 10, 30, 0),
+            totalAscent: 0, elevationSeries: [], photos: [], currentRecordings: [],
+            historicalContexts: [], threads: [thread], backfillComplete: true,
+            walkSnapshots: snapshots, recordingTimestamps: [:], fixes: [:], moon: nil
+        )
+        XCTAssertNil(DossierSenses.evaluateInvariant(.unarrivedIntention, input: input, suppressed: []))
+        XCTAssertTrue(DossierSenses.invarianceLines(input: input).isEmpty)
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: COMPILE FAILURE — no `unarrivedIntention`.
+
+- [ ] **Step 3: Implement**
+
+```swift
+extension DossierSensesInvariance {
+
+    /// The walker deliberately set out carrying a word, on at least
+    /// `minimumInvariantWalks` walks, and that word's thread is STILL
+    /// steady. They tried, on purpose, and nothing moved.
+    ///
+    /// SHIPS DARK behind `pendingFieldGate`. This is the most confronting
+    /// line the app can produce; the engine and its tests exist so the
+    /// judgement can be made on real history, not on a guess.
+    static func unarrivedIntention(
+        input: DossierSenses.Input, suppressed: Set<String>
+    ) -> DossierSenses.SenseLine? {
+        var intentionWalks: [String: Set<UUID>] = [:]
+        for snapshot in input.walkSnapshots {
+            guard let intention = snapshot.intention, !intention.isEmpty else { continue }
+            for lemma in TranscriptNLP.contentLemmas(in: intention) {
+                intentionWalks[lemma, default: []].insert(snapshot.walkUUID)
+            }
+        }
+
+        for thread in input.threads.sorted(by: { $0.lemma < $1.lemma })
+        where !suppressed.contains(thread.lemma) {
+            guard let walks = intentionWalks[thread.lemma],
+                  walks.count >= minimumInvariantWalks,
+                  ThreadStore.salienceDirection(of: thread) == .steady else { continue }
+            return DossierSenses.SenseLine(
+                text: "'\(thread.displayTerm)' was set as an intention on \(walks.count) walks; "
+                    + "it has not shifted since.",
+                lemma: thread.lemma
+            )
+        }
+        return nil
+    }
+}
+```
+
+Wire the case **with the flag guard**:
+
+```swift
+        case .unarrivedIntention:
+            guard !DossierSensesInvariance.pendingFieldGate else { return nil }
+            return DossierSensesInvariance.unarrivedIntention(input: input, suppressed: suppressed)
+```
+
+- [ ] **Step 4: Run to verify it passes**
+
+Expected: both PASS — the engine computes it, the flag withholds it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Models/Threads/DossierSensesInvariance.swift UnitTests/DossierSensesInvarianceTests.swift
+git commit -m "feat(threads): the unarrived intention, shipped dark
+
+The walker set out carrying a word, on purpose, three times or more, and
+the language never moved. Keeping good track of your failures, made
+literal - and the hardest thing the app could say to someone on a bad day.
+
+Engine and tests ship so the call can be made on real history rather than
+on a guess. The flag stays true until the field gate says otherwise.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 8: Build the `Unchanged:` block and carry it on `ActivityContext`
+
+**Why:** The engine produces lines; something must render them into a block, build it **once**, and hand it to the assembler.
+
+**Files:**
+- Modify: `Pilgrim/Models/Prompt/ActivityContext.swift` (add `var unchangedBlock: String?` and the `make` parameter)
+- Modify: `Pilgrim/Models/Threads/ThreadsDossierBuilder.swift` (build and assign)
+- Modify: `UnitTests/ThreadsDossierSensesTests.swift`
+
+**Interfaces:**
+- Produces: `ActivityContext.unchangedBlock: String?` — the fully rendered block including its `**Unchanged:**` heading, or `nil` when no invariant fired.
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `UnitTests/ThreadsDossierSensesTests.swift`:
+
+```swift
+func testUnchangedBlock_rendersHeadingAndLines() {
+    let block = ThreadsDossierBuilder.renderUnchangedBlock(
+        ["'father' and 'money' have appeared in 3 of 3 walks together, never apart.",
+         "'work' has returned across 4 walks; it sounds the same each time."]
+    )
+    XCTAssertEqual(
+        block,
+        """
+        **Unchanged:**
+        'father' and 'money' have appeared in 3 of 3 walks together, never apart.
+        'work' has returned across 4 walks; it sounds the same each time.
+        """
+    )
+}
+
+func testUnchangedBlock_emptyLines_isNil() {
+    XCTAssertNil(ThreadsDossierBuilder.renderUnchangedBlock([]))
+}
+
+func testActivityContext_carriesUnchangedBlock() {
+    let context = ActivityContext.make(
+        startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+        unchangedBlock: "**Unchanged:**\nline"
+    )
+    XCTAssertEqual(context.unchangedBlock, "**Unchanged:**\nline")
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: COMPILE FAILURE — no `renderUnchangedBlock`, no `unchangedBlock`.
+
+- [ ] **Step 3: Implement**
+
+In `Pilgrim/Models/Prompt/ActivityContext.swift`, add after `var threadsDossier: String?`:
+
+```swift
+    /// The `Unchanged:` block, built once alongside the dossier and emitted
+    /// only for voices whose context policy requests it. Built once because
+    /// `PromptGenerator.generateAll` fans ONE context across every style —
+    /// building per voice would undo PR #65's single-pass work.
+    var unchangedBlock: String?
+```
+
+Add `unchangedBlock: String? = nil` to the `make` parameter list (after `threadsDossier`) and `unchangedBlock: unchangedBlock` to the `ActivityContext(...)` body.
+
+In `ThreadsDossierBuilder`, add:
+
+```swift
+    /// Renders invariance lines into the block the assembler emits. Nil for
+    /// an empty list, so `unchangedBlock` is absent rather than an empty
+    /// heading — the same shape `ThreadsDossierFormatter.dossier` uses.
+    static func renderUnchangedBlock(_ lines: [String]) -> String? {
+        guard !lines.isEmpty else { return nil }
+        return "**Unchanged:**\n" + lines.joined(separator: "\n")
+    }
+```
+
+Then, at the same point the builder appends the `Noticed:` block (around line 253), also compute and assign the invariance block:
+
+```swift
+        let invariance = DossierSenses.invarianceLines(input: input)
+        unchangedBlock = ThreadsDossierBuilder.renderUnchangedBlock(invariance)
+```
+
+Assign it onto the `ActivityContext` at the same site the builder already assigns `threadsDossier`.
+
+- [ ] **Step 4: Run to verify it passes**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+```
+
+Expected: all PASS, full suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Pilgrim/Models/Prompt/ActivityContext.swift Pilgrim/Models/Threads/ThreadsDossierBuilder.swift UnitTests/
+git commit -m "feat(threads): build the Unchanged block once, carry it on the context
+
+generateAll fans one ActivityContext across every style, so the block is
+built alongside the dossier and merely emitted per voice later. Building it
+per voice would quietly undo the single-pass work from PR #65.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 9: The context policy, and the marker-in-a-journal-entry defect
+
+**Why:** `JournalingVoice` currently receives absolutist percentages and sentiment scores, and they land in an entry the walker rereads years later. `CreativeVoice` is asked for a poem while holding a sentiment score. This is live, and fixing it needs the same mechanism Oblique needs for hoisting.
+
+**Files:**
+- Create: `Pilgrim/Models/Prompt/PromptContextPolicy.swift`
+- Modify: `Pilgrim/Models/Prompt/PromptVoice.swift`
+- Modify: `Pilgrim/Models/Prompt/WalkPromptVoices.swift`
+- Modify: `Pilgrim/Models/Prompt/PromptAssembler.swift`
+- Modify: `Pilgrim/Models/Threads/ThreadsDossierFormatter.swift`
+- Create: `UnitTests/PromptContextPolicyTests.swift`
+
+**Interfaces:**
+- Produces:
+  - `struct PromptContextPolicy { let includesMarkerLines: Bool; let includesThreadAnalysis: Bool; let hoistsUnchangedBlock: Bool; static let full: PromptContextPolicy }`
+  - `PromptVoice.contextPolicy: PromptContextPolicy` with a `.full` default in the protocol extension
+  - `ThreadsDossierFormatter.dossier(..., includeMarkerLines: Bool, includeThreadAnalysis: Bool)`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `UnitTests/PromptContextPolicyTests.swift`:
+
+```swift
+import XCTest
+@testable import Pilgrim
+
+final class PromptContextPolicyTests: XCTestCase {
+
+    func testDefaultPolicy_isFull() {
+        XCTAssertTrue(ReflectiveVoice().contextPolicy.includesMarkerLines)
+        XCTAssertTrue(ContemplativeVoice().contextPolicy.includesMarkerLines)
+        XCTAssertTrue(PhilosophicalVoice().contextPolicy.includesMarkerLines)
+    }
+
+    func testJournalingVoice_excludesMarkerLines() {
+        XCTAssertFalse(JournalingVoice().contextPolicy.includesMarkerLines)
+    }
+
+    func testCreativeVoice_excludesMarkersAndThreadAnalysis() {
+        XCTAssertFalse(CreativeVoice().contextPolicy.includesMarkerLines)
+        XCTAssertFalse(CreativeVoice().contextPolicy.includesThreadAnalysis)
+    }
+
+    func testGratitudeVoice_excludesMarkersAndThreadAnalysis() {
+        XCTAssertFalse(GratitudeVoice().contextPolicy.includesMarkerLines)
+        XCTAssertFalse(GratitudeVoice().contextPolicy.includesThreadAnalysis)
+    }
+
+    func testCustomStyle_getsFullPolicyViaProtocolDefault() {
+        let custom = CustomPromptStyle(
+            id: UUID(), name: "Test", promptText: "Reflect on this walk."
+        )
+        XCTAssertTrue(custom.contextPolicy.includesMarkerLines)
+    }
+}
+```
+
+> If `CustomPromptStyle`'s initialiser differs, construct it however `CustomPromptStyleStoreTests` does — the assertion is what matters, not the fixture shape.
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: COMPILE FAILURE — no `contextPolicy`.
+
+- [ ] **Step 3: Implement**
+
+Create `Pilgrim/Models/Prompt/PromptContextPolicy.swift`:
+
+```swift
+import Foundation
+
+/// Which already-computed context blocks a voice receives. A FILTER at
+/// assembly time, never a per-voice build — `PromptGenerator.generateAll`
+/// fans one `ActivityContext` across every style, and computing per voice
+/// would undo PR #65's single-pass work.
+///
+/// Each voice is a frame, and the right frame is the one that makes the
+/// search space small enough to work in. A poem prompt holding a sentiment
+/// score is a covering-problem framing of a parity problem.
+struct PromptContextPolicy {
+    let includesMarkerLines: Bool
+    let includesThreadAnalysis: Bool
+    let hoistsUnchangedBlock: Bool
+
+    static let full = PromptContextPolicy(
+        includesMarkerLines: true,
+        includesThreadAnalysis: true,
+        hoistsUnchangedBlock: false
+    )
+}
+```
+
+In `Pilgrim/Models/Prompt/PromptVoice.swift`, add the protocol member and its default:
+
+```swift
+protocol PromptVoice {
+    func preamble(hasSpeech: Bool) -> String
+    func instruction(hasSpeech: Bool) -> String
+    func responseConstraints(hasSpeech: Bool) -> [String]
+    /// Which context blocks this voice receives. Defaults to `.full`, so
+    /// `CustomPromptStyle` and any future voice are unaffected until they
+    /// opt out deliberately.
+    var contextPolicy: PromptContextPolicy { get }
+}
+
+extension PromptVoice {
+    func responseConstraints(hasSpeech: Bool) -> [String] { [] }
+    var contextPolicy: PromptContextPolicy { .full }
+}
+```
+
+In `WalkPromptVoices.swift`, add to the three voices that opt out:
+
+```swift
+// inside CreativeVoice
+    var contextPolicy: PromptContextPolicy {
+        PromptContextPolicy(
+            includesMarkerLines: false, includesThreadAnalysis: false, hoistsUnchangedBlock: false
+        )
+    }
+
+// inside GratitudeVoice — identical body
+    var contextPolicy: PromptContextPolicy {
+        PromptContextPolicy(
+            includesMarkerLines: false, includesThreadAnalysis: false, hoistsUnchangedBlock: false
+        )
+    }
+
+// inside JournalingVoice — markers out, thread analysis kept
+    var contextPolicy: PromptContextPolicy {
+        PromptContextPolicy(
+            includesMarkerLines: false, includesThreadAnalysis: true, hoistsUnchangedBlock: false
+        )
+    }
+```
+
+In `ThreadsDossierFormatter.dossier`, add two parameters defaulting to `true` so existing callers are unchanged, and guard the two sections:
+
+```swift
+    static func dossier(
+        currentRecordings: [(context: TranscriptContext, wordsPerMinute: Double?)],
+        allContexts: [TranscriptContext],
+        threads: [WalkThread],
+        currentWalkUUID: UUID,
+        backfillComplete: Bool,
+        walkIndex: [UUID: UUID] = [:],
+        includeMarkerLines: Bool = true,
+        includeThreadAnalysis: Bool = true
+    ) -> String? {
+```
+
+Wrap the per-recording marker loop and the modal-lean append in `if includeMarkerLines { ... }`, and the `activeThreads` / `Quiet this walk` sections in `if includeThreadAnalysis { ... }`. If both are false and nothing was appended beyond the heading, return `nil` rather than a bare heading.
+
+In `PromptAssembler.assemble`, apply the policy. Where `contextDossier` currently appends unconditionally, and where `walkRecord` appends `context.threadsDossier`, consult `voice.contextPolicy`. Add the hoist immediately after the `**Context:**` line:
+
+```swift
+        if voice.contextPolicy.hoistsUnchangedBlock, let unchanged = context.unchangedBlock {
+            sections += "\n\n\(unchanged)"
+        }
+```
+
+`threadsDossier` arrives **pre-rendered**, so the assembler cannot strip marker lines from it after the fact without string surgery. Two options were considered:
+
+- Carry the raw inputs on `ActivityContext` and re-render per voice — **rejected**: it leaks `TranscriptContext` and `WalkThread` into the prompt layer, and re-rendering per voice reintroduces per-voice work.
+- Render both variants once in the builder and carry both strings — **chosen**: one extra format pass over data already in hand, still one build for all seven styles.
+
+In `ActivityContext.swift`, add alongside `threadsDossier`:
+
+```swift
+    /// Second pre-rendered variant, built in the same pass. Voices whose
+    /// policy excludes marker lines read this one. Both are built once —
+    /// `generateAll` fans one context across every style.
+    var threadsDossierWithoutMarkers: String?
+```
+
+Add `threadsDossierWithoutMarkers: String? = nil` to the `make` parameter list and `threadsDossierWithoutMarkers: threadsDossierWithoutMarkers` to the `ActivityContext(...)` body, exactly as Task 8 did for `unchangedBlock`.
+
+In `ThreadsDossierBuilder`, at the site that already assigns `threadsDossier`, call `ThreadsDossierFormatter.dossier` a second time with `includeMarkerLines: false` and assign the result to `threadsDossierWithoutMarkers`.
+
+The assembler then selects:
+
+```swift
+        let dossier = voice.contextPolicy.includesMarkerLines
+            ? context.threadsDossier
+            : context.threadsDossierWithoutMarkers
+        if let dossier {
+            sections += "\n\n\(dossier)"
+        }
+```
+
+- [ ] **Step 4: Write the assembler integration tests**
+
+Add to `UnitTests/PromptContextPolicyTests.swift`:
+
+```swift
+    private func contextWithDossiers() -> ActivityContext {
+        .make(
+            recordings: [RecordingContext(
+                text: "the river was loud today", timestamp: DateFactory.makeDate(2024, 6, 15, 9, 5, 0),
+                startCoordinate: nil, endCoordinate: nil, wordsPerMinute: 100,
+                recordingUUID: UUID(), endTimestamp: nil
+            )],
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            threadsDossier: "**Thought threads:**\nRecording 1: absolutist words 2.3%",
+            threadsDossierWithoutMarkers: "**Thought threads:**\n'river' — 3 walks",
+            unchangedBlock: "**Unchanged:**\n'river' has returned across 4 walks."
+        )
+    }
+
+    func testAssembler_journaling_omitsMarkerPercentages() {
+        let prompt = PromptAssembler.assemble(context: contextWithDossiers(), voice: JournalingVoice())
+        XCTAssertFalse(prompt.contains("absolutist words 2.3%"))
+    }
+
+    func testAssembler_reflective_keepsMarkerPercentages() {
+        let prompt = PromptAssembler.assemble(context: contextWithDossiers(), voice: ReflectiveVoice())
+        XCTAssertTrue(prompt.contains("absolutist words 2.3%"))
+    }
+
+    func testAssembler_nonObliqueVoices_neverSeeUnchangedBlock() {
+        for voice: PromptVoice in [
+            ContemplativeVoice(), ReflectiveVoice(), CreativeVoice(),
+            GratitudeVoice(), PhilosophicalVoice(), JournalingVoice()
+        ] {
+            let prompt = PromptAssembler.assemble(context: contextWithDossiers(), voice: voice)
+            XCTAssertFalse(prompt.contains("**Unchanged:**"))
+        }
+    }
+```
+
+- [ ] **Step 5: Run to verify everything passes**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+```
+
+Expected: all PASS, full suite green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Pilgrim/Models/Prompt/ Pilgrim/Models/Threads/ThreadsDossierFormatter.swift Pilgrim/Models/Threads/ThreadsDossierBuilder.swift UnitTests/PromptContextPolicyTests.swift
+git commit -m "fix(prompts): stop putting absolutist percentages in journal entries
+
+Journaling has been receiving marker profiles and sentiment scores and
+folding them into an entry the walker rereads years later. Creative was
+asked for a poem while holding a sentiment score. Live defect, shipping
+today.
+
+Each voice is a frame, and the right frame is the one that makes the space
+small enough to work in. The policy is a filter at assembly time over a
+context still built once - never a per-voice build, which would undo PR #65.
+Custom styles keep the full dossier through the protocol default.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 10: The Oblique voice
+
+**Why:** Everything above produces the block. This is the voice that reads it.
+
+**Files:**
+- Modify: `Pilgrim/Models/Prompt/PromptStyle.swift`
+- Modify: `Pilgrim/Models/Prompt/WalkPromptVoices.swift`
+- Create: `UnitTests/ObliqueVoiceTests.swift`
+
+**Interfaces:**
+- Produces: `PromptStyle.oblique`, `struct ObliqueVoice: PromptVoice`
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `UnitTests/ObliqueVoiceTests.swift`:
+
+```swift
+import XCTest
+@testable import Pilgrim
+
+final class ObliqueVoiceTests: XCTestCase {
+
+    func testStyle_existsWithTitleAndDescription() {
+        XCTAssertTrue(PromptStyle.allCases.contains(.oblique))
+        XCTAssertEqual(PromptStyle.oblique.title, "Oblique")
+        XCTAssertEqual(PromptStyle.oblique.description, "What has not moved")
+    }
+
+    func testPolicy_hoistsUnchangedBlock() {
+        XCTAssertTrue(ObliqueVoice().contextPolicy.hoistsUnchangedBlock)
+        XCTAssertTrue(ObliqueVoice().contextPolicy.includesMarkerLines)
+    }
+
+    func testConstraints_banContentlessReframeInstructions() {
+        let joined = ObliqueVoice().responseConstraints(hasSpeech: true).joined(separator: " ")
+        XCTAssertTrue(joined.contains("perhaps consider"))
+        XCTAssertTrue(joined.contains("outside the box"))
+        XCTAssertTrue(joined.contains("never assert a pattern that block does not show"))
+    }
+
+    func testConstraints_areExactlyFour() {
+        XCTAssertEqual(ObliqueVoice().responseConstraints(hasSpeech: true).count, 4)
+    }
+
+    func testAssembler_obliqueHoistsBlockAboveTranscription() {
+        let context = ActivityContext.make(
+            recordings: [RecordingContext(
+                text: "the river was loud today", timestamp: DateFactory.makeDate(2024, 6, 15, 9, 5, 0),
+                startCoordinate: nil, endCoordinate: nil, wordsPerMinute: 100,
+                recordingUUID: UUID(), endTimestamp: nil
+            )],
+            startDate: DateFactory.makeDate(2024, 6, 15, 9, 0, 0),
+            unchangedBlock: "**Unchanged:**\n'river' has returned across 4 walks."
+        )
+        let prompt = PromptAssembler.assemble(context: context, voice: ObliqueVoice())
+        let unchangedIndex = prompt.range(of: "**Unchanged:**")?.lowerBound
+        let transcriptionIndex = prompt.range(of: "**Walking Transcription:**")?.lowerBound
+        XCTAssertNotNil(unchangedIndex)
+        XCTAssertNotNil(transcriptionIndex)
+        XCTAssertLessThan(unchangedIndex!, transcriptionIndex!)
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: COMPILE FAILURE — no `.oblique`, no `ObliqueVoice`.
+
+- [ ] **Step 3: Implement**
+
+In `PromptStyle.swift`, add `case oblique` to the enum and a branch to each of `title`, `icon`, and `description`:
+
+```swift
+    case oblique
+    // title:       case .oblique: return "Oblique"
+    // icon:        case .oblique: return "circle.dotted"
+    // description: case .oblique: return "What has not moved"
+```
+
+Add the voice mapping: `case .oblique: return ObliqueVoice()`.
+
+In `WalkPromptVoices.swift`:
+
+```swift
+/// Reads what has NOT moved across the walker's history and names the frame
+/// they have been looking through rather than at.
+///
+/// The governing constraint is Weber et al. 1981: subjects stuck on the
+/// nine-dot problem were told "think outside the box" and it helped nobody.
+/// A contentless instruction to reframe does not transfer. A specific,
+/// structurally-grounded alternative reading does — which is why constraint
+/// 3 bans the former and requires the latter.
+struct ObliqueVoice: PromptVoice {
+
+    var contextPolicy: PromptContextPolicy {
+        PromptContextPolicy(
+            includesMarkerLines: true, includesThreadAnalysis: true, hoistsUnchangedBlock: true
+        )
+    }
+
+    func preamble(hasSpeech: Bool) -> String {
+        "This walker keeps a record. Across many walks they have returned, without planning to, to the same few things. What follows includes what has not changed across those returns — patterns in their own language that they cannot see, because these are the terms they think in rather than the terms they think about."
+    }
+
+    func instruction(hasSpeech: Bool) -> String {
+        "Work from the invariants named under Unchanged. Name what the walker has been treating as fixed — the assumption they have been looking through rather than at — and offer one specific alternative reading of that structure. Be concrete about the shape, not about what it means for their life."
+    }
+
+    func responseConstraints(hasSpeech: Bool) -> [String] {
+        [
+            "Build only on the invariants named under Unchanged — never assert a pattern that block does not show.",
+            "Name one thing. An insight that can be carried is single, not a list.",
+            "Offer a specific alternative reading of the structure; never a contentless instruction to reframe. Do not write \"perhaps consider\", \"try seeing\", \"from another perspective\", or \"outside the box\".",
+            "End on the observation. Do not resolve it and do not prescribe an action — the walker does that part."
+        ]
+    }
+}
+```
+
+Both `hasSpeech` branches return the same text: the availability gate in Task 11 means Oblique is never assembled without speech, and dead placeholder prose would be worse than an honest duplicate.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Expected: all PASS.
+
+- [ ] **Step 5: Run the full suite**
+
+Any test asserting `PromptStyle.allCases.count == 6` must become `7`. Any test iterating all styles will now include Oblique — confirm those still pass rather than weakening them.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Pilgrim/Models/Prompt/ UnitTests/ObliqueVoiceTests.swift
+git commit -m "feat(prompts): Oblique — what has not moved
+
+The voice that reads the Unchanged block. Its whole discipline is one
+finding: Weber et al. told stuck subjects to think outside the box and it
+helped nobody, because a contentless instruction to reframe does not
+transfer. A specific, structurally-grounded alternative reading does.
+
+So it may interpret and may not invent, names one thing rather than a list,
+and stops on the observation. The walker does the resolving - a reframe
+handed to you is not one you can act from.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 11: The picker gate — "Still listening"
+
+**Why:** Oblique needs ≥5 walks with transcripts *and* speech on the current walk. Below either, it would be inventing. It shows in the list from day one, unselectable, so the walker learns it exists.
+
+**Files:**
+- Modify: `Pilgrim/Models/Prompt/PromptStyle.swift` (availability helper)
+- Modify: `Pilgrim/Scenes/Prompts/PromptListView.swift`
+- Modify: `UnitTests/ObliqueVoiceTests.swift`
+
+**Interfaces:**
+- Produces: `PromptStyle.isAvailable(walksWithTranscripts:currentWalkHasSpeech:) -> Bool`, `PromptStyle.waitingCopy: String?`, `PromptStyle.minimumWalksForOblique`
+
+- [ ] **Step 1: Write the failing tests**
+
+```swift
+    func testAvailability_obliqueNeedsHistoryAndSpeech() {
+        XCTAssertFalse(PromptStyle.oblique.isAvailable(walksWithTranscripts: 4, currentWalkHasSpeech: true))
+        XCTAssertFalse(PromptStyle.oblique.isAvailable(walksWithTranscripts: 9, currentWalkHasSpeech: false))
+        XCTAssertTrue(PromptStyle.oblique.isAvailable(walksWithTranscripts: 5, currentWalkHasSpeech: true))
+    }
+
+    func testAvailability_otherStylesAlwaysAvailable() {
+        for style in PromptStyle.allCases where style != .oblique {
+            XCTAssertTrue(style.isAvailable(walksWithTranscripts: 0, currentWalkHasSpeech: false))
+        }
+    }
+
+    func testWaitingCopy_onlyObliqueHasIt() {
+        XCTAssertEqual(PromptStyle.oblique.waitingCopy, "Still listening. A few more walks with your voice.")
+        XCTAssertNil(PromptStyle.reflective.waitingCopy)
+    }
+```
+
+- [ ] **Step 2: Run to verify it fails**
+
+Expected: COMPILE FAILURE — no `isAvailable`.
+
+- [ ] **Step 3: Implement**
+
+In `PromptStyle.swift`:
+
+```swift
+extension PromptStyle {
+
+    static let minimumWalksForOblique = 5
+
+    /// Oblique needs both a deep enough record AND speech on this walk —
+    /// `ThreadsDossierFormatter.dossier` returns nil when the current walk
+    /// has no recordings, so a silent walk yields no Unchanged block to
+    /// read. Every other style is always available.
+    func isAvailable(walksWithTranscripts: Int, currentWalkHasSpeech: Bool) -> Bool {
+        guard self == .oblique else { return true }
+        return walksWithTranscripts >= Self.minimumWalksForOblique && currentWalkHasSpeech
+    }
+
+    /// Shown dimmed in the picker while unavailable. True for either failing
+    /// gate — thin history, or no voice on this walk — so one string covers
+    /// both without lying.
+    var waitingCopy: String? {
+        self == .oblique ? "Still listening. A few more walks with your voice." : nil
+    }
+}
+```
+
+In `PromptListView.swift`, `PromptStyleRow` (line ~352) takes a `GeneratedPrompt` and renders `prompt.icon` / `prompt.title` / `prompt.subtitle`. Add a waiting state to it:
+
+```swift
+struct PromptStyleRow: View {
+    let prompt: GeneratedPrompt
+    var waitingCopy: String? = nil
+
+    private var isWaiting: Bool { waitingCopy != nil }
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Image(systemName: prompt.icon)
+                .font(.title2)
+                .foregroundColor(.stone)
+                .frame(width: 40)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(prompt.title)
+                    .font(Constants.Typography.heading)
+                    .foregroundColor(.ink)
+                Text(waitingCopy ?? prompt.subtitle)
+                    .font(Constants.Typography.caption)
+                    .foregroundColor(.fog)
+                    .lineLimit(2)
+            }
+
+            Spacer()
+
+            if !isWaiting {
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundColor(.fog)
+            }
+        }
+        .padding(.vertical, Constants.UI.Padding.small)
+        .opacity(isWaiting ? 0.45 : 1)
+    }
+}
+```
+
+Keep `VStack(alignment: .leading)` — rows here vary in width and centring them misaligns the column.
+
+In the `ForEach(prompts)` body, suppress the button when the style is waiting:
+
+```swift
+                ForEach(prompts) { prompt in
+                    let waiting = prompt.style.flatMap { style in
+                        style.isAvailable(
+                            walksWithTranscripts: walksWithTranscripts,
+                            currentWalkHasSpeech: context.hasSpeech
+                        ) ? nil : style.waitingCopy
+                    }
+                    if let waiting {
+                        PromptStyleRow(prompt: prompt, waitingCopy: waiting)
+                            .listRowBackground(Color.parchment)
+                    } else {
+                        Button { selectedPrompt = prompt } label: {
+                            PromptStyleRow(prompt: prompt)
+                        }
+                        .listRowBackground(Color.parchment)
+                    }
+                }
+```
+
+`walksWithTranscripts` is a new `Int` the view needs. Source it the same way the view already obtains its `ActivityContext`; if that count is not already available, add it to the derivations `PromptGenerator.resolvedDerivations` returns rather than issuing a fetch from the view. Custom prompts have `style == nil` and so are never gated.
+
+Never use `.system()` fonts — `Constants.Typography.*` only.
+
+- [ ] **Step 4: Run to verify it passes**
+
+Expected: all PASS.
+
+- [ ] **Step 5: Check it on device**
+
+Build and run. Confirm: with a fresh profile Oblique appears dimmed with the waiting copy; the row is not tappable; the copy uses the project's fonts and does not crowd on a small screen at large Dynamic Type.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Pilgrim/Models/Prompt/PromptStyle.swift Pilgrim/Scenes/Prompts/PromptListView.swift UnitTests/ObliqueVoiceTests.swift
+git commit -m "feat(prompts): the Oblique gate — still listening
+
+Two gates, because both are real: five walks of record, and a voice on this
+walk. The dossier returns nil when the current walk has no recordings, so a
+silent walk has no Unchanged block to read.
+
+One string covers both failures without lying, and it frames the voice as
+needing to hear more rather than as a level to grind. Every other gate in
+this app is silent; a style that vanished from a picker would be stranger
+than one that says what it is waiting for.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 12: DEBUG harness and the field gate
+
+**Why:** Firing rate measures only the upside. The no-free-lunch theorem guarantees a matching downside that firing rate is structurally blind to — `questionDensity` escaped only because it was loud.
+
+**Files:**
+- Modify: `Pilgrim/Models/Threads/ThreadsDossierBuilder.swift` (the `#if DEBUG` harness block)
+- Modify: `docs/superpowers/specs/2026-08-27-oblique-and-prompt-relevance-design.md`
+
+**Interfaces:**
+- Produces: `--invariance-field-report` launch argument, mirroring `--senses-field-report`.
+
+- [ ] **Step 1: Add the harness**
+
+Extend the existing `#if DEBUG` harness block at the bottom of `ThreadsDossierBuilder.swift`, mirroring how `--senses-field-report` is structured:
+
+```swift
+    /// Ship-gate harness: iterates every walk with transcribed recordings,
+    /// evaluates every invariant UNCAPPED and ignoring `pendingFieldGate`,
+    /// and prints per-signal firing rates plus each emitted line, so a human
+    /// can judge degeneration (fires on nearly every walk) and dead signals
+    /// (nearly never) against a REAL device history.
+    ///
+    /// EVALUATES ONLY — never writes defaults, never consumes real state,
+    /// exactly like the senses report.
+    static func invarianceFieldReport(walkUUIDs: [UUID]) {
+        var fired: [DossierSenses.Invariant: Int] = [:]
+        var considered = 0
+
+        for walkUUID in walkUUIDs {
+            guard let input = makeSensesInputForReport(walkUUID: walkUUID) else { continue }
+            considered += 1
+            for invariant in DossierSenses.Invariant.allCases {
+                let line: DossierSenses.SenseLine?
+                if invariant == .unarrivedIntention {
+                    line = DossierSensesInvariance.unarrivedIntention(input: input, suppressed: [])
+                } else {
+                    line = DossierSenses.evaluateInvariant(invariant, input: input, suppressed: [])
+                }
+                guard let line else { continue }
+                fired[invariant, default: 0] += 1
+                print("[invariance] \(walkUUID) \(invariant): \(line.text)")
+            }
+        }
+
+        print("[invariance] walks considered: \(considered)")
+        for invariant in DossierSenses.Invariant.allCases {
+            let count = fired[invariant] ?? 0
+            let rate = considered > 0 ? Double(count) / Double(considered) * 100 : 0
+            print(String(format: "[invariance] %@: %d/%d (%.1f%%)",
+                         String(describing: invariant), count, considered, rate))
+        }
+    }
+```
+
+`makeSensesInputForReport` is whatever the existing senses harness already uses to assemble an `Input` per walk — reuse it rather than writing a second one. Signal 5 is called directly so the flag does not hide it from the very report meant to judge it.
+
+Wire `--invariance-field-report` into the same launch-argument switch that handles `--senses-field-report`.
+
+- [ ] **Step 2: Run the firing-rate pass**
+
+Launch the dev build on the team device with `--invariance-field-report` and read the console. Judge per signal: degeneration (fires on nearly every walk) and dead signals (nearly never). Known limitations, same as the senses harness: it skips stale-context self-heal and ignores the `threadsAfterWalks` toggle.
+
+- [ ] **Step 3: Run the harm check**
+
+For a sample of walks, generate the Oblique reflection twice — once as built, once with the `**Unchanged:**` block deleted by hand — and human-rate which is better. A signal that fires often and makes reflections worse is invisible to firing rate.
+
+- [ ] **Step 4: Run the LLM readback**
+
+Paste real Oblique prompts, including elevated marker profiles, into ChatGPT or Claude. Iterate until: no clinical language, no contentless reframe instruction, no invented invariant, one thing named rather than a list. Check specifically whether the model smuggles the pivot back in through a closing question.
+
+- [ ] **Step 5: Judge signal 5**
+
+Only after steps 2–4 pass, and only on real history, decide whether `DossierSensesInvariance.pendingFieldGate` flips to `false`.
+
+- [ ] **Step 6: Record outcomes and commit**
+
+```bash
+git add docs/superpowers/specs/2026-08-27-oblique-and-prompt-relevance-design.md Pilgrim/Models/Threads/ThreadsDossierBuilder.swift
+git commit -m "test(threads): invariance field harness, and the gate readback
+
+Per-signal firing rates plus the with/without harm check. Firing rate is
+the upside only; no free lunch guarantees a matching downside it cannot
+see, so both halves get recorded before anything ships externally.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Done when
+
+- [ ] `DossierSensesInvariance` is pure — no DataManager, no CoreStore, no `Date()`
+- [ ] Four signals live, fifth dark behind `pendingFieldGate`
+- [ ] `Unchanged:` built once, emitted only for Oblique, hoisted above the transcription
+- [ ] Marker percentages absent from Creative, Journaling, and Gratitude prompts
+- [ ] `CustomPromptStyle` still receives the full dossier via the protocol default
+- [ ] Oblique dimmed with "Still listening" until both gates pass, verified on device
+- [ ] `TranscriptContext.currentSchemaVersion` still `4`
+- [ ] No new `fetchAll` anywhere in the diff
+- [ ] Full suite green, no reduction from the 1388 baseline; lint clean, zero new warnings
+- [ ] Field gate steps 2–4 recorded in the spec before any external release

--- a/docs/superpowers/plans/2026-08-27-prompt-relevance-fixes.md
+++ b/docs/superpowers/plans/2026-08-27-prompt-relevance-fixes.md
@@ -1,0 +1,555 @@
+# Prompt Relevance Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix three defects in the existing prompt system — raw signals the model has to guess at, an unbounded connection-hunt that manufactures insight, and a directive that presupposes its own conclusion.
+
+**Architecture:** Three independent changes to three files. No new types, no new computation beyond two bounded lemma passes, no schema change. Each task is self-contained and separately revertible.
+
+**Tech Stack:** Swift 5, SwiftUI, XCTest. Build via `Pilgrim.xcworkspace`, scheme `Pilgrim`.
+
+**Spec:** `docs/superpowers/specs/2026-08-27-oblique-and-prompt-relevance-design.md` (Workstreams 2, 3, 4)
+
+## Global Constraints
+
+- This plan ships independently of the Oblique voice. Do not create `PromptStyle.oblique`, `DossierSensesInvariance`, or any context policy here — those belong to `2026-08-27-oblique-voice.md`.
+- **Accretion budget:** Task 1 adds exactly one response-contract line. Task 3 removes one always-on firing rule. Net +0. Do not add contract lines beyond the one specified.
+- Do not bump `TranscriptContext.currentSchemaVersion` (currently `4`). No change here alters how context is derived, so no stored file becomes stale.
+- Do not change `MarkerAnalyzer`, `ThemeExtractor`, `ThreadStore`, or anything under `Pilgrim/Models/Threads/`.
+- Preserve the single-NLP-pass property established by PR #65: `AttentionDirectives.detect` lemmatizes the joined transcript **once**. Task 3 may add at most two additional bounded passes (first and last recording only) and must never lemmatize all N recordings.
+- Typography, colors, and UI are untouched — this plan changes prompt text only.
+- Run the full suite before each commit. Baseline is 1388 tests; expect growth, never reduction.
+- Never use `--no-verify`.
+
+**Build:**
+```bash
+xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build
+```
+
+**Test:**
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+```
+
+**Single test class:**
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:UnitTests/PromptResponseContractTests
+```
+
+> **Note on test counts:** `xcodebuild` summary lines are unreliable under the macos-26 simulator flake. Reconcile by counting `Test Case '-[...]' started` lines rather than trusting the summary.
+
+---
+
+## Task 1: Interpretive keys for marker and modal data
+
+**Why:** `ThreadsDossierFormatter` ships `absolutist words 2.3%`, `self-focus 9.1%`, and `modal lean: obligation — 'should' ×31` as raw numbers. A model's default read of "should ×31" is *this person is being hard on themselves*. The correct read is that obligation names the **shape of the frame they were thinking inside**. One line converts three already-shipping signals from guessed-at to readable.
+
+**Files:**
+- Modify: `Pilgrim/Models/Prompt/PromptAssembler.swift` (the `hasThreadsDossier` branch of `responseContract`, around line 183)
+- Test: `UnitTests/PromptResponseContractTests.swift`
+
+**Interfaces:**
+- Consumes: `PromptAssembler.responseContract(voice:hasSpeech:hasThreadsDossier:) -> String` (existing signature, unchanged)
+- Produces: nothing new. This task changes string content only.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `UnitTests/PromptResponseContractTests.swift`:
+
+```swift
+func testResponseContract_withThreadsDossier_carriesInterpretiveKey() {
+    let contract = PromptAssembler.responseContract(
+        voice: ReflectiveVoice(), hasSpeech: true, hasThreadsDossier: true
+    )
+    XCTAssertTrue(contract.contains("absolutist density"))
+    XCTAssertTrue(contract.contains("first-person density"))
+    XCTAssertTrue(contract.contains("modal lean"))
+    XCTAssertTrue(contract.contains("obligation"))
+    XCTAssertTrue(contract.contains("counterfactual"))
+}
+
+func testResponseContract_withThreadsDossier_retainsClinicalGuard() {
+    let contract = PromptAssembler.responseContract(
+        voice: ReflectiveVoice(), hasSpeech: true, hasThreadsDossier: true
+    )
+    XCTAssertTrue(contract.contains("never produce clinical or diagnostic language"))
+}
+
+func testResponseContract_withoutThreadsDossier_hasNoInterpretiveKey() {
+    let contract = PromptAssembler.responseContract(
+        voice: ReflectiveVoice(), hasSpeech: true, hasThreadsDossier: false
+    )
+    XCTAssertFalse(contract.contains("absolutist density"))
+}
+
+func testResponseContract_withThreadsDossier_addsExactlyOneLine() {
+    let with = PromptAssembler.responseContract(
+        voice: ReflectiveVoice(), hasSpeech: true, hasThreadsDossier: true
+    )
+    let without = PromptAssembler.responseContract(
+        voice: ReflectiveVoice(), hasSpeech: true, hasThreadsDossier: false
+    )
+    let withLines = with.components(separatedBy: "\n- ").count
+    let withoutLines = without.components(separatedBy: "\n- ").count
+    XCTAssertEqual(withLines - withoutLines, 2, "clinical guard + interpretive key, no more")
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:UnitTests/PromptResponseContractTests
+```
+
+Expected: `testResponseContract_withThreadsDossier_carriesInterpretiveKey` FAILS (contract does not contain "absolutist density"). `testResponseContract_withThreadsDossier_addsExactlyOneLine` FAILS (difference is 1, not 2). The other two PASS already.
+
+- [ ] **Step 3: Add the interpretive key line**
+
+In `Pilgrim/Models/Prompt/PromptAssembler.swift`, find this block inside `responseContract`:
+
+```swift
+        if hasThreadsDossier {
+            lines.append("The thought-thread marker profiles are descriptive on-device linguistic signals, not assessments — interpret them gently, never produce clinical or diagnostic language, and never treat a single walk's numbers as meaningful on their own.")
+        }
+```
+
+Replace with:
+
+```swift
+        if hasThreadsDossier {
+            lines.append("The thought-thread marker profiles are descriptive on-device linguistic signals, not assessments — interpret them gently, never produce clinical or diagnostic language, and never treat a single walk's numbers as meaningful on their own.")
+            lines.append("Read absolutist density as how fixed the walker's framing was, first-person density as how far they placed themselves at the centre of it, and the modal lean as the frame they were working inside — obligation means the frame constrained them, counterfactual means they were already replaying alternatives, possibility and tentative mean it was still open. None of these has a fixed meaning; read each through this walk's intention and practice.")
+        }
+```
+
+Keep the existing clinical-language guard **exactly as it is** — it is the safety line and the new line is an interpretive one. They do different jobs.
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:UnitTests/PromptResponseContractTests
+```
+
+Expected: all four PASS.
+
+- [ ] **Step 5: Run the full suite**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+```
+
+Expected: no failures. Some snapshot-style tests in `PromptAssemblerLanguageTests` or `PromptGeneratorTests` may assert on full prompt text — if any fail, update the expected string to include the new line. Do **not** weaken an assertion to make it pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Pilgrim/Models/Prompt/PromptAssembler.swift UnitTests/PromptResponseContractTests.swift
+git commit -m "feat(prompts): give the model the key to the marker numbers
+
+The dossier has been shipping absolutist density, first-person density and
+the modal lean as bare figures, leaving the model to guess. Its default
+guess for 'should x31' is that the walker is being hard on themselves. The
+reading that is actually true is different: obligation names the shape of
+the frame they were thinking inside, and counterfactual means they were
+already replaying alternatives.
+
+One contract line, no new computation. The clinical-language guard stays
+exactly as it was; that line keeps the reading safe, this one makes it
+possible.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 2: Bound Reflective's connection-hunting to the walk's own evidence
+
+**Why:** `ReflectiveVoice.instruction` asks *"What connections do you see between the different moments?"* and *"What contradictions or tensions are present?"* Both are unbounded. Goodman 1972: any two things share indefinitely many true properties — a lawn mower and a plum both have rounded edges, contain carbon, and weigh more than a paperclip. So the model will always find connections, they will always sound insightful, and they will be arbitrary. Similarity only does work once relevance is supplied from outside it.
+
+**Files:**
+- Modify: `Pilgrim/Models/Prompt/WalkPromptVoices.swift:32-36` (`ReflectiveVoice.instruction`)
+- Test: `UnitTests/PromptGeneratorTests.swift`
+
+**Interfaces:**
+- Consumes: `PromptVoice.instruction(hasSpeech: Bool) -> String` (existing protocol member, unchanged)
+- Produces: nothing new. String content only.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `UnitTests/PromptGeneratorTests.swift`:
+
+```swift
+func testReflectiveVoice_spoken_bindsConnectionsToTheRecord() {
+    let instruction = ReflectiveVoice().instruction(hasSpeech: true)
+    XCTAssertTrue(instruction.contains("Where the walk's own record supports it"))
+    XCTAssertTrue(instruction.contains("say less rather than reaching"))
+    XCTAssertTrue(instruction.contains("do not manufacture one"))
+}
+
+func testReflectiveVoice_silent_bindsPatternsToTheRecord() {
+    let instruction = ReflectiveVoice().instruction(hasSpeech: false)
+    XCTAssertTrue(instruction.contains("Where the walk's own record supports it"))
+    XCTAssertTrue(instruction.contains("say less rather than reaching"))
+}
+
+func testReflectiveVoice_bothModes_keepSelfUnderstandingGoal() {
+    XCTAssertTrue(ReflectiveVoice().instruction(hasSpeech: true).contains("understand"))
+    XCTAssertTrue(ReflectiveVoice().instruction(hasSpeech: false).contains("understand"))
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:UnitTests/PromptGeneratorTests
+```
+
+Expected: the first two FAIL (instruction does not contain "Where the walk's own record supports it"). The third PASSES already.
+
+- [ ] **Step 3: Rewrite both instruction branches**
+
+In `Pilgrim/Models/Prompt/WalkPromptVoices.swift`, replace `ReflectiveVoice.instruction` entirely:
+
+```swift
+    func instruction(hasSpeech: Bool) -> String {
+        hasSpeech
+            ? "Please analyze these walking reflections for patterns, recurring themes, and emotional undercurrents. Where the walk's own record supports it — the stated intention, a word that recurs, a shift in pace or marker profile — name what connects the moments; where it does not, say less rather than reaching. Note any genuine tension the record shows, and do not manufacture one. Offer observations that help me understand myself better."
+            : "Read the shape of this walk — its pace, its pauses, its waypoints — as you would read a text. Where the walk's own record supports it, name the patterns you find; where it does not, say less rather than reaching. What might the walker have been processing? What does the choice of silence itself suggest? Offer observations that help them understand themselves."
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:UnitTests/PromptGeneratorTests
+```
+
+Expected: all three PASS.
+
+- [ ] **Step 5: Run the full suite**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+```
+
+Expected: no failures. Update any full-prompt snapshot assertions to the new text if they break; do not weaken them.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Pilgrim/Models/Prompt/WalkPromptVoices.swift UnitTests/PromptGeneratorTests.swift
+git commit -m "fix(prompts): stop Reflective asking for connections that always exist
+
+'What connections do you see between the different moments' is unbounded,
+and Goodman settled what happens next: any two things share indefinitely
+many true properties, so a model asked to connect will always connect, it
+will always sound insightful, and it will be arbitrary. Asking for
+contradictions the same way manufactures tension on walks that had none.
+
+Similarity only does work once relevance is supplied from outside it. Both
+branches now bind to the walk's own record - the intention, a recurring
+word, a shift in pace - and are told to say less rather than reach.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 3: Gate `firstVersusLast` on a delta that actually moved
+
+**Why:** The directive currently fires on every walk with ≥2 recordings and **presupposes its conclusion** — told to measure what changed, the model finds change, including on walks where nothing did. This is the defect that killed `questionDensity` at the 2026-08-25 gate, just quieter: it fires plausibly and is wrong.
+
+**Note on available data:** `ActivityContext` carries no structured marker data — only `threadsDossier` as a pre-formatted string. Sentiment and absolutist deltas are therefore **not reachable here**, and computing them would mean fresh `MarkerAnalyzer` passes per recording, undoing PR #65's single-pass work. The gate below uses `RecordingContext.wordsPerMinute` (already populated, free) plus exactly two bounded `TranscriptNLP.contentLemmas(in:)` passes on the first and last recording only.
+
+**Files:**
+- Modify: `Pilgrim/Models/Prompt/AttentionDirectives.swift` (the `firstVersusLast` detector and its two new constants)
+- Test: `UnitTests/AttentionDirectivesTests.swift` (create if absent)
+
+**Interfaces:**
+- Consumes: `RecordingContext.wordsPerMinute: Double?`, `RecordingContext.text: String`, `TranscriptNLP.contentLemmas(in:) -> [String]`
+- Produces: `AttentionDirectives.detect(context:detectedLanguageCode:) -> [String]` (existing signature, unchanged). Behaviour change only: `firstVersusLast` may now return `nil`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `UnitTests/AttentionDirectivesTests.swift` if it does not exist; otherwise append. Use `ActivityContext.make` and `DateFactory.makeDate`, matching the fixture style in `DossierSensesTests`.
+
+```swift
+import XCTest
+@testable import Pilgrim
+
+final class AttentionDirectivesFirstVersusLastTests: XCTestCase {
+
+    private static let start = DateFactory.makeDate(2024, 6, 15, 9, 0, 0)
+
+    private func recording(_ text: String, wpm: Double?, minutesIn: Int) -> RecordingContext {
+        RecordingContext(
+            text: text,
+            timestamp: Self.start.addingTimeInterval(TimeInterval(minutesIn * 60)),
+            startCoordinate: nil,
+            endCoordinate: nil,
+            wordsPerMinute: wpm,
+            recordingUUID: UUID(),
+            endTimestamp: nil
+        )
+    }
+
+    private func directives(_ recordings: [RecordingContext]) -> [String] {
+        AttentionDirectives.detect(
+            context: .make(recordings: recordings, startDate: Self.start),
+            detectedLanguageCode: "en"
+        )
+    }
+
+    private func isFirstVersusLast(_ line: String) -> Bool {
+        line.contains("attend to what moved between them")
+    }
+
+    func testFirstVersusLast_sameSubjectSamePace_staysSilent() {
+        let text = "the garden hedge grows beside the stone wall near the orchard gate"
+        let lines = directives([
+            recording(text, wpm: 100, minutesIn: 0),
+            recording(text, wpm: 102, minutesIn: 20)
+        ])
+        XCTAssertFalse(lines.contains(where: isFirstVersusLast))
+    }
+
+    func testFirstVersusLast_paceShift_fires() {
+        let text = "the garden hedge grows beside the stone wall near the orchard gate"
+        let lines = directives([
+            recording(text, wpm: 100, minutesIn: 0),
+            recording(text, wpm: 140, minutesIn: 20)
+        ])
+        XCTAssertTrue(lines.contains { isFirstVersusLast($0) && $0.contains("faster") })
+    }
+
+    func testFirstVersusLast_paceSlowed_namesSlower() {
+        let text = "the garden hedge grows beside the stone wall near the orchard gate"
+        let lines = directives([
+            recording(text, wpm: 140, minutesIn: 0),
+            recording(text, wpm: 100, minutesIn: 20)
+        ])
+        XCTAssertTrue(lines.contains { isFirstVersusLast($0) && $0.contains("more slowly") })
+    }
+
+    func testFirstVersusLast_subjectDiverged_fires() {
+        let lines = directives([
+            recording("the garden hedge grows beside the stone wall near the orchard gate",
+                      wpm: 100, minutesIn: 0),
+            recording("my brother telephoned about the mortgage payment and the lawyer's invoice",
+                      wpm: 101, minutesIn: 20)
+        ])
+        XCTAssertTrue(lines.contains { isFirstVersusLast($0) && $0.contains("shares little vocabulary") })
+    }
+
+    func testFirstVersusLast_tooFewLemmasToJudge_staysSilent() {
+        let lines = directives([
+            recording("yes", wpm: 100, minutesIn: 0),
+            recording("no", wpm: 101, minutesIn: 20)
+        ])
+        XCTAssertFalse(lines.contains(where: isFirstVersusLast))
+    }
+
+    func testFirstVersusLast_missingPace_fallsBackToSubjectOnly() {
+        let text = "the garden hedge grows beside the stone wall near the orchard gate"
+        let lines = directives([
+            recording(text, wpm: nil, minutesIn: 0),
+            recording(text, wpm: nil, minutesIn: 20)
+        ])
+        XCTAssertFalse(lines.contains(where: isFirstVersusLast))
+    }
+
+    func testFirstVersusLast_singleRecording_staysSilent() {
+        let lines = directives([
+            recording("the garden hedge grows beside the stone wall", wpm: 100, minutesIn: 0)
+        ])
+        XCTAssertFalse(lines.contains(where: isFirstVersusLast))
+    }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:UnitTests/AttentionDirectivesFirstVersusLastTests
+```
+
+Expected: `sameSubjectSamePace_staysSilent`, `tooFewLemmasToJudge_staysSilent`, and `missingPace_fallsBackToSubjectOnly` FAIL — the current unconditional directive fires. The two "fires" tests also FAIL, because the current text is "Compare the first recording with the last — measure what changed in the walker between them" and contains none of the new phrases. `singleRecording_staysSilent` PASSES already.
+
+- [ ] **Step 3: Replace the detector**
+
+In `Pilgrim/Models/Prompt/AttentionDirectives.swift`, add these constants beside `movingThreshold` and `maxDirectives`:
+
+```swift
+    private static let paceShiftThreshold = 0.15
+    private static let subjectOverlapCeiling = 0.20
+    private static let minimumLemmasToJudgeSubject = 5
+```
+
+Then replace `firstVersusLast` entirely:
+
+```swift
+    /// Fires only when something measurably moved between the first
+    /// recording and the last. The previous version fired on every walk
+    /// with two recordings and presupposed its own conclusion — told to
+    /// measure what changed, the model finds change, including on walks
+    /// where nothing did (the `questionDensity` failure mode, quieter).
+    ///
+    /// Marker and sentiment deltas are deliberately NOT used: they are
+    /// unreachable from `ActivityContext`, and computing them here would
+    /// mean a fresh analyzer pass per recording. Pace is free
+    /// (`wordsPerMinute` is already populated); subject costs exactly two
+    /// lemma passes, never N.
+    private static func firstVersusLast(_ context: ActivityContext) -> String? {
+        guard let first = context.recordings.first,
+              let last = context.recordings.last,
+              context.recordings.count >= 2 else { return nil }
+
+        if let firstPace = first.wordsPerMinute, let lastPace = last.wordsPerMinute, firstPace > 0 {
+            let change = (lastPace - firstPace) / firstPace
+            if change >= paceShiftThreshold {
+                return "The walker spoke faster by the last recording than the first — attend to what moved between them."
+            }
+            if change <= -paceShiftThreshold {
+                return "The walker spoke more slowly by the last recording than the first — attend to what moved between them."
+            }
+        }
+
+        let firstLemmas = Set(TranscriptNLP.contentLemmas(in: first.text))
+        let lastLemmas = Set(TranscriptNLP.contentLemmas(in: last.text))
+        guard firstLemmas.count >= minimumLemmasToJudgeSubject,
+              lastLemmas.count >= minimumLemmasToJudgeSubject else { return nil }
+
+        let union = firstLemmas.union(lastLemmas).count
+        guard union > 0 else { return nil }
+        let jaccard = Double(firstLemmas.intersection(lastLemmas).count) / Double(union)
+        guard jaccard <= subjectOverlapCeiling else { return nil }
+
+        return "The walker's last recording shares little vocabulary with the first — attend to what moved between them."
+    }
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro' \
+  -only-testing:UnitTests/AttentionDirectivesFirstVersusLastTests
+```
+
+Expected: all seven PASS.
+
+If `subjectDiverged_fires` does not pass, print the two lemma sets and check the actual Jaccard value before touching `subjectOverlapCeiling` — `contentLemmas` applies its own stoplist, so the sets may be smaller than the raw text suggests. Adjust the **fixture text** to be more clearly divergent rather than loosening the threshold; the threshold is a spec value subject to the field gate, not a knob to make a test green.
+
+- [ ] **Step 5: Run the full suite**
+
+```bash
+xcodebuild test -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator \
+  -destination 'platform=iOS Simulator,name=iPhone 17 Pro'
+```
+
+Expected: no failures. Any existing test asserting the old "Compare the first recording with the last" string must be updated to the new behaviour — including, if present, one that assumed four directives always fire.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add Pilgrim/Models/Prompt/AttentionDirectives.swift UnitTests/AttentionDirectivesTests.swift
+git commit -m "fix(prompts): stop firstVersusLast presupposing its own conclusion
+
+The directive fired on every walk with two recordings and told the model to
+measure what changed. Told that, the model finds change - including on the
+walks where nothing did. Same disease that killed questionDensity at the
+gate, only quieter: it fires plausibly and it is wrong.
+
+Now it fires only when something moved. Pace comes free from
+wordsPerMinute; subject costs two bounded lemma passes on the first and
+last recording, never all N. Marker and sentiment deltas would have been
+the better signals and are deliberately absent - they are unreachable from
+ActivityContext, and reaching them would undo the single-pass work from
+PR #65.
+
+When nothing moved the directive is silent and the budget goes to a
+detector with something to say.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Task 4: Verify on device and record the readback
+
+**Why:** All three changes alter what the downstream model receives. The spec's field gate requires a harm check, because firing rate measures only the upside — the no-free-lunch theorem guarantees a matching downside that firing rate is structurally blind to.
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-08-27-oblique-and-prompt-relevance-design.md` (Deferred section — record outcomes)
+
+**Interfaces:**
+- Consumes: nothing. Manual QA task.
+- Produces: recorded outcomes that gate external release.
+
+- [ ] **Step 1: Build and install a DEBUG build on the test device**
+
+```bash
+xcodebuild -workspace Pilgrim.xcworkspace -scheme Pilgrim -sdk iphonesimulator build
+```
+
+Then run on the team device from Xcode. A simulator is acceptable for Tasks 1 and 2; Task 3's pace gate needs real `wordsPerMinute` values, so use a device with real walk history.
+
+- [ ] **Step 2: Collect three real prompts**
+
+Open a walk with ≥2 voice recordings and a threads dossier. Copy the generated prompt for Reflective, Journaling, and Contemplative.
+
+- [ ] **Step 3: Harm check — with and without the interpretive key**
+
+For each of the three prompts, produce two variants: one as generated, one with the new interpretive-key line deleted by hand. Paste both into ChatGPT or Claude and human-rate which reflection is better.
+
+Record: does the key make the reflection read *less* clinical, or does naming the modal families make the model reach for framing language it would not otherwise have used? A signal that fires often and makes reflections worse is exactly what firing rate cannot see.
+
+- [ ] **Step 4: Confirm `firstVersusLast` silence is correct, not broken**
+
+Find a walk where the walker spoke about the same thing at the same pace throughout. Confirm the directive is absent. Then find a walk where the subject clearly shifted and confirm it fires and names the right signal.
+
+If it fires on nearly every walk, the thresholds are too loose. If it never fires across the whole history, they are too tight. Record the observed rate.
+
+- [ ] **Step 5: Record outcomes in the spec**
+
+Append findings to the Deferred / open questions section of `docs/superpowers/specs/2026-08-27-oblique-and-prompt-relevance-design.md`, including the observed `firstVersusLast` firing rate and the harm-check verdict on the interpretive key.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add docs/superpowers/specs/2026-08-27-oblique-and-prompt-relevance-design.md
+git commit -m "docs(prompts): record the field-gate readback for the relevance fixes
+
+Firing rates and the with/without harm check for the interpretive key.
+Firing rate alone measures the upside; no free lunch guarantees a matching
+downside it cannot see, so both halves are recorded here.
+
+Co-Authored-By: Claude Opus 5 (1M context) <noreply@anthropic.com>"
+```
+
+---
+
+## Done when
+
+- [ ] Task 1: interpretive key ships, clinical guard retained, contract grew by exactly one line
+- [ ] Task 2: Reflective binds connections and tension to the walk's record in both branches
+- [ ] Task 3: `firstVersusLast` fires only on a measured pace or subject shift and names which
+- [ ] Task 4: device readback done, harm check recorded, firing rate recorded in the spec
+- [ ] Full suite green, no reductions from the 1388 baseline
+- [ ] Lint clean against `main`'s current baseline, zero new warnings
+- [ ] No `PromptStyle` case added, no Threads module file touched

--- a/docs/superpowers/plans/2026-08-27-prompt-relevance-fixes.md
+++ b/docs/superpowers/plans/2026-08-27-prompt-relevance-fixes.md
@@ -362,7 +362,7 @@ final class AttentionDirectivesFirstVersusLastTests: XCTestCase {
         XCTAssertFalse(lines.contains(where: isFirstVersusLast))
     }
 
-    func testFirstVersusLast_missingPace_fallsBackToSubjectOnly() {
+    func testFirstVersusLast_missingPaceAndSameSubject_staysSilent() {
         let text = "the garden hedge grows beside the stone wall near the orchard gate"
         let lines = directives([
             recording(text, wpm: nil, minutesIn: 0),

--- a/docs/superpowers/specs/2026-08-27-oblique-and-prompt-relevance-design.md
+++ b/docs/superpowers/specs/2026-08-27-oblique-and-prompt-relevance-design.md
@@ -186,17 +186,21 @@ private static func firstVersusLast(_ context: ActivityContext) -> String? {
 
 Unconditional on ≥2 recordings, so it fires on nearly every spoken walk, and it **presupposes its conclusion**. Told to measure what changed, the model finds change — including on walks where nothing did. This is the same defect that killed `questionDensity` at the 2026-08-25 gate: it fires plausibly and is wrong.
 
-**Fix.** Gate on a delta the system already computes. Fire only when at least one of the following clears its threshold between the first and last recording:
+**Fix.** Gate on a delta actually reachable from `ActivityContext`.
 
-- sentiment delta ≥ 0.3 (absolute)
-- absolutist rate delta ≥ 50% relative, both recordings clearing `densityFloorWords`
-- words-per-minute delta ≥ `paceDifferenceThreshold` (0.15)
+**Correction (found while planning, 2026-08-27):** an earlier draft of this section named sentiment and absolutist-rate deltas. Those are **not reachable** — `ActivityContext` carries no structured marker data, only `threadsDossier` as a pre-formatted string. Computing them inside `AttentionDirectives` would mean fresh `MarkerAnalyzer` passes per recording, undoing PR #65's single-NLP-pass work. The gate below uses only data already on the context plus two bounded lemma passes.
 
-When it fires, the directive names *which* signal moved rather than asking for an open-ended comparison, so the model is pointed at something real:
+Fire only when at least one clears its threshold between the **first** and **last** recording:
 
-> The walker's [signal] shifted between the first recording and the last — attend to what moved between them.
+- **Pace:** `wordsPerMinute` delta ≥ 15% relative. Free — `RecordingContext.wordsPerMinute` is already populated. Skipped when either value is `nil`.
+- **Subject:** Jaccard similarity of content-lemma sets ≤ 0.20 — they are no longer talking about the same thing. Costs exactly two `TranscriptNLP.contentLemmas(in:)` passes (first and last recording only, never all N). Requires both recordings to yield ≥ 5 content lemmas, so a two-word recording cannot manufacture divergence.
 
-When nothing cleared, the directive stays silent and `maxDirectives` budget goes to a detector with something to say.
+When it fires, the directive names *which* signal moved, so the model is pointed at something real rather than asked to hunt:
+
+- Pace: `The walker spoke [faster|more slowly] by the last recording than the first — attend to what moved between them.`
+- Subject: `The walker's last recording shares little vocabulary with the first — attend to what moved between them.`
+
+When both clear, pace is reported (declaration order). When neither clears, the directive stays silent and the `maxDirectives` budget goes to a detector with something to say.
 
 **Cost.** Removes one always-on firing rule. Net −1 against the accretion budget.
 

--- a/docs/superpowers/specs/2026-08-27-oblique-and-prompt-relevance-design.md
+++ b/docs/superpowers/specs/2026-08-27-oblique-and-prompt-relevance-design.md
@@ -143,9 +143,13 @@ Per the approved context-scope decision, Oblique receives the **full** dossier w
 
 **Problem.** The dossier ships rich signals raw and the model guesses. `ThreadsDossierFormatter.markerLine` emits absolutist and first-person percentages; `modalLeanLine` emits `modal lean: obligation — 'should' ×31 (your usual ~8 per walk)`. A model's default read of "should ×31" is *this person is being hard on themselves*. The correct read is entirely different: obligation names the **shape of the frame they were thinking inside**.
 
-**Fix.** One line added to `PromptAssembler.responseContract`, in the `hasThreadsDossier` branch alongside the existing clinical-language guard:
+**Fix.** One line added to `PromptAssembler.responseContract`, in the threads-dossier branch alongside the existing clinical-language guard:
 
-> Read the absolutist-word share as how fixed the walker's framing was, self-focus as how far they placed themselves at the centre of it, and the modal lean as the frame they were working inside — obligation means the frame constrained them, counterfactual means they were already replaying alternatives, possibility and tentative mean it was still open, intention means they had settled on a course, and desire means they were naming a want rather than a plan. None of these has a fixed meaning; read each through this walk's intention and practice.
+> Read the absolutist-word share as how fixed the walker's framing was, and self-focus as how far they placed themselves at the centre of it. Read the modal lean as the frame the walker was working inside — obligation means the frame constrained them, counterfactual means they were already replaying alternatives, possibility and tentative mean it was still open, intention means they had settled on a course, and desire means they were naming a want rather than a plan. None of these has a fixed meaning; read each through this walk's intention and practice.
+
+**Emitted per clause, not per dossier — corrected at review, 2026-08-27.** The first draft fired the whole key whenever a dossier was present. But `markerLine` prints "Markers unavailable (non-English recording)" when the recording has no `MarkerPack`, prints raw counts rather than shares below `densityFloorWords` (100), and `modalLeanLine` is silent unless it clears three thresholds — so the key routinely taught a taxonomy the dossier had withheld, handing the model vocabulary with no referent. `responseContract` therefore takes the dossier **text** (`threadsDossier: String?`) rather than a `Bool`, and emits only the clauses whose referents were printed: the share clause when shares appear, a bare-tally variant when only raw counts do, the modal clause only when a modal lean was printed, and no interpretive line at all when the dossier withheld everything. The clinical guard stays unconditional on the dossier's presence — it is the safety line. Still at most one interpretive line, so the accretion budget is unchanged.
+
+The probes match `ThreadsDossierFormatter`'s own phrasings. That coupling is pinned by a test that runs the real formatter, so a phrasing change fails a test rather than silently suppressing the key on every walk.
 
 The labels ("absolutist-word share", "self-focus") match what `ThreadsDossierFormatter` actually prints, not a paraphrase of it. The key names all six `MarkerLexicons.ModalFamily` cases — `possibility`, `obligation`, `counterfactual`, `tentative`, `intention`, `desire` — not a subset: naming only four invites the model to back-fit an unnamed family (`intention`, `desire`) onto the nearest named one, and `desire` in particular is high-frequency in spoken reflection ("want", "need", "wish"), so an unnamed reading of it would surface often.
 
@@ -167,9 +171,11 @@ Both are unbounded. Per Principle 2 the model will always find connections and w
 
 **Fix.** Bind both to the walk's own evidence. Revised instruction:
 
-> Please analyze these walking reflections for patterns, recurring themes, and emotional undercurrents. Where the walk's own record supports it — the stated intention, a word that recurs, a shift in pace or marker profile — name what connects the moments. Where it does not, say less rather than reaching. Note any genuine tension the record shows, and do not manufacture one. Offer observations that help me understand myself better.
+> Please analyze these walking reflections for patterns, recurring themes, and emotional undercurrents. Where the walk's own record supports it — the stated intention, a word that recurs, a shift in pace — name what connects the moments. Where it does not, say less rather than reaching. Note any genuine tension the record shows, and do not manufacture one. Offer observations that help me understand myself better.
 
 The `hasSpeech: false` variant gets the parallel treatment for its "What patterns do you see?" clause.
+
+**"or marker profile" dropped at review, 2026-08-27.** The first draft's enumeration named the marker profile as licensed evidence. But the threads dossier reaches the prompt only when `UserPreferences.threadsAfterWalks` is on, and `instruction(hasSpeech:)` — unlike `responseContract` — has no way to know whether it did. The enumeration must name only evidence every spoken walk actually carries; the alternative is widening the `PromptVoice` protocol signature, which is a larger call than this fix warrants.
 
 **Cost.** No contract lines. Prose-only change to one voice.
 
@@ -194,10 +200,23 @@ Unconditional on ≥2 recordings, so it fires on nearly every spoken walk, and i
 
 Fire only when at least one clears its threshold between the **first** and **last** recording:
 
-- **Pace:** `wordsPerMinute` delta ≥ 15% relative. Free — `RecordingContext.wordsPerMinute` is already populated. Skipped when either value is `nil`.
-- **Subject:** overlap coefficient of content-lemma sets (`intersection.count / min(firstLemmas.count, lastLemmas.count)`) ≤ 0.20 — they are no longer talking about the same thing. Costs exactly two `TranscriptNLP.contentLemmas(in:)` passes (first and last recording only, never all N). Requires both recordings to yield ≥ 5 content lemmas, so a two-word recording cannot manufacture divergence.
+- **Pace:** `wordsPerMinute` delta ≥ 15% relative (`paceShiftThreshold`). Free — `RecordingContext.wordsPerMinute` is already populated. Skipped when either value is `nil`, and when either recording holds fewer than 25 words (`minimumWordsToJudgePace`).
+
+  **Word floor added at review, 2026-08-27.** The first draft gated pace on the relative delta alone. A short opening note ("Setting out heavy") has a `wordsPerMinute` fixed by the rounding of its own start and end timestamps, so a 15% relative change is trivially cleared and the directive fired on noise. The floor mirrors the subject branch's shape — a floor on each side, sized so the signal is measurable at all. At any plausible speaking rate, 25 words means at least ten seconds of continuous speech.
+
+- **Subject:** overlap coefficient of content-lemma sets (`intersection.count / min(firstLemmas.count, lastLemmas.count)`) ≤ 0.20 (`subjectOverlapCeiling`) — they are no longer talking about the same thing. Costs exactly two `TranscriptNLP.contentLemmas(in:)` passes (first and last recording only, never all N). Requires both recordings to yield ≥ 12 content lemmas (`minimumLemmasToJudgeSubject`), and the longer set to be no more than 3× the shorter (`subjectLengthRatioCeiling`).
 
   **Not Jaccard.** An earlier draft of this workstream specified Jaccard similarity (`intersection / union`). Jaccard collapses to `|smaller| / |larger|` whenever one lemma set is a subset of the other, which is exactly the shape of a long opening reflection followed by a short closing note on the *same* subject: ~32 unique lemmas in the opening, a 6-lemma closing note drawn entirely from that same vocabulary, Jaccard ≈ 6/32 ≈ 0.19 — under the 0.20 ceiling, so it would fire "shares little vocabulary" on a walk that never left its subject. The overlap coefficient is 1.0 for that same subset case (correctly silent) and still near 0 for genuinely divergent subjects, because it measures how much of the *smaller* recording's vocabulary is accounted for by the larger one, rather than penalizing a short recording for being short relative to a long one.
+
+  **Three subject guards added at review, 2026-08-27.** The first draft's gate was still loose enough to fire on walks that never changed subject:
+
+  1. **Scaffolding is filtered.** `SpokenStoplist.scaffoldLemmas` is subtracted from both sets before intersecting, as `recurringWord` already does. NLTagger tags "think", "know", "want", "keep" as content words; left in, a closing recording made entirely of spoken scaffolding counted eighteen "lemmas", cleared the floor, and shared nothing with the opening.
+  2. **The lemma floor rose from 5 to 12,** and now counts content lemmas only. Five sat far below where a lexical-overlap judgment carries information: a sign-off ("heading back down the hill, tired but glad") clears it and scores near-zero overlap. A genuinely divergent long pair measures around 0.06, so there is ample headroom above the higher floor.
+  3. **A length-ratio ceiling of 3.0.** Past it, the smaller recording is a thin sample of the walk rather than its second half, and its overlap against a much longer transcript says more about its length than about the subject.
+
+- **Language.** The subject branch runs only when `NLTagger.availableTagSchemes(for: .word, language:)` reports a `.lemma` model for the transcript's detected language, **and** the first and last recordings resolve to the same language. Asked of the OS at runtime rather than hardcoded, so the branch widens on its own as Apple adds lemma models.
+
+  **Added at review, 2026-08-27.** `TranscriptNLP.contentLemmas` falls back to the lowercased surface form when NLTagger has no lemma model, so an inflected language yields a distinct "lemma" per inflection and overlap is depressed systematically. Pilgrim's core audience walks the Camino: French, German, Italian, Portuguese, and Spanish transcripts are a primary case, and every one of them would have read as total divergence. A language switch between the first and last recording guaranteed a false fire outright. Silence is the correct answer when the measurement is not valid — the pace branch is unaffected and still speaks.
 
 When it fires, the directive names *which* signal moved, so the model is pointed at something real rather than asked to hunt:
 

--- a/docs/superpowers/specs/2026-08-27-oblique-and-prompt-relevance-design.md
+++ b/docs/superpowers/specs/2026-08-27-oblique-and-prompt-relevance-design.md
@@ -1,0 +1,303 @@
+# Oblique voice + prompt relevance — design
+
+**Date:** 2026-08-27
+**Status:** Design — awaiting user review
+**Origin:** John Vervaeke, *Intelligence, Rationality, Wisdom and Spirituality* (transcript reviewed 2026-08-26). The talk's core thesis — *relevance realization*, the meta-problem of ignoring almost everything and zeroing in on what matters — is structurally what the Thought Threads dossier already does. This spec applies the talk's specific findings to a new prompt voice and to three defects in the existing prompts.
+
+Related: [Thought Threads design](2026-08-22-thought-threads-design.md).
+
+---
+
+## Principles
+
+These govern every decision below. They are derived from the source talk and are binding on implementation.
+
+1. **Never instruct a reframe with no content attached.** Weber et al. 1981 gave people the nine-dot problem, waited until they were stuck, then told them "think outside the box, go beyond the square." It helped nobody. A *specific, concrete, structurally-grounded* alternative reading is a different thing and transfers fine — Vervaeke hands his audience the parity reframe for the mutilated chessboard outright and they have the aha. The ban is on contentless instruction, not on interpretation.
+
+2. **Relevance must be supplied from outside similarity.** Goodman 1972: any two things share indefinitely many true properties (a lawn mower and a plum both have rounded edges, contain carbon, weigh more than a paperclip). An LLM asked to find connections will always find them, they will always sound insightful, and they will be arbitrary. Deterministic on-device computation is what supplies the relevance criterion; the model may interpret those invariants and may not invent new ones.
+
+3. **Two layers, split by capability.** Layer 1 (on-device, deterministic) does *relevance realization* — what is actually invariant across this walker's history. Layer 2 (the model) does *aspectualization* — what frame that invariant reveals. Neither can do the other's job: the model has no access to history, and the device cannot see-as.
+
+4. **Every heuristic has a matching cost.** The no-free-lunch theorem is formally proved: a heuristic that improves performance on some distribution degrades it by an equal area elsewhere. Each sense and each directive is a heuristic. Firing rate measures only the upside.
+
+5. **Rules do not specify their own conditions of application.** "Be kind" applies one way to a puppy, another to an adult child, another to a partner at a funeral; fixing that with more rules gives infinite regress. The response contract is a rule pile at up to 7 lines on a rich walk. **Accretion budget: any change that grows the contract must justify the slot.** This spec adds exactly one contract line (Workstream 2) and removes one always-on firing rule (Workstream 4).
+
+6. **Chunking bounds what is held.** Working memory is ~4 items. `DossierSenses.lineCap = 3` already respects this; `Unchanged:` inherits the same cap.
+
+---
+
+## Workstream 1 — Oblique
+
+A seventh `PromptStyle` that reads what has **not** moved across the walker's history, and names the frame the walker has been looking *through* rather than *at*.
+
+### Why this voice can exist at all
+
+Vervaeke's mechanism for escaping a bad frame is the **notice-invariance heuristic** (Kaplan & Simon 1990): find what stayed the same across your failed attempts, and change that. He then names why nobody applies it:
+
+> in order to apply it, you have to keep good track of your failures. And you have to be really willing to look at them very carefully. You don't like to do that. I don't like to do that.
+
+Thought Threads *is* that record — the same person returning to the same unresolved thing, across weeks, in their own voice, with the linguistic texture of each return preserved. No journal, no chat session, and no wearable holds this. Oblique is the payoff for having built Threads.
+
+### Division of labour
+
+**Layer 1 — deterministic, on-device, enters the prompt as context:**
+
+```
+**Unchanged:**
+'father' and 'money' have appeared in 4 of 4 walks together, never apart.
+'work' has returned across 5 walks; salience steady, marker profile flat.
+Every walk where 'money' appears is obligation-dominant ('should' ×14 avg).
+```
+
+**Layer 2 — the model, what the walker reads:**
+
+> *You've walked with your father five times this month. Money came too, every single time — you have never once set out with one and left the other at home. And both arrive the same way, as things owed.*
+>
+> *Four of these walks you framed as being about money. It may be that money was never the subject.*
+
+### Architecture
+
+New file `Pilgrim/Models/Threads/DossierSensesInvariance.swift`, extending `DossierSenses` exactly as `DossierSensesTracks.swift` does. New entry point `DossierSenses.invarianceLines(input:) -> [String]`, parallel to `lines(input:)`, under the same binding purity contract: no `DataManager`, no `CoreStore`, no singleton access, and `Date()` is never called — time arrives as data.
+
+`DossierSenses.Input` gains one field:
+
+```swift
+let historicalContexts: [TranscriptContext]
+```
+
+wired from the fetch `ThreadsDossierBuilder` **already performs** to feed `ThreadsDossierFormatter.dossier(allContexts:)`. This is a widened hand-off, not a new query. No new build-time fetch cost.
+
+`ActivityContext` gains `var unchangedBlock: String?`, following the existing `var threadsDossier: String?` pattern (set post-construction by the builder).
+
+**Critical constraint:** `PromptGenerator.generateAll` maps one `ActivityContext` across `PromptStyle.allCases`, and `resolvedDerivations` computes language detection and directives once for all styles. PR #65's perf wave established this single-pass property. Therefore `unchangedBlock` is **built once** with the rest of the dossier and merely *emitted* by `PromptAssembler` when the voice requests it. Per-voice variation happens at assembly time, never at dossier-build time.
+
+`PromptStyle` gains `case oblique` — title "Oblique", description "What has not moved". Icon chosen at implementation against the rendered picker; candidates `arrow.trianglehead.branch`, `circle.dotted`, `eyeglasses`.
+
+### The four shipping signals
+
+All thresholds below are **starting values, subject to revision at the field gate**, following the precedent of `ThemeExtractor.minimumMentions` and the `questionDensity` cut. Priority order is declaration order in the `Invariant` enum, matching the `Sense.allCases` convention. Cap 3 lines.
+
+| # | Signal | Fires when | Inputs |
+|---|---|---|---|
+| 1 | **Fused themes** | Two themes' walk-sets are identical or one nests in the other, across ≥3 shared walks, and the nested set has ≥3 members | `threads` (existing) |
+| 2 | **Unmoved return** | ≥3 appearances, `salienceDirection == .steady`, and marker profile variance below threshold across appearances | `threads` + `historicalContexts` (new) |
+| 3 | **Frame constancy** | One `ModalFamily` is dominant in every walk where the theme appears, across ≥3 walks | `threads` + `historicalContexts` (new) |
+| 4 | **Place-frame lock** | Same theme within the same 150m cluster (`placeClusterRadius`) across ≥3 walks | `threads` + `fixes` (existing) |
+
+Feasibility is confirmed: `ThreadAppearance` carries `recordingUUID`, `walkUUID`, `date`, `mentionCount`, and `salience`, so both the marker lookup (`historicalContexts` keyed by `recordingUUID`) and the place lookup (`fixes[recordingUUID]`) resolve. `ThreadsDossierBuilder.resolveFixes` already takes `threads:` and populates fixes for thread appearances, not just current recordings.
+
+Signal 2's "marker profile variance" is defined as: coefficient of variation across appearances of absolutist rate, first-person rate, and sentiment, **each ≤ 0.20** (starting value), computed only over appearances whose context clears `ThreadsDossierFormatter.densityFloorWords` (100). At least 3 appearances must clear that floor. Appearances below it are excluded, not counted as flat — a short recording is not evidence of sameness. Sentiment CV is computed on the shifted range `sentiment + 1.0` to keep the denominator away from zero, since NLTagger sentiment spans −1…1 and a mean near zero would make raw CV explode.
+
+Signal 3 reuses `MarkerLexicons.ModalFamily` (`possibility`, `obligation`, `counterfactual`, `tentative`, `intention`, `desire`) and the existing per-context `markers.modalCounts`. Dominance is per-walk mode, mirroring the `weatherWeave` majority→mode fix from PR #71 that killed the cloud tautologies.
+
+**Held dark behind a flag** — `DossierSensesInvariance.pendingFieldGate = true`, mirroring `ThreadIntentionSuggestions.pendingFieldGate`:
+
+| # | Signal | Fires when |
+|---|---|---|
+| 5 | **Unarrived intention** | An intention was set around a lemma on ≥3 walks and that lemma's thread is still `.steady` |
+
+This is the most confronting line the app could produce — it says, in effect, *you have deliberately tried and nothing moved*. The engine ships with tests; the flag flips only after the field gate judges it on real history.
+
+### Availability
+
+Oblique requires **both**:
+- ≥5 walks with transcribed recordings (history depth), and
+- transcribed speech on the **current** walk
+
+The second gate follows from the architecture: `ThreadsDossierFormatter.dossier` returns `nil` when `currentRecordings.isEmpty`, so a silent walk produces no dossier and therefore no `Unchanged:` block. History-only Oblique on a silent walk is a **deferred open question** (§Deferred), not a v1 feature.
+
+In the picker Oblique is **visible but unselectable** until both gates pass, dimmed, with the copy:
+
+> **Oblique** — *Still listening. A few more walks with your voice.*
+
+"Still listening" is true for either failing gate — insufficient history, or no voice on this walk — so one string covers both without lying. It reads as the voice needing to hear more, not as a level to grind, which keeps it clear of the streak-pressure mechanics the app deliberately refuses.
+
+If `hasInsight` is false (no invariant fires despite gates passing), Oblique remains selectable and the assembler omits the `Unchanged:` block; the voice then reads the walk without invariance material. This is the one case where Oblique degrades rather than hides, because the gates already promised availability.
+
+### Voice text
+
+**Preamble (`hasSpeech: true`):**
+
+> This walker keeps a record. Across many walks they have returned, without planning to, to the same few things. What follows includes what has *not* changed across those returns — patterns in their own language that they cannot see, because these are the terms they think in rather than the terms they think about.
+
+**Instruction (`hasSpeech: true`):**
+
+> Work from the invariants named under **Unchanged**. Name what the walker has been treating as fixed — the assumption they have been looking through rather than at — and offer one specific alternative reading of that structure. Be concrete about the shape, not about what it means for their life.
+
+**Response constraints (4 lines):**
+
+1. Build only on the invariants named under **Unchanged** — never assert a pattern that block does not show.
+2. Name one thing. An insight that can be carried is single, not a list.
+3. Offer a specific alternative reading of the structure; never a contentless instruction to reframe. Do not write "perhaps consider", "try seeing", "from another perspective", or "outside the box".
+4. End on the observation. Do not resolve it and do not prescribe an action — the walker does that part.
+
+`hasSpeech: false` variants exist for protocol conformance and are unreachable given the availability gates; they return the `hasSpeech: true` text rather than dead placeholder prose.
+
+### Block placement
+
+Per the approved context-scope decision, Oblique receives the **full** dossier with `Unchanged:` **hoisted** above the context dossier, plus a re-anchor in the closing instruction. Since input cannot be narrowed, the output constraint carries the weight omission would have — constraint 2 above is load-bearing, not stylistic — and the sandwich uses recency to do what deletion would otherwise do.
+
+---
+
+## Workstream 2 — Interpretive keys
+
+**Problem.** The dossier ships rich signals raw and the model guesses. `ThreadsDossierFormatter.markerLine` emits absolutist and first-person percentages; `modalLeanLine` emits `modal lean: obligation — 'should' ×31 (your usual ~8 per walk)`. A model's default read of "should ×31" is *this person is being hard on themselves*. The correct read is entirely different: obligation names the **shape of the frame they were thinking inside**.
+
+**Fix.** One line added to `PromptAssembler.responseContract`, in the `hasThreadsDossier` branch alongside the existing clinical-language guard:
+
+> Read absolutist density as how fixed the walker's framing was, first-person density as how far they placed themselves at the centre of it, and the modal lean as the frame they were working inside — obligation means the frame constrained them, counterfactual means they were already replaying alternatives, possibility and tentative mean it was still open. None of these has a fixed meaning; read each through this walk's intention and practice.
+
+The closing clause is Fodor's point: "it will be windy tomorrow" holds its truth while its relevance shifts entirely depending on whether the walker is sailing, flying a kite, or staying in. A first-person spike on a grief walk and on a planning walk are not the same fact.
+
+**Cost.** +1 contract line, zero computation, applies to every dossier-carrying voice. This is the spec's one accretion; Workstream 4 removes an always-on firing rule to partly offset it. Justified because it converts three already-shipping raw signals into readable ones.
+
+The existing clinical-language guard is **retained unchanged** — it is the safety line, and the new line is an interpretive one.
+
+---
+
+## Workstream 3 — Goodman fix on Reflective
+
+**Problem.** `WalkPromptVoices.swift` `ReflectiveVoice.instruction(hasSpeech: true)` asks:
+
+> What connections do you see between the different moments? [...] What contradictions or tensions are present?
+
+Both are unbounded. Per Principle 2 the model will always find connections and will manufacture tension when asked for it, on walks where none exists.
+
+**Fix.** Bind both to the walk's own evidence. Revised instruction:
+
+> Please analyze these walking reflections for patterns, recurring themes, and emotional undercurrents. Where the walk's own record supports it — the stated intention, a word that recurs, a shift in pace or marker profile — name what connects the moments. Where it does not, say less rather than reaching. Note any genuine tension the record shows, and do not manufacture one. Offer observations that help me understand myself better.
+
+The `hasSpeech: false` variant gets the parallel treatment for its "What patterns do you see?" clause.
+
+**Cost.** No contract lines. Prose-only change to one voice.
+
+---
+
+## Workstream 4 — `firstVersusLast` gating
+
+**Problem.** In `AttentionDirectives`:
+
+```swift
+private static func firstVersusLast(_ context: ActivityContext) -> String? {
+    guard context.recordings.count >= 2 else { return nil }
+    return "Compare the first recording with the last — measure what changed in the walker between them."
+}
+```
+
+Unconditional on ≥2 recordings, so it fires on nearly every spoken walk, and it **presupposes its conclusion**. Told to measure what changed, the model finds change — including on walks where nothing did. This is the same defect that killed `questionDensity` at the 2026-08-25 gate: it fires plausibly and is wrong.
+
+**Fix.** Gate on a delta the system already computes. Fire only when at least one of the following clears its threshold between the first and last recording:
+
+- sentiment delta ≥ 0.3 (absolute)
+- absolutist rate delta ≥ 50% relative, both recordings clearing `densityFloorWords`
+- words-per-minute delta ≥ `paceDifferenceThreshold` (0.15)
+
+When it fires, the directive names *which* signal moved rather than asking for an open-ended comparison, so the model is pointed at something real:
+
+> The walker's [signal] shifted between the first recording and the last — attend to what moved between them.
+
+When nothing cleared, the directive stays silent and `maxDirectives` budget goes to a detector with something to say.
+
+**Cost.** Removes one always-on firing rule. Net −1 against the accretion budget.
+
+---
+
+## Workstream 5 — Context policy mechanism
+
+**Problem (live defect).** `PromptAssembler.assemble` builds one dossier and every voice receives all of it. `JournalingVoice` — whose instruction is *"turn these scattered walking thoughts into a coherent journal entry... preserving my authentic voice"* — currently receives absolutist percentages, sentiment scores, and modal lean lines, which land in an entry the walker rereads years later. `CreativeVoice` is asked for a poem while holding a sentiment score. `GratitudeVoice` receives marker profiles it has no use for.
+
+**Fix.** A declarative per-voice context policy on the `PromptVoice` protocol, using the existing default-implementation extension pattern so `CustomPromptStyle` is unaffected:
+
+```swift
+protocol PromptVoice {
+    // existing members...
+    var contextPolicy: PromptContextPolicy { get }
+}
+
+extension PromptVoice {
+    var contextPolicy: PromptContextPolicy { .full }
+}
+```
+
+`PromptContextPolicy` declares which already-computed blocks are emitted. It is a **filter at assembly time on a context built once** — it must not cause any block to be computed per-voice, which would break the `generateAll` single-pass property.
+
+**Applied narrowly in this spec:**
+
+| Voice | Policy |
+|---|---|
+| Oblique | `.full` + `unchangedBlock` hoisted |
+| Creative | `.full` minus marker lines and thread analysis |
+| Journaling | `.full` minus marker lines |
+| Gratitude | `.full` minus marker lines and thread analysis |
+| Contemplative, Reflective, Philosophical | `.full` (unchanged) |
+
+"Minus marker lines" suppresses the per-recording marker line and the modal lean clause from `ThreadsDossierFormatter.dossier` output. The thread section, `Quiet this walk`, and `Noticed:` are governed separately so the suppression is legible rather than all-or-nothing.
+
+**The full six-voice matrix is deferred** (§Deferred). It changes output for every voice and needs its own LLM-readback pass; folding it here would produce a spec that cannot be reviewed coherently.
+
+---
+
+## Non-goals
+
+- `Unchanged:` for voices other than Oblique. It is the differentiator; sharing it collapses Oblique into Reflective.
+- Embedding-based theme clustering. Still parked from the Threads field gate, and Principle 2 sharpens the caution: naive nearest-neighbour supplies no relevance criterion. Any future version must be intention-conditioned.
+- Reducing `AttentionDirectives.maxDirectives`. There is a real argument the prompts are over-directed (4 directives + 3 `Noticed:` lines + dossier exceeds the chunking bound, and Principle 4 says the added heuristics carry uncounted cost), but this is a field-test question, not an armchair one. Recorded in Deferred.
+- Any change to the Threads engine, `ThemeExtractor`, `MarkerAnalyzer`, or schema. `TranscriptContext.schemaVersion` is **not** bumped — no derived-cache semantics change, so the "derived-cache-semantics-are-schema" rule from the build-108 field bug does not trigger.
+
+---
+
+## Testing
+
+**Unit — `DossierSensesInvariance`.** Pure-module tests mirroring `DossierSensesTracks` coverage: one fires/does-not-fire pair per signal, threshold boundary cases, the density-floor exclusion in signal 2, cap-3 truncation, priority ordering, and lemma suppression across signals (a theme named by a higher-ranked invariant never reappears, matching the `used` set belt in `DossierSenses.lines`).
+
+**Unit — availability.** Both gates independently: history-deep + silent walk → unavailable; history-shallow + speech → unavailable; both pass → available; both pass but no invariant fires → available with no block.
+
+**Unit — dark flag.** Signal 5 engine tested directly; `pendingFieldGate = true` verified to suppress it from assembled output.
+
+**Unit — assembler.** Snapshot per voice confirming `unchangedBlock` appears only for Oblique and is hoisted above the context dossier; confirming marker lines are absent for Creative, Journaling, and Gratitude and present for the other three; confirming `CustomPromptStyle` still receives `.full` via the protocol default.
+
+**Unit — directives.** `firstVersusLast` fires on each qualifying delta and stays silent when none clears; the freed budget slot is confirmed to promote a lower-ranked detector.
+
+**Regression.** The existing sentiment per-sentence-averaging pin stays green. Suite baseline is 1388; expect growth, no reductions. Lint baseline is whatever `main` currently reports — confirm before starting and hold it at zero new warnings; the Threads ledger records the adjudicated exceptions.
+
+**DEBUG harness.** Extend the `--senses-field-report` pattern with `--invariance-field-report`, evaluating every invariant uncapped across all walks with transcribed recordings, printing per-signal firing rates and every emitted line. Same discipline as the senses harness: evaluate only, never write defaults, never consume real state.
+
+---
+
+## Field gate
+
+Binding before **external** release. Internal TestFlight may precede it.
+
+1. **Firing-rate pass** on real device history via `--invariance-field-report`. Judge degeneration (fires on nearly every walk) and dead signals (nearly never), per signal. Same known limitations as the senses harness: it skips stale-context self-heal and ignores the `threadsAfterWalks` toggle.
+
+2. **Harm check — new, and required by Principle 4.** The existing harness measures firing rate, which is the upside only; the no-free-lunch theorem guarantees a matching downside that firing rate is structurally blind to. For a sample of walks, generate the Oblique reflection **with** and **without** the `Unchanged:` block and human-rate which is better. A signal that fires often and makes reflections worse is the failure mode `questionDensity` only escaped because it was loud. This check applies to Workstream 2 as well — interpretive keys with and without.
+
+3. **LLM-readback QA.** Paste real Oblique prompts, including elevated marker profiles, into ChatGPT/Claude. Iterate until: no clinical language, no contentless reframe instruction, no invented invariant, one thing named rather than a list. Confirm the model does not smuggle the pivot back in through a closing question.
+
+4. **Signal 5 judgement.** Decide on `pendingFieldGate` for the unarrived intention only after 1–3 pass, and only on real history.
+
+5. **Record outcomes** in this document's Deferred section before any Stage-2 work.
+
+---
+
+## Deferred / open questions
+
+- **Full six-voice context matrix.** Mechanism ships here; broad application needs its own spec and readback pass.
+- **History-only Oblique on silent walks.** Would require an `Unchanged:` build path independent of `currentRecordings.isEmpty`. Deferred as YAGNI; revisit if walkers ask for it.
+- **`maxDirectives` reduction / shared directive+sense budget.** Field-test question. Principle 4 and Principle 6 both suggest 7+ pointers is past the peak.
+- **Hoisting "do not summarize the walk back to the walker; they were there"** from `ContemplativeVoice` into the shared contract. It is Cherniak's relevant-implication point and every voice needs it; hoisting replaces rather than adds, so it fits the accretion budget. Cut from this spec only for scope.
+- **Output chunk cap** ("at most three things worth carrying") for Reflective, Philosophical, and Gratitude — not Creative or Journaling, where the output is not a list of observations.
+- **Direction-aware `recurringWord`.** `ThreadStore.salienceDirection` already knows rising/steady/fading; the directive currently says "it may be doing quiet work" for all three.
+- **Icon choice** for Oblique, decided against the rendered picker.
+- **Non-English walks.** `markerLine` already degrades to "Markers unavailable (non-English recording)"; signals 2 and 3 will therefore never fire for them, while 1 and 4 still can. Whether that asymmetry is acceptable, or Oblique should gate on marker availability, is unresolved.
+
+---
+
+## Risks
+
+1. **Oblique collapses into Reflective.** Mitigated by the anchoring constraint (build only on `Unchanged:`), by Reflective's Goodman fix pulling it toward evidence-bound observation, and by the picker copy. Verified at readback.
+2. **Invented invariants.** The highest-severity failure: an LLM told to stitch a meta-frame is maximally Goodman-exposed. Mitigated by constraint 1 and checked explicitly at readback.
+3. **Small-N noise.** Co-occurrence over 3 walks is thin. Thresholds are starting values and the gate is the arbiter, per the `questionDensity` precedent.
+4. **Invasiveness.** "You have never spoken about X without Y" is a large claim about a person. Signal 5 is dark for exactly this reason; the Honest intensity level was chosen deliberately over Unflinching.
+5. **Build-time cost.** No new fetches, but signals 2 and 3 iterate `historicalContexts` per thread. The honest budget is ~0.3s median cold (context loading + sense math, with a 2.66s outlier already on the optimization list). Invariance math must be measured against that, memoized on the same key, and kept off-main.
+6. **Picker gate reads as gamification.** Mitigated by copy register — "Still listening" frames the voice as needing to hear more, not as an unlock. Revisit if it lands wrong on device.

--- a/docs/superpowers/specs/2026-08-27-oblique-and-prompt-relevance-design.md
+++ b/docs/superpowers/specs/2026-08-27-oblique-and-prompt-relevance-design.md
@@ -145,7 +145,9 @@ Per the approved context-scope decision, Oblique receives the **full** dossier w
 
 **Fix.** One line added to `PromptAssembler.responseContract`, in the `hasThreadsDossier` branch alongside the existing clinical-language guard:
 
-> Read absolutist density as how fixed the walker's framing was, first-person density as how far they placed themselves at the centre of it, and the modal lean as the frame they were working inside — obligation means the frame constrained them, counterfactual means they were already replaying alternatives, possibility and tentative mean it was still open. None of these has a fixed meaning; read each through this walk's intention and practice.
+> Read the absolutist-word share as how fixed the walker's framing was, self-focus as how far they placed themselves at the centre of it, and the modal lean as the frame they were working inside — obligation means the frame constrained them, counterfactual means they were already replaying alternatives, possibility and tentative mean it was still open, intention means they had settled on a course, and desire means they were naming a want rather than a plan. None of these has a fixed meaning; read each through this walk's intention and practice.
+
+The labels ("absolutist-word share", "self-focus") match what `ThreadsDossierFormatter` actually prints, not a paraphrase of it. The key names all six `MarkerLexicons.ModalFamily` cases — `possibility`, `obligation`, `counterfactual`, `tentative`, `intention`, `desire` — not a subset: naming only four invites the model to back-fit an unnamed family (`intention`, `desire`) onto the nearest named one, and `desire` in particular is high-frequency in spoken reflection ("want", "need", "wish"), so an unnamed reading of it would surface often.
 
 The closing clause is Fodor's point: "it will be windy tomorrow" holds its truth while its relevance shifts entirely depending on whether the walker is sailing, flying a kite, or staying in. A first-person spike on a grief walk and on a planning walk are not the same fact.
 
@@ -193,7 +195,9 @@ Unconditional on ≥2 recordings, so it fires on nearly every spoken walk, and i
 Fire only when at least one clears its threshold between the **first** and **last** recording:
 
 - **Pace:** `wordsPerMinute` delta ≥ 15% relative. Free — `RecordingContext.wordsPerMinute` is already populated. Skipped when either value is `nil`.
-- **Subject:** Jaccard similarity of content-lemma sets ≤ 0.20 — they are no longer talking about the same thing. Costs exactly two `TranscriptNLP.contentLemmas(in:)` passes (first and last recording only, never all N). Requires both recordings to yield ≥ 5 content lemmas, so a two-word recording cannot manufacture divergence.
+- **Subject:** overlap coefficient of content-lemma sets (`intersection.count / min(firstLemmas.count, lastLemmas.count)`) ≤ 0.20 — they are no longer talking about the same thing. Costs exactly two `TranscriptNLP.contentLemmas(in:)` passes (first and last recording only, never all N). Requires both recordings to yield ≥ 5 content lemmas, so a two-word recording cannot manufacture divergence.
+
+  **Not Jaccard.** An earlier draft of this workstream specified Jaccard similarity (`intersection / union`). Jaccard collapses to `|smaller| / |larger|` whenever one lemma set is a subset of the other, which is exactly the shape of a long opening reflection followed by a short closing note on the *same* subject: ~32 unique lemmas in the opening, a 6-lemma closing note drawn entirely from that same vocabulary, Jaccard ≈ 6/32 ≈ 0.19 — under the 0.20 ceiling, so it would fire "shares little vocabulary" on a walk that never left its subject. The overlap coefficient is 1.0 for that same subset case (correctly silent) and still near 0 for genuinely divergent subjects, because it measures how much of the *smaller* recording's vocabulary is accounted for by the larger one, rather than penalizing a short recording for being short relative to a long one.
 
 When it fires, the directive names *which* signal moved, so the model is pointed at something real rather than asked to hunt:
 


### PR DESCRIPTION
Three defects in the prompt system, fixed. Plus the spec and plans for a seventh voice, committed but not yet built.

Origin: a John Vervaeke lecture on relevance realization — the meta-problem of ignoring almost everything and zeroing in on what matters. That is structurally what the Thought Threads dossier already does, so the talk read less like inspiration and more like a spec review. Three things it found:

## The model was guessing at numbers we hand it

The dossier ships absolutist density, self-focus, and a modal lean into every prompt as bare figures. A model's default read of `should ×31` is *this person is being hard on themselves*. The reading that is actually true is different — obligation names the shape of the frame they were thinking inside, counterfactual means they were already replaying alternatives.

One contract line, no new computation. The clinical-language guard stays exactly as it was: that line keeps the reading safe, this one makes it possible.

The whole-branch review caught that my first version named only four of the six `ModalFamily` cases. `.intention` ("will") and `.desire` ("want/need/wish") are among the most common modals in speech, so `modal lean: desire — 'want' ×18` renders regularly and the model back-fits it onto the nearest named family — the exact misread the line exists to prevent. All six are named now, and the test iterates `ModalFamily.allCases` so a seventh case cannot be added without updating the line.

## Reflective was asking for connections that always exist

*"What connections do you see between the different moments?"* is unbounded, and Goodman settled what happens next: any two things share indefinitely many true properties. A lawn mower and a plum both have rounded edges, contain carbon, and weigh more than a paperclip. So the model always connects, always sounds insightful, and is arbitrary. Asking for contradictions the same way manufactures tension on walks that had none.

Similarity only does work once relevance is supplied from outside it. Both branches now bind to the walk's own record — the stated intention, a word that recurs, a shift in pace — and are told to say less rather than reach.

## firstVersusLast was presupposing its own conclusion

It fired on every walk with two recordings and told the model to *measure what changed in the walker*. Told that, the model finds change, including on the walks where nothing did. Same disease that killed `questionDensity` at the last gate, only quieter: it fires plausibly and it is wrong.

Now it fires only when something moved, and names which. Pace comes free from `wordsPerMinute`; subject costs two bounded lemma passes on the first and last recording, never all N — PR #55's single-pass property is preserved.

Marker and sentiment deltas would have been better signals and are deliberately absent: they are unreachable from `ActivityContext`, which carries no structured marker data, and reaching them would have undone that same single-pass work.

The review also caught a real math error here. Jaccard is `intersection / union`, which for a subset collapses to `|smaller| / |larger|` — so a long opening reflection followed by a short closing note **on the same subject** scored 0.175, cleared the ceiling, and fired "shares little vocabulary." Manufactured change, straight back in through the metric. Now an overlap coefficient, which returns 1.0 for that case and stays correctly silent. This mattered more than it looked: `wordsPerMinute` is persisted asynchronously and is nil on the walk-recovery path, so the subject branch is the effective path right after a walk ends.

## Also here, not yet built

`docs/superpowers/specs/2026-08-27-oblique-and-prompt-relevance-design.md` and two plans. Oblique is a seventh voice that reads what has *not* moved across a walker's history and names the frame they have been looking through rather than at. Its whole discipline comes from one finding: Weber et al. 1981 told subjects stuck on the nine-dot problem to "think outside the box" and it helped nobody. A contentless instruction to reframe does not transfer; a specific, structurally-grounded alternative reading does.

## Testing

`-only-testing:UnitTests` — **1407 started, 1407 passed, 0 failed.** 1388 baseline + 19 new.

Every task passed a spec-compliance and code-quality review; the whole-branch review returned two Important findings, both fixed above and re-verified.

## Not done yet

Task 4 of the relevance plan is manual device QA and has not run: the with/without harm check on the interpretive key, and the observed `firstVersusLast` firing rate on real history. Firing rate measures only the upside — no free lunch guarantees a matching downside it is structurally blind to. That readback gates external release, not merge.

Known minors carried forward and deliberately not fixed here: no language gate on the subject branch (inflected non-English inflates apparent divergence); `firstVersusLast` sits last in the directive array so `.prefix(4)` drops it first now that it is meaningful; `paceShift` (GPS speed) and the new pace branch (speaking rate) can both fire and disagree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)