### PR TITLE
fix(pods): CombineExt's DemandBuffer no longer traps on a value after a cancel

### DIFF
--- a/Pilgrim.xcodeproj/project.pbxproj
+++ b/Pilgrim.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		11C747B0EAF53D9F444C6243 /* DataSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1066617851420CAB7B50442 /* DataSettingsView.swift */; };
 		126F1949D837CC878A1E6D21 /* HonorMomentTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BB0C825C8EFC112CA91645 /* HonorMomentTracker.swift */; };
 		12B4814A464F4B33A4DFDF5E /* ThreadIntentionSuggestionsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1177FF093DBC4775929CC150 /* ThreadIntentionSuggestionsTests.swift */; };
+		12C6CDFB56CC3A47937E2511 /* CombineExtDemandBufferTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 85218CAD2816EBF40EA0D48C /* CombineExtDemandBufferTests.swift */; };
 		12E3604D72CCECD3C8BC22D8 /* ArchivedWalkPrivacyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5594E7D807E64AEF97963F69 /* ArchivedWalkPrivacyTests.swift */; };
 		13F3292004EFCFD3572E44B9 /* AudioSessionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AE6DC51742E035602E624F1 /* AudioSessionCoordinator.swift */; };
 		141180E7BB8B17200B0BA8EE /* HonorEngine.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FBA0BA40BB22ADE0C73524C /* HonorEngine.swift */; };
@@ -1028,6 +1029,7 @@
 		83BD1C5A8539657B3A5EC6BD /* whisper-presence-4.aac */ = {isa = PBXFileReference; includeInIndex = 1; path = "whisper-presence-4.aac"; sourceTree = "<group>"; };
 		841E96DB07AF435E7D911B50 /* WhisperManifestService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperManifestService.swift; sourceTree = "<group>"; };
 		84222C86D32DD5651B365FE4 /* CollectiveRoute.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CollectiveRoute.swift; sourceTree = "<group>"; };
+		85218CAD2816EBF40EA0D48C /* CombineExtDemandBufferTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CombineExtDemandBufferTests.swift; sourceTree = "<group>"; };
 		8585A815173A295C2F468057 /* WhisperService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WhisperService.swift; sourceTree = "<group>"; };
 		86222C880AE25FA86DCC6C66 /* View+ListRow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "View+ListRow.swift"; sourceTree = "<group>"; };
 		862461B76A73D888F6A1A77D /* WalkPromptVoices.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = WalkPromptVoices.swift; sourceTree = "<group>"; };
@@ -2156,6 +2158,7 @@
 				14E8AB91D2FEEE6CBBA235C6 /* CollectiveRouteBundledArtifactTests.swift */,
 				F5DA9377F2D838797758AC46 /* Honor */,
 				10DFF0205EDFD489A5BFC491 /* AudioPriorityQueueTests.swift */,
+				85218CAD2816EBF40EA0D48C /* CombineExtDemandBufferTests.swift */,
 			);
 			path = UnitTests;
 			sourceTree = "<group>";
@@ -3684,6 +3687,7 @@
 				441413024C1949B2E1B94DD6 /* WayMediaDownloaderTests.swift in Sources */,
 				B8AEBE27DE6EA2822E939ACE /* HonorLinkTests.swift in Sources */,
 				22392BA6A14C3C4F889E9864 /* HonorImportReducerTests.swift in Sources */,
