### PR TITLE
feat(honor): a voice card quotes what was said here

### DIFF
--- a/Pilgrim/Models/Honor/OwnWalkWayBuilder.swift
+++ b/Pilgrim/Models/Honor/OwnWalkWayBuilder.swift
@@ -50,7 +50,8 @@ enum OwnWalkWayBuilder {
                 id: "voice-\(n + 1)", frac: start.frac, at: start.at,
                 kind: .voice(endFrac: max(end.frac, start.frac), duration: rec.duration,
                              kind: TourBuilder.classify(transcription: rec.transcription) == .spoken ? .spoken : .ambient,
-                             media: .recording(relativePath: rec.fileRelativePath))))
+                             media: .recording(relativePath: rec.fileRelativePath)),
+                transcript: WayMoment.trimmedTranscript(rec.transcription)))
         }
         for (n, photo) in walk.walkPhotos.sorted(by: { $0.capturedAt < $1.capturedAt }).enumerated() {
             let p = place(photo.capturedAt)

--- a/Pilgrim/Models/Honor/TourManifest.swift
+++ b/Pilgrim/Models/Honor/TourManifest.swift
@@ -31,9 +31,10 @@ struct TourManifest: Decodable {
         let lat: Double?
         let lon: Double?
         let place: String?
+        let transcript: String?
 
         enum CodingKeys: String, CodingKey {
-            case type, frac, end_frac, n, duration, label, icon, minutes, lat, lon, place
+            case type, frac, end_frac, n, duration, label, icon, minutes, lat, lon, place, transcript
         }
     }
 

--- a/Pilgrim/Models/Honor/Way.swift
+++ b/Pilgrim/Models/Honor/Way.swift
@@ -44,6 +44,36 @@ struct WayMoment: Codable, Equatable, Identifiable {
     /// The street or place the sharer's page names for a voice, when the
     /// worker had one. Optional and last: older `way.json` files lack it.
     var place: String?
+    /// What they said, when the source transcribed it: the walker's own
+    /// recordings carry one; shared walks carry the worker's. Optional and
+    /// last, like `place`.
+    var transcript: String?
+
+    /// The first sentence of the transcript, for a card that has one line
+    /// to spare. Nil when there is nothing to quote.
+    var transcriptLine: String? { WayMoment.firstSentence(of: transcript, maxCharacters: 120) }
+
+    static let maxTranscriptCharacters = 600
+
+    /// Trims, drops the empty, and caps at `maxTranscriptCharacters`.
+    static func trimmedTranscript(_ raw: String?) -> String? {
+        guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines), !trimmed.isEmpty else { return nil }
+        return String(trimmed.prefix(maxTranscriptCharacters))
+    }
+
+    static func firstSentence(of transcript: String?, maxCharacters: Int) -> String? {
+        guard let transcript = trimmedTranscript(transcript) else { return nil }
+        var sentence = transcript
+        if let end = transcript.firstIndex(where: { ".!?".contains($0) }) {
+            sentence = String(transcript[...end])
+        }
+        if sentence.count > maxCharacters {
+            let cut = sentence.prefix(maxCharacters)
+            let atWord = cut.lastIndex(of: " ").map { String(cut[..<$0]) } ?? String(cut)
+            return atWord + "…"
+        }
+        return sentence
+    }
 
     var isVoice: Bool {
         if case .voice = kind { return true }

--- a/Pilgrim/Models/Honor/WayImporter.swift
+++ b/Pilgrim/Models/Honor/WayImporter.swift
@@ -149,7 +149,7 @@ struct WayImporter {
                 moments.append(WayMoment(id: "voice-\(voiceN)", frac: e.frac, at: at,
                     kind: .voice(endFrac: e.end_frac ?? e.frac, duration: e.duration ?? 0,
                                  kind: e.type == "voice" ? .spoken : .ambient, media: .file("audio/\(n).m4a")),
-                    place: trimmedPlace(e.place)))
+                    place: trimmedPlace(e.place), transcript: WayMoment.trimmedTranscript(e.transcript)))
             case "photo":
                 guard let n = e.n else { continue }
                 photoN += 1

--- a/Pilgrim/Scenes/ActiveWalk/WayPlaceCard.swift
+++ b/Pilgrim/Scenes/ActiveWalk/WayPlaceCard.swift
@@ -143,6 +143,11 @@ struct WayPlaceCard: View {
                 .accessibilityLabel("Stop recording your reply")
             }
         } else {
+            if let line = moment.transcriptLine {
+                Text("“\(line)”")
+                    .font(Constants.Typography.body).italic().foregroundColor(.ink)
+                    .lineLimit(2)
+            }
             transportRow(duration: duration)
             replyRow
         }

