### PR TITLE
The theme layer was losing real words

### DIFF
--- a/Pilgrim/Models/Threads/ThemeExtractor.swift
+++ b/Pilgrim/Models/Threads/ThemeExtractor.swift
@@ -62,9 +62,15 @@ enum ThemeExtractor {
 
     /// Nouns only — verbs and adjectives dominated raw-frequency ranking
     /// with spoken scaffolding ("was", "have", "can", "think") on real
-    /// devices, never the topical content underneath it.
+    /// devices, never the topical content underneath it. The noun class is
+    /// necessary but not sufficient: NLTagger also calls 'yeah' a noun, so
+    /// `SpokenStoplist.filler` carries what lexical class cannot.
     private static func mentions(in text: String) -> [TranscriptNLP.LemmaMention] {
         TranscriptNLP.contentLemmaMentions(in: text, classes: [.noun])
-            .filter { !walkingDomain.contains($0.lemma) && !SpokenStoplist.lightNouns.contains($0.lemma) }
+            .filter {
+                !walkingDomain.contains($0.lemma)
+                    && !SpokenStoplist.lightNouns.contains($0.lemma)
+                    && !SpokenStoplist.filler.contains($0.lemma)
+            }
     }
 }

--- a/Pilgrim/Models/Threads/ThreadsBackfill.swift
+++ b/Pilgrim/Models/Threads/ThreadsBackfill.swift
@@ -5,7 +5,7 @@ import Foundation
 /// once history is fully analyzed (spec: ThreadStore).
 enum ThreadsBackfill {
 
-    static let completedKey = "threadsBackfillCompletedV6"
+    static let completedKey = "threadsBackfillCompletedV7"
     /// v1.11.0 TestFlight devices could run the sweep, account for zero
     /// recordings under a snapshot bug (fixed alongside the V2 rename), and
     /// still set the old flag — stranding those devices on a never-swept
@@ -30,13 +30,20 @@ enum ThreadsBackfill {
     /// `days`, `area` to `SpokenStoplist.lightNouns` (schema v3→v4), a
     /// narrower theme-extraction change than V2→V3's — like V4→V5, no
     /// moon-line re-arm accompanies it; `performLegacyHygiene` still only
-    /// watches the V3 key.
+    /// watches the V3 key. V7 (field report, 2026-08-28) adds
+    /// `SpokenStoplist.filler` and `time`/`person`/`app`, and stops
+    /// punctuation from reaching a lemma at all (schema v4→v5) — a V6 sweep's
+    /// themes can name 'yeah' or print 'yeah.'. Same shape as V5→V6, so again
+    /// no moon-line re-arm; `performLegacyHygiene` still only watches the V3
+    /// key.
     private static let legacyCompletedKeyV3 = "threadsBackfillCompletedV3"
     private static let legacyCompletedKeyV4 = "threadsBackfillCompletedV4"
     private static let legacyCompletedKeyV5 = "threadsBackfillCompletedV5"
+    private static let legacyCompletedKeyV6 = "threadsBackfillCompletedV6"
     private static let legacyCompletedKeys = [
         "threadsBackfillCompleted", "threadsBackfillCompletedV2",
-        legacyCompletedKeyV3, legacyCompletedKeyV4, legacyCompletedKeyV5
+        legacyCompletedKeyV3, legacyCompletedKeyV4, legacyCompletedKeyV5,
+        legacyCompletedKeyV6
     ]
     private static var isRunning = false
     private static var generation = 0
@@ -72,8 +79,8 @@ enum ThreadsBackfill {
 
     static let batchSize = 25
 
-    /// One-time hygiene ahead of the `isComplete` check below: the pre-V4
-    /// keys no longer mean anything, and removing an absent key is a
+    /// One-time hygiene ahead of the `isComplete` check below: every
+    /// superseded key no longer means anything, and removing an absent key is a
     /// harmless no-op on every call after the first. The V3 key's presence
     /// — captured before removal — is also the moon-line re-arm signal
     /// (item 2): only a device that completed the stale-theme V3 sweep ever

--- a/Pilgrim/Models/Threads/TranscriptContext.swift
+++ b/Pilgrim/Models/Threads/TranscriptContext.swift
@@ -22,7 +22,17 @@ struct TranscriptContext: Codable, Equatable {
     /// `days`, `area` — a v3 file's stored themes may still carry one of
     /// those as a generic noun rather than topical content, so the bump
     /// forces re-analysis under `ThemeExtractor`'s tightened stoplist.
-    static let currentSchemaVersion = 4
+    ///
+    /// v5 (field report, 2026-08-28): two extractor changes, both making a v4
+    /// file's themes wrong rather than merely coarse. `TranscriptNLP` now
+    /// reduces every lemma and surface to its leading run of letters — a v4
+    /// file can hold 'yeah.' as a thread identity and print it as a Recurring
+    /// chip, and can hold one real noun split across two lemmas by a
+    /// swallowed sentence period. And `SpokenStoplist` gained `filler`
+    /// (conversational 'yeah'/'okay'/'hmm', which NLTagger classes as nouns)
+    /// plus `time`/`person`/`app` in `lightNouns`. The bump forces every
+    /// stored recording to re-analyze under both.
+    static let currentSchemaVersion = 5
 
     let schemaVersion: Int
     let recordingUUID: UUID

--- a/Pilgrim/Models/Threads/TranscriptNLP.swift
+++ b/Pilgrim/Models/Threads/TranscriptNLP.swift
@@ -49,21 +49,42 @@ enum TranscriptNLP {
             options: [.omitPunctuation, .omitWhitespace, .omitOther]
         ) { tag, range in
             guard let tag, classes.contains(tag) else { return true }
-            let surface = String(text[range]).lowercased()
-            guard surface.count > 2 else { return true }
-            let lemma = tagger.tag(at: range.lowerBound, unit: .word, scheme: .lemma)
-                .0?.rawValue.lowercased() ?? surface
+            let token = String(text[range])
+            let core = letterCore(token)
+            guard core.count > 2 else { return true }
+            let surface = core.lowercased()
+            let taggedLemma = tagger.tag(at: range.lowerBound, unit: .word, scheme: .lemma)
+                .0.map { letterCore($0.rawValue).lowercased() } ?? ""
             lastOffset += text.distance(from: lastIndex, to: range.lowerBound)
             lastIndex = range.lowerBound
             mentions.append(LemmaMention(
-                lemma: lemma,
+                lemma: taggedLemma.isEmpty ? surface : taggedLemma,
                 surface: surface,
-                start: lastOffset,
-                length: text.distance(from: range.lowerBound, to: range.upperBound)
+                start: lastOffset + token.prefix { !$0.isLetter }.count,
+                length: core.count
             ))
             return true
         }
         return mentions
+    }
+
+    /// The leading run of letters, skipping any non-letters before it.
+    ///
+    /// NLTagger's `.word` unit does not always end a token at the word: when
+    /// a sentence-final period is followed by a lowercase word — the shape
+    /// Whisper writes — the token range swallows the period ("yeah.",
+    /// "garden.", "mary.") and the token is classed as a content word, so
+    /// `.omitPunctuation` never sees it. Left alone, the tagger then has no
+    /// lemma for that glued form and the `?? surface` fallback stores the
+    /// punctuation as thread identity: 'yeah' and 'yeah.' become two lemmas
+    /// for one spoken word, and a real noun's mentions split across two
+    /// threads. Field-confirmed on device (2026-08-28) as a fabricated
+    /// "never apart" invariant and as a Recurring chip printing "yeah.".
+    ///
+    /// Reducing to the leading letter run also repairs the no-space case
+    /// ("garden.the" → "garden"), where the token glues two words together.
+    private static func letterCore(_ token: String) -> String {
+        String(token.drop { !$0.isLetter }.prefix { $0.isLetter })
     }
 
     static func contentLemmas(in text: String) -> [String] {
@@ -144,10 +165,41 @@ enum SpokenStoplist {
     /// history showed place resonance threading 'day' (17 mentions near the
     /// same ground) and photo adjacency threading 'area' — the same
     /// generic-noun class as `thing`/`way`, not topical content.
+    ///
+    /// `time`/`times`, `person`/`people`, `app`/`apps` joined on 2026-08-28,
+    /// all three observed as live themes on real-device history. `app` is the
+    /// walker narrating Pilgrim itself — meta-noise, never a life theme.
+    /// The filter reads LEMMAS, and NLTagger folds `people` → `person` and
+    /// `times` → `time`, so the singular forms are the ones that do the work;
+    /// the plurals are listed for the reader, and cost nothing.
     static let lightNouns: Set<String> = [
         "thing", "things", "stuff", "kind", "sort", "lot", "bit", "way", "ways",
         "one", "ones", "something", "anything", "everything", "nothing",
-        "day", "days", "area"
+        "day", "days", "area",
+        "time", "times", "person", "people", "app", "apps"
+    ]
+
+    /// Conversational filler filtered out of THEME extraction. The noun-only
+    /// restriction does not stop these: in Whisper's lowercase sentence runs
+    /// NLTagger classes 'yeah' as a NOUN, and the field report of 2026-08-28
+    /// found it threading three real walks.
+    ///
+    /// `ok` sits beside `okay` because NLTagger lemmatizes the surface
+    /// "okay" to "OK" in some positions and "okay" in others — the same fold
+    /// that makes `people` arrive as `person`. The two-letter spellings
+    /// (`um`, `uh`, `er`, `mm`) are absent because `contentLemmaMentions`
+    /// already drops any surface shorter than three characters; the doubled
+    /// spellings Whisper actually writes are what needs listing.
+    ///
+    /// Deliberately NOT here, because every word added blinds the feature to
+    /// that word forever: `right` (a direction on a walk — and already
+    /// covered by `ThemeExtractor.walkingDomain`), `sure`, `yes`, `no`,
+    /// `well`, `like`, `just`, `anyway`. Each can carry real weight in a
+    /// walker's speech; none has been seen misfiring.
+    static let filler: Set<String> = [
+        "yeah", "yep", "yup", "nah", "okay", "ok",
+        "uhh", "umm", "erm", "hmm", "mhm", "mmm", "huh",
+        "gonna", "gotta", "wanna"
     ]
 
     /// Light/auxiliary/modal verbs plus the filler nouns above, filtered out

--- a/UnitTests/AttentionDirectivesTests.swift
+++ b/UnitTests/AttentionDirectivesTests.swift
@@ -240,6 +240,23 @@ final class AttentionDirectivesTests: XCTestCase {
         XCTAssertTrue(joined(context).contains("intention spoke of"))
     }
 
+    /// A guard, not a fix. `recurringWord` filters `scaffoldLemmas`, which
+    /// covers light verbs but not conversational filler, and it reads verbs
+    /// and adjectives as well as nouns — so filler reaching the AI prompt
+    /// looked possible once the theme layer surfaced 'yeah' on real device
+    /// history. It is not reproducible: the tagger classes 'yeah' as an
+    /// interjection in both the bare and the period-glued position, so it
+    /// never enters the mention set. Pinned so that widening the class set,
+    /// or a tagger change, cannot quietly make it true.
+    func testRecurringWord_ignoresConversationalFiller() {
+        let context = ActivityContext.make(
+            recordings: [recording("yeah. the light was low yeah. the ridge went on yeah. the wind kept up yeah. it held")],
+            startDate: start
+        )
+        let text = joined(context)
+        XCTAssertFalse(text.contains("'yeah'"), "filler must never be named as a recurring word")
+    }
+
     func testRecurringWord_countsAcrossInflections() {
         let context = ActivityContext.make(
             recordings: [recording("Moving is hard. We moved before. This move feels different.")],

--- a/UnitTests/ThemeExtractorTests.swift
+++ b/UnitTests/ThemeExtractorTests.swift
@@ -69,4 +69,67 @@ final class ThemeExtractorTests: XCTestCase {
         let themes = ThemeExtractor.themes(in: text, languageCode: "en")
         XCTAssertEqual(themes.map(\.lemma), ["harbor"])
     }
+
+    // MARK: - Conversational filler (field bug, 2026-08-28)
+
+    /// Whisper's lowercase sentence runs make NLTagger class 'yeah' as a NOUN
+    /// (and swallow the following period into the token), so the noun-only
+    /// restriction does not stop it: the real device produced 'yeah' / 'yeah.'
+    /// as a recurring theme across three walks.
+    private let fillerText = "so i was walking. yeah. and then i stopped by the water. yeah. it was " +
+        "fine. yeah. and i kept on going for a while. yeah. and then home. yeah. that was it."
+
+    func testFillerRun_yieldsNoThemes() {
+        XCTAssertTrue(ThemeExtractor.themes(in: fillerText, languageCode: "en").isEmpty,
+                      "conversational filler is not what a walk was about")
+    }
+
+    func testHesitationRun_yieldsNoThemes() {
+        let text = "hmm. i was out again. hmm. the wind was up and the light was going. hmm. i " +
+            "turned back before dark. hmm. that was the whole of it really. hmm."
+        XCTAssertTrue(ThemeExtractor.themes(in: text, languageCode: "en").isEmpty)
+    }
+
+    func testNounAmongFiller_isTheOnlyTheme() {
+        let text = fillerText + " the river was high. the river was high again. i thought about the river."
+        XCTAssertEqual(ThemeExtractor.themes(in: text, languageCode: "en").map(\.lemma), ["river"])
+    }
+
+    /// The chip and the dossier both print `displayTerm`; a theme identity or
+    /// a printed term carrying a period is the punctuation defect one layer
+    /// out, whatever produced it.
+    func testThemeIdentityAndDisplayTerm_carryOnlyLetters() {
+        let text = fillerText + " the river was high. the river was high again. i thought about the river."
+        for theme in ThemeExtractor.themes(in: text, languageCode: "en") {
+            XCTAssertTrue(theme.lemma.allSatisfy(\.isLetter), "theme lemma '\(theme.lemma)'")
+            XCTAssertTrue(theme.displayTerm.allSatisfy(\.isLetter), "displayTerm '\(theme.displayTerm)'")
+        }
+    }
+
+    // MARK: - lightNouns gate: time/times/person/people/app/apps
+
+    /// Observed as live themes on the same real-device history one pass
+    /// before the filler ones surfaced. NLTagger folds `people` → `person`
+    /// and `times` → `time`, so the lemma forms are what the filter sees.
+    func testTimeAndPeople_stoplisted_yieldNoThemes() {
+        let text = "the people were kind and the people walked with me for a time. i met a person " +
+            "by the water and the person spoke of time. time after time the people came back. " +
+            "the times were strange."
+        XCTAssertTrue(ThemeExtractor.themes(in: text, languageCode: "en").isEmpty)
+    }
+
+    /// 'app' is the walker talking about Pilgrim itself — meta-noise, never a
+    /// life theme.
+    func testApp_stoplisted_yieldsNoThemes() {
+        let text = "i opened the app again and the app was slow. the apps on this phone are all " +
+            "slow. i keep opening the app when i should be looking at the water. apps and apps and apps."
+        XCTAssertTrue(ThemeExtractor.themes(in: text, languageCode: "en").isEmpty)
+    }
+
+    func testNounAmongGenericNouns_isTheOnlyTheme() {
+        let text = "i keep thinking about the harbor when the people are around. the harbor at that " +
+            "time of year. person after person passes the harbor and the app is open in my hand. " +
+            "the harbor. apps and time."
+        XCTAssertEqual(ThemeExtractor.themes(in: text, languageCode: "en").map(\.lemma), ["harbor"])
+    }
 }

--- a/UnitTests/ThreadsBackfillTests.swift
+++ b/UnitTests/ThreadsBackfillTests.swift
@@ -18,6 +18,7 @@ final class ThreadsBackfillTests: XCTestCase {
     private static let legacyCompletedKeyV3 = "threadsBackfillCompletedV3"
     private static let legacyCompletedKeyV4 = "threadsBackfillCompletedV4"
     private static let legacyCompletedKeyV5 = "threadsBackfillCompletedV5"
+    private static let legacyCompletedKeyV6 = "threadsBackfillCompletedV6"
 
     private var store: TranscriptContextStore!
     private var directory: URL!
@@ -27,6 +28,7 @@ final class ThreadsBackfillTests: XCTestCase {
     private var savedLegacyCompletedV3: Any?
     private var savedLegacyCompletedV4: Any?
     private var savedLegacyCompletedV5: Any?
+    private var savedLegacyCompletedV6: Any?
     private var savedMoonState: Any?
     private var savedToggle = true
 
@@ -38,6 +40,7 @@ final class ThreadsBackfillTests: XCTestCase {
         savedLegacyCompletedV3 = UserDefaults.standard.object(forKey: Self.legacyCompletedKeyV3)
         savedLegacyCompletedV4 = UserDefaults.standard.object(forKey: Self.legacyCompletedKeyV4)
         savedLegacyCompletedV5 = UserDefaults.standard.object(forKey: Self.legacyCompletedKeyV5)
+        savedLegacyCompletedV6 = UserDefaults.standard.object(forKey: Self.legacyCompletedKeyV6)
         savedMoonState = UserDefaults.standard.object(forKey: ThreadsDossierBuilder.moonLineDefaultsKey)
         savedToggle = UserPreferences.threadsAfterWalks.value
         UserDefaults.standard.set(false, forKey: ThreadsBackfill.completedKey)
@@ -46,6 +49,7 @@ final class ThreadsBackfillTests: XCTestCase {
         UserDefaults.standard.removeObject(forKey: Self.legacyCompletedKeyV3)
         UserDefaults.standard.removeObject(forKey: Self.legacyCompletedKeyV4)
         UserDefaults.standard.removeObject(forKey: Self.legacyCompletedKeyV5)
+        UserDefaults.standard.removeObject(forKey: Self.legacyCompletedKeyV6)
         UserPreferences.threadsAfterWalks.value = true
         directory = FileManager.default.temporaryDirectory
             .appendingPathComponent("ThreadsBackfillTests-\(UUID().uuidString)")
@@ -82,6 +86,11 @@ final class ThreadsBackfillTests: XCTestCase {
             UserDefaults.standard.set(savedLegacyCompletedV5, forKey: Self.legacyCompletedKeyV5)
         } else {
             UserDefaults.standard.removeObject(forKey: Self.legacyCompletedKeyV5)
+        }
+        if let savedLegacyCompletedV6 {
+            UserDefaults.standard.set(savedLegacyCompletedV6, forKey: Self.legacyCompletedKeyV6)
+        } else {
+            UserDefaults.standard.removeObject(forKey: Self.legacyCompletedKeyV6)
         }
         if let savedMoonState {
             UserDefaults.standard.set(savedMoonState, forKey: ThreadsDossierBuilder.moonLineDefaultsKey)
@@ -161,6 +170,32 @@ final class ThreadsBackfillTests: XCTestCase {
 
         XCTAssertFalse(ThreadsBackfill.isComplete,
                        "a device that completed the pre-lightNouns-gate V5 sweep must re-evaluate under the new key")
+    }
+
+    /// V6 devices completed a real sweep under schema v4, but that extractor
+    /// admitted conversational filler ('yeah') as a theme and let a swallowed
+    /// sentence period fork one word into two lemmas ('yeah' / 'yeah.'). The
+    /// V7 rename (schema v5) re-arms them the same way every prior rename
+    /// did: the new key is absent regardless of what the V6 key holds.
+    func testIsComplete_legacyV6KeyTrue_reArmsUnderNewKey() {
+        UserDefaults.standard.set(true, forKey: Self.legacyCompletedKeyV6)
+
+        XCTAssertFalse(ThreadsBackfill.isComplete,
+                       "a device that completed the pre-filler-gate V6 sweep must re-evaluate under the new key")
+    }
+
+    /// Hygiene must reach the V6 key too — an unremoved key is a slow leak of
+    /// meaningless defaults, and the list is the record of every rename.
+    func testRunIfNeeded_removesLegacyV6Key() async {
+        UserDefaults.standard.set(true, forKey: Self.legacyCompletedKeyV6)
+
+        let done = expectation(description: "sweep finished")
+        ThreadsBackfill.runIfNeeded(
+            store: store, snapshotProvider: { [] }, gate: { true }, onFinish: { done.fulfill() }
+        )
+        await fulfillment(of: [done], timeout: 5)
+
+        XCTAssertNil(UserDefaults.standard.object(forKey: Self.legacyCompletedKeyV6))
     }
 
     /// The where-clause skip (`!store.hasContext`) must become version-aware

--- a/UnitTests/TranscriptContextStoreTests.swift
+++ b/UnitTests/TranscriptContextStoreTests.swift
@@ -168,6 +168,22 @@ final class TranscriptContextStoreTests: XCTestCase {
                       "existence still true — only freshness differs")
     }
 
+    /// The v1.11 shipped schema. Its themes were computed by an extractor
+    /// that admitted conversational filler and let a swallowed sentence
+    /// period fork one word into two lemmas, so a v4 file on disk is stale by
+    /// derivation even though it decodes cleanly
+    /// (docs/solutions/derived-cache-semantics-are-schema.md).
+    func testHasCurrentContext_falseForSchemaVersionFour() {
+        let context = TranscriptContext(
+            schemaVersion: 4, recordingUUID: UUID(), transcriptHash: "v4",
+            languageCode: "en", wordCount: 2, themes: [], markers: nil
+        )
+        store.save(context)
+        XCTAssertFalse(store.hasCurrentContext(for: context.recordingUUID),
+                       "the filler/punctuation fix makes every v4-derived context stale")
+        XCTAssertTrue(store.loadAll().isEmpty)
+    }
+
     func testHasCurrentContext_trueForCurrentSchemaVersion() {
         let fresh = makeContext()
         store.save(fresh)

--- a/UnitTests/TranscriptNLPTests.swift
+++ b/UnitTests/TranscriptNLPTests.swift
@@ -43,4 +43,69 @@ final class TranscriptNLPTests: XCTestCase {
     func testRelated_exactMatchNeedsNoEmbedding() {
         XCTAssertTrue(TranscriptNLP.related("move", "move", languageCode: "zz"))
     }
+
+    // MARK: - Punctuation may never reach a lemma (field bug, 2026-08-28)
+
+    /// Whisper writes long lowercase runs, and NLTagger's `.word` unit does
+    /// not split a sentence-final period off the word before it when the next
+    /// word isn't capitalized — the token range swallows the period and the
+    /// token is classed as a content word, so `.omitPunctuation` never sees
+    /// it. These are the shapes that produced 'yeah.' as a real-device theme.
+    private static let punctuationTrapTexts = [
+        "so i was walking. yeah. and then the garden. yeah. it was fine. yeah. okay.",
+        "yeah.yeah.yeah. the garden.the garden.",
+        "i walked to st. mary. mr. jones was there. yeah. etc. and so on.",
+        "i walked 5.5 miles today and it was 5.5 miles",
+        "don't the walk's edge isn't it",
+        "mm-hmm the well-being of the walk mm-hmm"
+    ]
+
+    /// The invariant, independent of which tagger quirk produced it: a lemma
+    /// is a word, so every character in it is a letter.
+    func testContentLemmaMentions_lemmasCarryOnlyLetters() {
+        for text in Self.punctuationTrapTexts {
+            for mention in TranscriptNLP.contentLemmaMentions(in: text) {
+                XCTAssertTrue(
+                    mention.lemma.allSatisfy(\.isLetter),
+                    "lemma '\(mention.lemma)' carries a non-letter (from: \(text))"
+                )
+            }
+        }
+    }
+
+    /// `surface` becomes the displayed term on the Recurring chips and in the
+    /// dossier, so it must be a word too — a chip reading "garden." is the
+    /// same defect one layer out.
+    func testContentLemmaMentions_surfacesCarryOnlyLetters() {
+        for text in Self.punctuationTrapTexts {
+            for mention in TranscriptNLP.contentLemmaMentions(in: text) {
+                XCTAssertTrue(
+                    mention.surface.allSatisfy(\.isLetter),
+                    "surface '\(mention.surface)' carries a non-letter (from: \(text))"
+                )
+            }
+        }
+    }
+
+    /// The fabricated-invariant shape itself: one spoken word must not become
+    /// two lemmas because a period rode along on some of its occurrences.
+    /// Here the first "garden." is the glued token and the other two are
+    /// bare — under the old fallback that read as 'garden.' ×1 and 'garden'
+    /// ×2, two threads where the walker said one word.
+    func testContentLemmaMentions_trailingPeriodDoesNotForkTheLemma() {
+        let text = "i walked for a while. and then the garden. and i sat in the garden and the garden was quiet."
+        let lemmas = TranscriptNLP.contentLemmaMentions(in: text).map(\.lemma)
+        XCTAssertEqual(lemmas.filter { $0 == "garden" }.count, 3)
+        XCTAssertFalse(lemmas.contains("garden."))
+    }
+
+    /// Offsets must still land on the word after the range is narrowed.
+    func testMentions_carryCharacterOffsets_afterPunctuationTrim() {
+        let text = "so i sat in the garden. yeah. the garden again."
+        for mention in TranscriptNLP.contentLemmaMentions(in: text) {
+            let start = text.index(text.startIndex, offsetBy: mention.start)
+            let end = text.index(start, offsetBy: mention.length)
+            XCTAssertEqual(String(text[start..<end]).lowercased(), mention.surface)
+        }
+    }
 }


### PR DESCRIPTION
Thought Threads has been forking real themes in half since v1.11, and nobody could see it because the halves looked like two small themes instead of one real one.

## What was happening

NLTagger does not split a sentence-final period off a word when the next word is lowercase — which is exactly the shape Whisper produces. So the token spans the period, `.omitPunctuation` never sees it, the tagger has no lemma for the glued form, and `contentLemmaMentions`'s `?? surface` fallback writes `"garden."`.

`garden` and `garden.` then live as two distinct lemmas for one word. Say it eight times across walks and it counts as two fours — neither clears the mention floor, and the Recurring chip never appears.

The same class flip is why conversational filler reached a nouns-only extractor at all: bare *yeah* is an Interjection and never gets near `ThemeExtractor`; only glued `yeah.` arrives tagged as a Noun.

## How it surfaced

A field-report harness running against 16 walks of real device history emitted:

> `'yeah' and 'yeah.' have appeared in the same 3 walks, never apart.`

Of course they had. They are the same word.

## The fix

Lemma **and** surface are reduced to the leading letter run — surface too, because it becomes the `displayTerm` the chip prints. Sixteen filler words added to a new stoplist, and `time`/`person`/`app` to the generic-noun list.

Deliberately rejected: *right* (a direction on a walk, and already in `walkingDomain`), *sure*, *yes*/*no* (can be the substance of a walk), *well* (a pilgrim walks to one). Every word added permanently blinds the feature to that word.

Note `people` alone would have filtered nothing — the tagger folds it to `person`, and the extractor filters on lemma. Verified against the shipped tagger rather than reasoned about.

## Verified on real data

Same phone, same history, against the recorded v1.11 gate:

| Sense | v1.11 | After |
|---|---|---|
| `markerColoring` | 3/15 — *agents, friends, car* | **6/16** — *agents, car, character, drones, friends, island* |
| `placeResonance` | 1/15, caught *day* | 0/16 — correct, *day* is stoplisted |
| `photoAdjacency` | 1/15, caught *area* | 1/16, caught *circuit* |

Real themes doubled. *character*, *drones* and *island* are precisely the shape the forking would have halved below the floor. Build time median 0.265s / max 2.584s — unchanged.

## Schema

`TranscriptContext.currentSchemaVersion` 4 → 5, backfill key `V6` → `V7` with V6 in the legacy-hygiene list. Required: this changes how themes are derived, so stored contexts are semantically stale and must re-analyze. Every device does one re-analysis sweep on upgrade — worth a line in the release notes.

## Testing

`-only-testing:UnitTests` — **1433 started, 1433 passed, 0 failed.** 1418 baseline plus 15.

Includes an invariant that no lemma may contain a non-letter, which holds regardless of which tagger quirk produced it, and a guard pinning that filler never becomes a recurring word — investigated, found not reproducible, pinned so it cannot become true quietly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)