+				12C6CDFB56CC3A47937E2511 /* CombineExtDemandBufferTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Podfile
+++ b/Podfile
@@ -27,6 +27,27 @@ post_install do |installer|
     end
   end
 
+  # CombineExt 1.8.0's DemandBuffer reads `completion` outside its lock and
+  # traps when a value lands after a cancel — reachable when a walk ends
+  # with a location sample in flight. Pods are checked in, so the patched
+  # source is in git; this re-applies it after any `pod install`.
+  demand_buffer = 'Pods/CombineExt/Sources/Common/DemandBuffer.swift'
+  if File.exist?(demand_buffer)
+    src = File.read(demand_buffer)
+    unless src.include?('Pilgrim patch')
+      src = src.sub(
+        "    func buffer(value: S.Input) -> Subscribers.Demand {\n        precondition(self.completion == nil,\n                     \"How could a completed publisher sent values?! Beats me 🤷‍♂️\")\n        lock.lock()\n        defer { lock.unlock() }\n",
+        "    func buffer(value: S.Input) -> Subscribers.Demand {\n        lock.lock()\n        defer { lock.unlock() }\n\n        // Pilgrim patch (see Podfile post_install): `completion` used to be\n        // read here OUTSIDE the lock and trapped when non-nil. A relay\n        // cancelled on one thread while another is still delivering a value\n        // — ending a walk with a location sample in flight — races that\n        // read. A value that arrives after completion is dropped instead.\n        guard self.completion == nil else { return .none }\n"
+      )
+      src = src.sub(
+        "    func complete(completion: Subscribers.Completion<S.Failure>) {\n        precondition(self.completion == nil,\n                     \"Completion have already occured, which is quite awkward 🥺\")\n\n        self.completion = completion\n",
+        "    func complete(completion: Subscribers.Completion<S.Failure>) {\n        lock.lock()\n        defer { lock.unlock() }\n\n        // Pilgrim patch: a second completion is ignored rather than trapped.\n        guard self.completion == nil else { return }\n\n        self.completion = completion\n"
+      )
+      raise 'CombineExt DemandBuffer patch did not apply — the pod changed; update Podfile post_install' unless src.include?('Pilgrim patch')
+      File.write(demand_buffer, src)
+    end
+  end
+
   # Inject Secrets.xcconfig into Pilgrim target xcconfigs
   secrets_include = '#include? "../../../Secrets.xcconfig"'
   Dir.glob('Pods/Target Support Files/Pods-Pilgrim/*.xcconfig').each do |path|

--- a/Pods/CombineExt/Sources/Common/DemandBuffer.swift
+++ b/Pods/CombineExt/Sources/Common/DemandBuffer.swift
@@ -41,10 +41,15 @@ class DemandBuffer<S: Subscriber> {
     ///
     /// - returns: The demand fulfilled by the bufferr
     func buffer(value: S.Input) -> Subscribers.Demand {
-        precondition(self.completion == nil,
-                     "How could a completed publisher sent values?! Beats me 🤷‍♂️")
         lock.lock()
         defer { lock.unlock() }
+
+        // Pilgrim patch (see Podfile post_install): `completion` used to be
+        // read here OUTSIDE the lock and trapped when non-nil. A relay
+        // cancelled on one thread while another is still delivering a value
+        // — ending a walk with a location sample in flight — races that
+        // read. A value that arrives after completion is dropped instead.
+        guard self.completion == nil else { return .none }
 
         switch demandState.requested {
         case .unlimited:
@@ -63,8 +68,11 @@ class DemandBuffer<S: Subscriber> {
     ///
     /// - parameter completion: Completion event
     func complete(completion: Subscribers.Completion<S.Failure>) {
-        precondition(self.completion == nil,
-                     "Completion have already occured, which is quite awkward 🥺")
+        lock.lock()
+        defer { lock.unlock() }
+
+        // Pilgrim patch: a second completion is ignored rather than trapped.
+        guard self.completion == nil else { return }
 
         self.completion = completion
         _ = flush()

--- a/UnitTests/CombineExtDemandBufferTests.swift
+++ b/UnitTests/CombineExtDemandBufferTests.swift
@@ -1,0 +1,43 @@
+import Combine
+import CombineExt
+import XCTest
+@testable import Pilgrim
+
+/// Guards the Podfile's CombineExt patch. Unpatched, `DemandBuffer` reads
+/// its `completion` outside the lock and traps when a value lands after a
+/// cancel — the shape of ending a walk while a location sample is still
+/// crossing the shared background queue. A trap here fails the whole run,
+/// which is the point: this must never regress silently.
+final class CombineExtDemandBufferTests: XCTestCase {
+
+    func testCancellingARelayWhileAnotherThreadFloodsItNeverTraps() {
+        for round in 0..<40 {
+            let relay = CurrentValueRelay<Int>(0)
+            var received = 0
+            var cancellable: AnyCancellable? = relay
+                .asBackgroundPublisher()
+                .sink { _ in received += 1 }
+            let flood = expectation(description: "flood \(round)")
+            DispatchQueue.global(qos: .userInitiated).async {
+                for i in 1...20_000 { relay.accept(i) }
+                flood.fulfill()
+            }
+            // Cancel mid-flood, from another thread than the producer.
+            usleep(UInt32.random(in: 50...500))
+            cancellable?.cancel()
+            cancellable = nil
+            wait(for: [flood], timeout: 10)
+            _ = received
+        }
+    }
+
+    func testAValueAfterCompletionIsDroppedNotTrapped() {
+        let relay = PassthroughRelay<Int>()
+        var values: [Int] = []
+        let cancellable = relay.sink { values.append($0) }
+        relay.accept(1)
+        cancellable.cancel()
+        relay.accept(2)
+        XCTAssertEqual(values, [1])
+    }
+}


### PR DESCRIPTION
## What

CombineExt 1.8.0's `DemandBuffer.buffer(value:)` reads `completion` **outside** its lock and traps ("How could a completed publisher sent values?!") when non-nil. A relay cancelled on one thread while another thread is still delivering a value races that read. In the app that is ending a walk with a location sample still crossing the shared background queue; in tests it was the intermittent trap in `RoutePipelineTests.testTenThousandSampleWalk_neverTriggersFullRouteRebuild` (0/20 survived at a 200k backlog in a harness).

- `buffer(value:)`: the read moves inside the lock and a late value is **dropped** (`.none`) instead of trapping.
- `complete(completion:)`: takes the lock; a second completion is ignored instead of trapping.
- Pods are checked in, so the patched source is in git. `Podfile` `post_install` re-applies the patch after any `pod install` and raises if the pod's source ever changes under it, so it can't silently regress.

## Tests

- New `CombineExtDemandBufferTests`: 40 rounds of cancelling a `CurrentValueRelay` → `asBackgroundPublisher()` sink from the main thread while a background thread floods 20k values; and a direct case proving a value after cancel is dropped.
- `RoutePipelineTests` (all 12) green alongside.

## Upstream

Worth sending to CombineExt as a PR; the patch is self-contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)