--- a/Pilgrim/Scenes/Honor/WayMomentPreview.swift
+++ b/Pilgrim/Scenes/Honor/WayMomentPreview.swift
@@ -82,6 +82,11 @@ struct WayMomentPreview: View {
 
     private func voiceContent(duration: Double, kind: VoiceKind) -> some View {
         VStack(alignment: .leading, spacing: Constants.UI.Padding.small) {
+            if let transcript = moment.transcript {
+                Text("“\(transcript)”")
+                    .font(Constants.Typography.body).italic().foregroundColor(.ink)
+                    .padding(.bottom, Constants.UI.Padding.xs)
+            }
             if let mediaURL {
                 HStack(spacing: Constants.UI.Padding.small) {
                     Button { player.toggle(url: mediaURL) } label: {

--- a/UnitTests/Honor/HonorWayRenderingTests.swift
+++ b/UnitTests/Honor/HonorWayRenderingTests.swift
@@ -148,3 +148,15 @@ extension HonorWayRenderingTests {
         XCTAssertEqual(WayMomentHeader.relation(distanceMeters: 18_244, place: "Rúa do Franco"), "18.2 km away · Rúa do Franco")
     }
 }
+
+extension HonorWayRenderingTests {
+
+    func testTranscriptLineIsTheFirstSentenceCutAtAWordWhenLong() {
+        XCTAssertNil(WayMoment.firstSentence(of: nil, maxCharacters: 120))
+        XCTAssertNil(WayMoment.firstSentence(of: "  ", maxCharacters: 120))
+        XCTAssertEqual(WayMoment.firstSentence(of: "Quiet here. Birds later.", maxCharacters: 120), "Quiet here.")
+        XCTAssertEqual(WayMoment.firstSentence(of: "no punctuation at all", maxCharacters: 120), "no punctuation at all")
+        let long = "one two three four five six seven eight nine ten eleven twelve"
+        XCTAssertEqual(WayMoment.firstSentence(of: long, maxCharacters: 20), "one two three four…")
+    }
+}

--- a/UnitTests/Honor/OwnWalkWayBuilderTests.swift
+++ b/UnitTests/Honor/OwnWalkWayBuilderTests.swift
@@ -120,3 +120,12 @@ extension OwnWalkWayBuilderTests {
         }
     }
 }
+
+extension OwnWalkWayBuilderTests {
+
+    func testTheWalkersOwnTranscriptionRidesOntoTheVoiceMoment() throws {
+        let way = try XCTUnwrap(OwnWalkWayBuilder.make(from: walk()))
+        let voice = try XCTUnwrap(way.moments.first { $0.isVoice })
+        XCTAssertEqual(voice.transcript, "a thought that runs on for more than eight words in total")
+    }
+}

--- a/UnitTests/Honor/WayImporterTests.swift
+++ b/UnitTests/Honor/WayImporterTests.swift
@@ -226,3 +226,22 @@ extension WayImporterTests {
         XCTAssertNil(place("voice-5"))
     }
 }
+
+extension WayImporterTests {
+
+    func testVoiceTranscriptIsCarriedTrimmedAndCapped() throws {
+        let long = String(repeating: "y", count: WayMoment.maxTranscriptCharacters + 40)
+        let extra = """
+        ,{"type":"voice","frac":0.55,"end_frac":0.56,"n":3,"duration":5,"dwell":1,"transcript":"  The adobe walls hold the light. Then more.  "},
+        {"type":"voice","frac":0.56,"end_frac":0.57,"n":4,"duration":5,"dwell":1,"transcript":"\(long)"},
+        {"type":"voice","frac":0.57,"end_frac":0.58,"n":5,"duration":5,"dwell":1,"transcript":"   "}
+        """
+        let way = try WayImporter.way(from: manifest(extraEncounter: extra), shareId: "Qoi4YmPHLN", now: Date())
+        func transcript(_ id: String) -> String? { way.moments.first { $0.id == id }?.transcript }
+        XCTAssertNil(transcript("voice-1"), "a voice the worker never transcribed carries nothing")
+        XCTAssertEqual(transcript("voice-3"), "The adobe walls hold the light. Then more.")
+        XCTAssertEqual(transcript("voice-4")?.count, WayMoment.maxTranscriptCharacters)
+        XCTAssertNil(transcript("voice-5"))
+        XCTAssertEqual(way.moments.first { $0.id == "voice-3" }?.transcriptLine, "The adobe walls hold the light.")
+    }
+}


### PR DESCRIPTION
## What

- `WayMoment.transcript: String?` (optional, last, backward compatible like `place`), with `transcriptLine` = first sentence, cut at a word boundary past 120 characters, and `trimmedTranscript` (trim, drop blank, cap at 600).
- Own walks: `OwnWalkWayBuilder` carries the recording's transcription. Shared walks: `TourManifest.Encounter.transcript` → importer, paired with pilgrim-worker PR #43 which adds `transcript` to voice encounters on tour.json.
- Walk card (voice body): the first sentence as an italic quote under the header, two lines max. Overview preview: the whole transcript above the player.

## Tests

Importer (trim / cap / blank / absent, plus the card line); builder (own transcription rides onto the moment); `firstSentence` (nil, blank, punctuation, no punctuation, long cut at a word). Honor suites 44/44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)